### PR TITLE
fix(common): Use Wayland instead of XWayland on Linux

### DIFF
--- a/common/settings.cpp
+++ b/common/settings.cpp
@@ -19,19 +19,22 @@ SettingsClass::SettingsClass()
     /*
     ** Video settings
     */
-    Video.WindowWidth = 640;
-    Video.WindowHeight = 400;
+    // TODO: Could offer presets through the launcher or a ini setting (retro, modern etc.)
+    Video.WindowWidth = 1280;
+    Video.WindowHeight = 800;
     Video.Windowed = false;
+    Video.Display = 1;
     Video.Width = 0;
     Video.Height = 0;
     Video.Boxing = true;
-    Video.BoxingAspectRatio = "16:10";
+    Video.BoxingAspectRatio = "4:3";
     Video.FrameLimit = 120;
     Video.InterpolationMode = 2;
     Video.HardwareCursor = false;
     Video.DOSMode = false;
     Video.Scaler = "nearest";
-    Video.Driver = "default";
+    Video.VideoDriver = "default";
+    Video.RenderDriver = "default";
     Video.PixelFormat = "default";
 }
 
@@ -60,13 +63,15 @@ void SettingsClass::Load(INIClass& ini)
     Video.Windowed = ini.Get_Bool("Video", "Windowed", Video.Windowed);
     Video.Boxing = ini.Get_Bool("Video", "Boxing", Video.Boxing);
     Video.BoxingAspectRatio = ini.Get_String("Video", "BoxingAspectRatio", Video.BoxingAspectRatio);
+    Video.Display = ini.Get_Int("Video", "Display", Video.Display);
     Video.Width = ini.Get_Int("Video", "Width", Video.Width);
     Video.Height = ini.Get_Int("Video", "Height", Video.Height);
     Video.FrameLimit = ini.Get_Int("Video", "FrameLimit", Video.FrameLimit);
     Video.HardwareCursor = ini.Get_Bool("Video", "HardwareCursor", Video.HardwareCursor);
     Video.DOSMode = ini.Get_Bool("Video", "DOSMode", Video.DOSMode);
     Video.Scaler = ini.Get_String("Video", "Scaler", Video.Scaler);
-    Video.Driver = ini.Get_String("Video", "Driver", Video.Driver);
+    Video.VideoDriver = ini.Get_String("Video", "VideoDriver", Video.VideoDriver);
+    Video.RenderDriver = ini.Get_String("Video", "RenderDriver", Video.RenderDriver);
     Video.PixelFormat = ini.Get_String("Video", "PixelFormat", Video.PixelFormat);
 
     /*
@@ -110,13 +115,15 @@ void SettingsClass::Save(INIClass& ini)
     ini.Put_Bool("Video", "Windowed", Video.Windowed);
     ini.Put_Bool("Video", "Boxing", Video.Boxing);
     ini.Put_String("Video", "BoxingAspectRatio", Video.BoxingAspectRatio);
+    ini.Put_Int("Video", "Display", Video.Display);
     ini.Put_Int("Video", "Width", Video.Width);
     ini.Put_Int("Video", "Height", Video.Height);
     ini.Put_Int("Video", "FrameLimit", Video.FrameLimit);
     ini.Put_Bool("Video", "HardwareCursor", Video.HardwareCursor);
     ini.Put_Bool("Video", "DOSMode", Video.DOSMode);
     ini.Put_String("Video", "Scaler", Video.Scaler);
-    ini.Put_String("Video", "Driver", Video.Driver);
+    ini.Put_String("Video", "VideoDriver", Video.VideoDriver);
+    ini.Put_String("Video", "RenderDriver", Video.RenderDriver);
     ini.Put_String("Video", "PixelFormat", Video.PixelFormat);
 
     /*

--- a/common/settings.h
+++ b/common/settings.h
@@ -27,6 +27,7 @@ public:
         bool Windowed;
         bool Boxing;
         std::string BoxingAspectRatio;
+        int Display;
         int Width;
         int Height;
         int FrameLimit;
@@ -35,7 +36,8 @@ public:
         bool DOSMode;
         int ButtonStyle;
         std::string Scaler;
-        std::string Driver;
+        std::string VideoDriver;
+        std::string RenderDriver;
         std::string PixelFormat;
     } Video;
 

--- a/common/video_sdl2.cpp
+++ b/common/video_sdl2.cpp
@@ -44,6 +44,7 @@
 #include "wwmouse.h"
 #include "settings.h"
 #include "debugstring.h"
+#include "logger.h"
 
 #include <SDL.h>
 
@@ -216,9 +217,49 @@ SurfaceMonitorClass& AllSurfaces = AllSurfacesDummy; // List of all direct draw 
  *=============================================================================================*/
 bool Set_Video_Mode(int w, int h, int bits_per_pixel)
 {
+    if (Settings.Video.VideoDriver != "default") {
+        CNC_LOG_INFO("Using SDL video driver hint: {}", Settings.Video.VideoDriver);
+        SDL_SetHint(SDL_HINT_VIDEODRIVER, Settings.Video.VideoDriver.c_str());
+    } else {
+#ifdef __linux__
+        // Workaround for XWayland on linux returning all displays as one massive render surface; image under XWayland
+        // can be zoomed in (due to a large reported resolution) and always renders on left most monitor.
+        //
+        // Note: SDL2 video driver auto selection prefers x11 over wayland, so XWayland is automatically selected under
+        // wayland environments. SDL3 prefers wayland over x11, so this can be removed if library is upgraded.
+        if (std::getenv("WAYLAND_DISPLAY") != nullptr) {
+            CNC_LOG_INFO("Environment variable 'WAYLAND_DISPLAY' found, using SDL video driver hint: wayland");
+            SDL_SetHint(SDL_HINT_VIDEODRIVER, "wayland");
+        }
+#else
+        CNC_LOG_DEBUG("No default video driver override logic for this platform");
+#endif
+    }
+
     SDL_Init(SDL_INIT_VIDEO | SDL_INIT_EVENTS);
     SDL_ShowCursor(SDL_DISABLE);
 
+    // dump info on detected displays
+    auto num_displays = SDL_GetNumVideoDisplays();
+
+    CNC_LOG_INFO("Found {} display(s)", num_displays);
+    for (auto i = 0; i < num_displays; i++)
+    {
+        SDL_DisplayMode display_mode;
+        SDL_GetCurrentDisplayMode(i, &display_mode);
+
+        if (display_mode.refresh_rate == 0) {
+            CNC_LOG_INFO("Display #{} mode: {}x{}@?hz", i + 1, display_mode.w, display_mode.h);
+        } else {
+            CNC_LOG_INFO(
+                "Display #{} mode: {}x{}@{}hz", i + 1, display_mode.w, display_mode.h, display_mode.refresh_rate
+            );
+        }
+    }
+
+    const auto display = Settings.Video.Display - 1; // SDL displays are 0 indexed
+    int x = SDL_WINDOWPOS_CENTERED_DISPLAY(display);
+    int y = SDL_WINDOWPOS_CENTERED_DISPLAY(display);
     int win_w = w;
     int win_h = h;
     int win_flags = 0;
@@ -237,6 +278,9 @@ bool Set_Video_Mode(int w, int h, int bits_per_pixel)
             win_h = Settings.Video.Height;
             win_flags |= SDL_WINDOW_FULLSCREEN;
         }
