### PR TITLE
fix(common+td): Ensure external libraries encapsulated in common headers

### DIFF
--- a/common/debugstring.cpp
+++ b/common/debugstring.cpp
@@ -7,8 +7,6 @@
 #include <stdio.h>
 #include <string.h>
 
-#include <spdlog/spdlog.h>
-
 #include "logger.h"
 
 /**

--- a/common/enum.h
+++ b/common/enum.h
@@ -1,0 +1,4 @@
+#pragma once
+
+#define MAGIC_ENUM_RANGE_MAX 256 // ensure all values for 'unsigned char' enums are detected
+#include <magic_enum.hpp>

--- a/common/json.h
+++ b/common/json.h
@@ -3,7 +3,7 @@
 #include <bitset>
 #include <functional>
 
-// this define ensures that CNC enum types are never serialized as numbers
+// force manual handling of enum values - ensures CNC enum types are never serialized by value (use strings instead)
 #define JSON_DISABLE_ENUM_SERIALIZATION 1
 #include <nlohmann/json.hpp>
 

--- a/common/logger.h
+++ b/common/logger.h
@@ -3,15 +3,16 @@
 #include <memory>
 #include <string_view>
 
-/**
- * spdlog static configuration
- */
-
-// pull in function call info for current compiler
-#if defined(__GNUC__) || defined(__clang__)
-    #define SPDLOG_FUNCTION static_cast<const char*>(__PRETTY_FUNCTION__)
-#elif defined(_MSC_VER)
-    #define SPDLOG_FUNCTION static_cast<const char*>(__FUNCSIG__)
+// set SPDLOG_FUNCTION to platform specific macro for more detailed function signatures
+#ifndef SPDLOG_FUNCTION
+    #if defined(__GNUC__) || defined(__clang__)
+        #define SPDLOG_FUNCTION static_cast<const char*>(__PRETTY_FUNCTION__)
+    #elif defined(_MSC_VER)
+        #define SPDLOG_FUNCTION static_cast<const char*>(__FUNCSIG__)
+    #else
+        // fallback, supported by all C++ compilers
+        #define SPDLOG_FUNCTION static_cast<const char*>(__FUNCTION__)
+    #endif
 #endif
 
 #include <spdlog/async.h>
@@ -20,19 +21,25 @@
 #include <spdlog/sinks/stdout_color_sinks.h>
 #include <spdlog/sinks/rotating_file_sink.h>
 
-#ifdef _DEBUG
-    #ifdef _WIN32
-        #include <intrin.h>
-        #define TRIGGER_DEBUGGER __debugbreak()
-    #elif defined(__GNUC__) && !defined(__clang__)
-        #define TRIGGER_DEBUGGER __builtin_trap()
-    #elif defined(__GNUC__) && defined(__clang__)
-        #define TRIGGER_DEBUGGER __builtin_debugtrap()
+#ifndef TRIGGER_DEBUGGER
+    #ifdef _DEBUG
+        // reference platform specific macro/function
+        #ifdef _WIN32
+            #include <intrin.h>
+            #define TRIGGER_DEBUGGER __debugbreak()
+        #elif defined(__GNUC__) && !defined(__clang__)
+            #define TRIGGER_DEBUGGER __builtin_trap()
+        #elif defined(__GNUC__) && defined(__clang__)
+            #define TRIGGER_DEBUGGER __builtin_debugtrap()
+        #else
+            // fallback, use C standard error handling
+            #define TRIGGER_DEBUGGER #include <assert.h>; \
+                assert(false)
+        #endif
     #else
-        #define TRIGGER_DEBUGGER assert(false)
+        // no-op if not building Debug version
+        #define TRIGGER_DEBUGGER (void)0
     #endif
-#else
-    #define TRIGGER_DEBUGGER (void)0
 #endif
 
 /**

--- a/common/lua/logging_luaapi.h
+++ b/common/lua/logging_luaapi.h
@@ -1,7 +1,6 @@
 #pragma once
 
-#include <spdlog/spdlog.h>
-
+#include "logger.h"
 #include "luaapi.h"
 
 /**

--- a/common/twowaymap.h
+++ b/common/twowaymap.h
@@ -6,16 +6,25 @@
 #include "logger.h"
 
 /**
+ * There are alot of template instantiations for TwoWayMap, and thus
+ * static fields would be repeated. So this delcares one set of static
+ * fields for all TwoWayMap classes.
+ */
+class TwoWayMapStatic
+{
+protected:
+    static inline const auto& Logger = CncLogger::For(TwoWayMap);
+};
+
+/**
  * Map that enables mapping between two lists of values, in
  * either direction. Useful for converting between enums/constants
  * and strings, for example.
  */
 template<typename A, typename B>
-class TwoWayMap
+class TwoWayMap : private TwoWayMapStatic
 {
 private:
-    static inline const auto& Logger = CncLogger::For(TwoWayMap);
-
     std::map<A, B> ForwardMap;
     std::map<B, A> BackwardMap;
 

--- a/tiberiandawn/typeconverter.h
+++ b/tiberiandawn/typeconverter.h
@@ -5,9 +5,7 @@
 #include <string>
 #include <type_traits>
 
-#define MAGIC_ENUM_RANGE_MAX 256 // ensure all values for 'unsigned char' enums are detected
-#include <magic_enum.hpp>
-
+#include "common/enum.h"
 #include "common/json.h"
 #include "common/twowaymap.h"
 #include "common/rulesections.h"


### PR DESCRIPTION
- fix(common): Keep all external libraries behind headers in common to enforce library behavior (and allow reuse)
- fix(common): Prevent `TwoWayMap` from spawning tons of loggers due to template instantiation 