### PR TITLE
chore: Filter Paths For Workflows

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -19,10 +19,23 @@ on:
         description: 'OS to run on (e.g., ubuntu-24.04)'
         required: false
         default: 'ubuntu-24.04'
+
   pull_request:
+    paths: &change-paths
+      - .clang-format
+      - CMake**
+      - .github/workflows/linux.yml
+      - cmake/**
+      - common/**
+      - redalert/**
+      - resources
+      - tiberiandawn/**
+      - tools/**
+
   push:
     branches:
       - main
+    paths: *change-paths
 
 jobs:
   create_dev_release:

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -7,14 +7,29 @@ on:
         description: 'Build preset (e.g., nco-tiberian-dawn)'
         required: false
         default: 'nco-tiberian-dawn'
-  # TODO: Re-enable mac builds, saving on action minute usage for now
-  # pull_request:
+
+  # TODO: Builds *only* run for PRs and *only* if you label the PR with 'macos'.
+  #       I want to save on action minute usage for now.
+  pull_request:
+    paths: &change-paths
+      - .clang-format
+      - CMake**
+      - .github/workflows/linux.yml
+      - cmake/**
+      - common/**
+      - redalert/**
+      - resources
+      - tiberiandawn/**
+      - tools/**
+
   # push:
   #   branches:
   #     - main
+  #   paths: *change-paths
 
 jobs:
   vanilla-macos:
+    if: contains(github.event.pull_request.labels.*.name, 'macos')
     runs-on: macos-14
     strategy:
       matrix:

--- a/.github/workflows/mingw.yml
+++ b/.github/workflows/mingw.yml
@@ -16,13 +16,28 @@ on:
         required: false
         default: 'nco-tiberian-dawn'
 
-#  pull_request:
-#  push:
-#    branches:
-#      - main
+  # TODO: Builds *only* run for PRs and *only* if you label the PR with 'mingw'.
+  #       I want to save on action minute usage for now.
+  pull_request:
+    paths: &change-paths
+      - .clang-format
+      - CMake**
+      - .github/workflows/linux.yml
+      - cmake/**
+      - common/**
+      - redalert/**
+      - resources
+      - tiberiandawn/**
+      - tools/**
+
+  # push:
+  #   branches:
+  #     - main
+  #   paths: *change-paths
 
 jobs:
   vanilla_win_gcc:
+    if: contains(github.event.pull_request.labels.*.name, 'mingw')
     runs-on: ubuntu-22.04
     strategy:
       matrix:

--- a/.github/workflows/wiki.yml
+++ b/.github/workflows/wiki.yml
@@ -2,12 +2,18 @@ name: deploy-wiki
 
 on:
   workflow_dispatch:
+
+  # wiki workflow runs in 'dry run' mode on PRs
+  pull_request:
+    paths: &change-paths
+      - .github/workflows/wiki.yml
+      - wiki/**
+
+  # wiki should only be deployed from main
   push:
     branches:
       - main
-    paths:
-      - wiki/**
-      - .github/workflows/wiki.yml
+    paths: *change-paths
 
 concurrency:
   group: publish-wiki
@@ -27,3 +33,4 @@ jobs:
           preprocess: true
           ignore: |
             .obsidian
+          dry_run: ${{ github.ref != 'refs/heads/main' }}

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -17,9 +17,21 @@ on:
         default: 'x86_64'
 
   pull_request:
+    paths: &change-paths
+      - .clang-format
+      - CMake**
+      - .github/workflows/linux.yml
+      - cmake/**
+      - common/**
+      - redalert/**
+      - resources
+      - tiberiandawn/**
+      - tools/**
+
   push:
     branches:
       - main
+    paths: *change-paths
 
 jobs:
   # TODO: Remaster compatibility

--- a/README.md
+++ b/README.md
@@ -20,8 +20,8 @@ This project is under construction and intial development, so no release builds 
 
 ---
 
-### [> Enhancements List](https://github.com/djfdyuruiry/cnc-new-construction-options/wiki/enhancements)
-### [> Planned Features](https://github.com/djfdyuruiry/cnc-new-construction-options/wiki/planned-features)
+### [> Enhancements List](https://github.com/djfdyuruiry/cnc-new-construction-options/wiki/2.Enhancements)
+### [> Planned Features](https://github.com/djfdyuruiry/cnc-new-construction-options/wiki/3.Planned-Features)
 
 ### [> Project Wiki](https://github.com/djfdyuruiry/cnc-new-construction-options/wiki)
 


### PR DESCRIPTION
- Allow mingw and macos builds on PR only, if appropriate label is added to PR
- Allow dry run wiki builds on PR
- All workflows only run if changes are made that would change the build artefact (or change the related workflow definiton)