+
+        x = SDL_WINDOWPOS_UNDEFINED_DISPLAY(display);
+        y = SDL_WINDOWPOS_UNDEFINED_DISPLAY(display);
     } else if (Settings.Video.WindowWidth > w || Settings.Video.WindowHeight > h) {
         win_w = Settings.Video.WindowWidth;
         win_h = Settings.Video.WindowHeight;
@@ -245,8 +289,8 @@ bool Set_Video_Mode(int w, int h, int bits_per_pixel)
         Settings.Video.WindowHeight = win_h;
     }
 
-    window =
-        SDL_CreateWindow("Vanilla Conquer", SDL_WINDOWPOS_UNDEFINED, SDL_WINDOWPOS_UNDEFINED, win_w, win_h, win_flags);
+    window = SDL_CreateWindow("Vanilla Conquer", x, y, win_w, win_h, win_flags);
+
     if (window == nullptr) {
         DBG_ERROR("SDL_CreateWindow failed: %s", SDL_GetError());
         Reset_Video_Mode();
@@ -266,12 +310,12 @@ bool Set_Video_Mode(int w, int h, int bits_per_pixel)
 
     DBG_INFO("  pixel format: %s (%d bpp)", SDL_GetPixelFormatName(pixel_format), SDL_BITSPERPIXEL(pixel_format));
 
-    DBG_INFO("SDL2 drivers available: (user preference '%s')", Settings.Video.Driver.c_str());
+    DBG_INFO("SDL2 render drivers available: (user preference '%s')", Settings.Video.RenderDriver.c_str());
     int renderer_index = -1;
     for (int i = 0; i < SDL_GetNumRenderDrivers(); i++) {
         SDL_RendererInfo info;
         if (SDL_GetRenderDriverInfo(i, &info) == 0) {
-            if (Settings.Video.Driver.compare(info.name) == 0) {
+            if (Settings.Video.RenderDriver.compare(info.name) == 0) {
                 renderer_index = i;
             }
 

--- a/scripts/docker/ubuntu.Dockerfile
+++ b/scripts/docker/ubuntu.Dockerfile
@@ -42,6 +42,9 @@ RUN apt-get install -y \
 # vcpkg package: libxcrypt
 RUN apt-get install -y libltdl-dev
 
+# vcpkg package: gettext
+RUN apt-get install -y bison
+
 ARG UID=1000
 ARG GID=1000
 

--- a/wiki/5.Building.md
+++ b/wiki/5.Building.md
@@ -38,6 +38,7 @@ Some package manager dependencies are required on Linux:
     sudo apt-get install -y autoconf \
       autoconf-archive \
       automake \
+      bison \
       build-essential \
       cmake \
       clang \
@@ -81,7 +82,7 @@ Some package manager dependencies are required on Linux:
 - Install XCode and XCode Command Line Tools
   - Doing this will also provide `git`
 - Use MacPorts or Homebrew to install required build tools
-  - Homebrew example: `brew install cmake dylibbundler imagemagick jinja2-cli jq ninja python3`
+  - Homebrew example: `brew install bison cmake dylibbundler imagemagick jinja2-cli jq ninja python3`
 
 ## Run the build
 


### PR DESCRIPTION
## Features

- common: Ability to set SDL2 video driver in INI
- common: Ability to set target display for fullscreen in INI
- common: Default to double resolution for windowed mode
- common: Default to 4:3 aspect ratio

## Fixes

- common: Prefer Wayland over XWayland due to bug with fullscreen and multiple displays (displays present as one massive display)