### PR TITLE
feat(td): In-Game Lua Console

### DIFF
--- a/cmake/NcoRules.cmake
+++ b/cmake/NcoRules.cmake
@@ -77,11 +77,12 @@ function(TransformRuleNameToUpperSnakecase _RULE_NAME _RULE_NAME_SNAKE_CASE)
   set("${_RULE_NAME_SNAKE_CASE}" ${RULE_NAME_SNAKE_CASE} PARENT_SCOPE)
 endfunction()
 
-function(LoadRuleProperties _RULES_JSON _RULE_INDEX _RULE_NAME _RULE_TYPE _RULE_DEFAULT)
+function(LoadRuleProperties _RULES_JSON _RULE_INDEX _RULE_NAME _RULE_TYPE _RULE_COMMENT _RULE_DEFAULT)
   string(JSON RULE_OBJECT_JSON GET "${_RULES_JSON}" rules "${_RULE_INDEX}")
 
   string(JSON RULE_NAME GET "${RULE_OBJECT_JSON}" name)
   string(JSON RULE_TYPE GET "${RULE_OBJECT_JSON}" type)
+  string(JSON RULE_COMMENT GET "${RULE_OBJECT_JSON}" comment)
   string(JSON RULE_DEFAULT GET "${RULE_OBJECT_JSON}" default)
 
   string(JSON IS_IMPLEMENTED ERROR_VARIABLE JSON_ERROR GET "${RULE_OBJECT_JSON}" implemented)
@@ -93,6 +94,7 @@ function(LoadRuleProperties _RULES_JSON _RULE_INDEX _RULE_NAME _RULE_TYPE _RULE_
 
   set(RULE_NAME ${RULE_NAME} PARENT_SCOPE)
   set(RULE_TYPE ${RULE_TYPE} PARENT_SCOPE)
+  set(RULE_TYPE ${RULE_COMMENT} PARENT_SCOPE)
   set(RULE_DEFAULT ${RULE_DEFAULT} PARENT_SCOPE)
   set(IS_IMPLEMENTED ${IS_IMPLEMENTED} PARENT_SCOPE)
 endfunction()
@@ -268,7 +270,7 @@ function(Main)
         string(APPEND RULE_PROCESS_CODE "\n             ")
       endif()
 
-      LoadRuleProperties("${RULES_JSON}" "${RULE_INDEX}" RULE_NAME RULE_TYPE RULE_DEFAULT)
+      LoadRuleProperties("${RULES_JSON}" "${RULE_INDEX}" RULE_NAME RULE_TYPE RULE_COMMENT RULE_DEFAULT)
 
       TransformRuleNameToUpperSnakecase("${RULE_NAME}" RULE_NAME_SNAKE_CASE)
       set(RULE_DEFINE "${RULE_NAME_SNAKE_CASE}_RULE")
@@ -276,7 +278,7 @@ function(Main)
       # rules-nco.cpp
       ResolveRuleValue("${RULE_DEFAULT}" RULE_VALUE)
 
-      string(APPEND RULE_PROCESS_CODE ".Load(${RULE_DEFINE}).With_Default(${RULE_VALUE})")
+      string(APPEND RULE_PROCESS_CODE ".Load(${RULE_DEFINE}).With_Comment(${RULE_COMMENT}).With_Default(${RULE_VALUE})")
 
       if(${RULE_INDEX} EQUAL ${RULE_COUNT})
         # close call chain for section

--- a/cmake/NcoRules.cmake
+++ b/cmake/NcoRules.cmake
@@ -47,20 +47,20 @@ CHECK_REQUIRED_VARIABLE(RULES_NCO_PATH)
 CHECK_REQUIRED_VARIABLE(RULE_KEYS_TEMPLATE_PATH)
 CHECK_REQUIRED_VARIABLE(RULE_KEYS_PATH)
 
-function(ResolveRuleValue _RULE_DEFAULT _RULE_VALUE)
+function(ResolveRuleValue _RULE_TYPE _RULE_DEFAULT _RULE_VALUE)
   set(RULE_VALUE "${_RULE_DEFAULT}")
 
-  if(${RULE_TYPE} STREQUAL "bool")
+  if(${_RULE_TYPE} STREQUAL "bool")
     # convert ON/OFF to C boolean literals
     if(${_RULE_DEFAULT})
       set(RULE_VALUE "true")
     else()
       set(RULE_VALUE "false")
     endif()
-  elseif(${RULE_TYPE} STREQUAL "float")
+  elseif(${_RULE_TYPE} STREQUAL "float")
       # ensure value is denoted as a float
       set(RULE_VALUE "${RULE_VALUE}f")
-  elseif(${RULE_TYPE} STREQUAL "fixed")
+  elseif(${_RULE_TYPE} STREQUAL "fixed")
       # ensure value wrapped in a fixed class constructor call
       set(RULE_VALUE "fixed(${RULE_VALUE}f)")
   endif()
@@ -77,7 +77,7 @@ function(TransformRuleNameToUpperSnakecase _RULE_NAME _RULE_NAME_SNAKE_CASE)
   set("${_RULE_NAME_SNAKE_CASE}" ${RULE_NAME_SNAKE_CASE} PARENT_SCOPE)
 endfunction()
 
-function(LoadRuleProperties _RULES_JSON _RULE_INDEX _RULE_NAME _RULE_TYPE _RULE_COMMENT _RULE_DEFAULT)
+function(LoadRuleProperties _RULES_JSON _RULE_INDEX _RULE_NAME _RULE_TYPE _RULE_COMMENT _RULE_DEFAULT _IS_IMPLEMENTED)
   string(JSON RULE_OBJECT_JSON GET "${_RULES_JSON}" rules "${_RULE_INDEX}")
 
   string(JSON RULE_NAME GET "${RULE_OBJECT_JSON}" name)
@@ -92,11 +92,11 @@ function(LoadRuleProperties _RULES_JSON _RULE_INDEX _RULE_NAME _RULE_TYPE _RULE_
     set(IS_IMPLEMENTED "ON")
   endif()
 
-  set(RULE_NAME ${RULE_NAME} PARENT_SCOPE)
-  set(RULE_TYPE ${RULE_TYPE} PARENT_SCOPE)
-  set(RULE_TYPE ${RULE_COMMENT} PARENT_SCOPE)
-  set(RULE_DEFAULT ${RULE_DEFAULT} PARENT_SCOPE)
-  set(IS_IMPLEMENTED ${IS_IMPLEMENTED} PARENT_SCOPE)
+  set("${_RULE_NAME}" ${RULE_NAME} PARENT_SCOPE)
+  set("${_RULE_TYPE}" ${RULE_TYPE} PARENT_SCOPE)
+  set("${_RULE_COMMENT}" ${RULE_COMMENT} PARENT_SCOPE)
+  set("${_RULE_DEFAULT}" ${RULE_DEFAULT} PARENT_SCOPE)
+  set("${_IS_IMPLEMENTED}" ${IS_IMPLEMENTED} PARENT_SCOPE)
 endfunction()
 
 function (ExtractSectionIniCommentFromJson _RULES_JSON _INI_COMMENT)
@@ -192,6 +192,12 @@ function(ScanForRuleFiles _RULES_STATE_FILE _RULES_FILES _RULES_HASH _FILES_HAVE
   WatchFileForChanges("${RULES_NCO_TEMPLATE_PATH}")
   WatchFileForChanges("${RULE_KEYS_TEMPLATE_PATH}")
 
+  # watch this cmake script so changes to template rendering are detected
+  file(SHA256 "${CMAKE_CURRENT_LIST_FILE}" FILE_HASH)
+  string(SHA256 RULES_HASH "${RULES_HASH}${FILE_HASH}")
+
+  WatchFileForChanges("${CMAKE_CURRENT_LIST_FILE}")
+
   # If a previous hash was calculated, and does not match the
   # hash we just calculated, then flag that files have changed.
   set(FILES_HAVE_CHANGED true)
@@ -270,15 +276,15 @@ function(Main)
         string(APPEND RULE_PROCESS_CODE "\n             ")
       endif()
 
-      LoadRuleProperties("${RULES_JSON}" "${RULE_INDEX}" RULE_NAME RULE_TYPE RULE_COMMENT RULE_DEFAULT)
+      LoadRuleProperties("${RULES_JSON}" "${RULE_INDEX}" RULE_NAME RULE_TYPE RULE_COMMENT RULE_DEFAULT IS_IMPLEMENTED)
 
       TransformRuleNameToUpperSnakecase("${RULE_NAME}" RULE_NAME_SNAKE_CASE)
       set(RULE_DEFINE "${RULE_NAME_SNAKE_CASE}_RULE")
 
       # rules-nco.cpp
-      ResolveRuleValue("${RULE_DEFAULT}" RULE_VALUE)
+      ResolveRuleValue("${RULE_TYPE}" "${RULE_DEFAULT}" RULE_VALUE)
 
-      string(APPEND RULE_PROCESS_CODE ".Load(${RULE_DEFINE}).With_Comment(${RULE_COMMENT}).With_Default(${RULE_VALUE})")
+      string(APPEND RULE_PROCESS_CODE ".Load(${RULE_DEFINE}).With_Comment(\"${RULE_COMMENT}\").With_Default(${RULE_VALUE})")
 
       if(${RULE_INDEX} EQUAL ${RULE_COUNT})
         # close call chain for section

--- a/cmake/NcoTypes.cmake
+++ b/cmake/NcoTypes.cmake
@@ -37,10 +37,11 @@ endmacro()
 CHECK_REQUIRED_VARIABLE(TYPES_PATH)
 CHECK_REQUIRED_VARIABLE(TYPES_TEMPLATE_PATH)
 
-function(LoadTypeProperties _TYPE_JSON _PROP_INDEX _PROP_NAME _PROP_TYPE _REQ_CONVERTER _REQ_CSV_CONVERTER _TEMPLATE_IGNORE)
+function(LoadTypeProperties _TYPE_JSON _PROP_INDEX _PROP_NAME _PROP_COMMENT _PROP_TYPE _REQ_CONVERTER _REQ_CSV_CONVERTER _TEMPLATE_IGNORE)
   string(JSON TYPE_OBJECT_JSON GET "${_TYPE_JSON}" properties "${_PROP_INDEX}")
 
   string(JSON PROP_NAME GET "${TYPE_OBJECT_JSON}" name)
+  string(JSON PROP_COMMENT GET "${TYPE_OBJECT_JSON}" comment)
   string(JSON PROP_TYPE GET "${TYPE_OBJECT_JSON}" type)
 
   string(JSON REQ_CONVERTER ERROR_VARIABLE JSON_ERROR GET "${TYPE_OBJECT_JSON}" requires_converter)
@@ -65,6 +66,7 @@ function(LoadTypeProperties _TYPE_JSON _PROP_INDEX _PROP_NAME _PROP_TYPE _REQ_CO
   endif()
 
   set("${_PROP_NAME}" ${PROP_NAME} PARENT_SCOPE)
+  set("${_PROP_COMMENT}" ${PROP_COMMENT} PARENT_SCOPE)
   set("${_PROP_TYPE}" ${PROP_TYPE} PARENT_SCOPE)
   set("${_REQ_CONVERTER}" ${REQ_CONVERTER} PARENT_SCOPE)
   set("${_REQ_CSV_CONVERTER}" ${REQ_CSV_CONVERTER} PARENT_SCOPE)
@@ -148,10 +150,17 @@ function(ScanForTypeFiles _TYPE_STATE_FILE _TYPES_FILES _TYPES_HASH _FILES_HAVE_
     WatchFileForChanges("${TYPE_FILE}")
   endforeach()
 
+  # ensure templates is included in hash so code is generated if changed
   file(SHA256 "${TYPES_TEMPLATE_PATH}" FILE_HASH)
   string(SHA256 TYPES_HASH "${TYPES_HASH}${FILE_HASH}")
 
   WatchFileForChanges("${TYPES_TEMPLATE_PATH}")
+
+  # watch this cmake script so changes to template rendering are detected
+  file(SHA256 "${CMAKE_CURRENT_LIST_FILE}" FILE_HASH)
+  string(SHA256 TYPES_HASH "${TYPES_HASH}${FILE_HASH}")
+
+  WatchFileForChanges("${CMAKE_CURRENT_LIST_FILE}")
 
   # If a previous hash was calculated, and does not match the
   # hash we just calculated, then flag that files have changed.
@@ -196,11 +205,12 @@ function(Main)
     ExtractTypeInfoFromJson("${TYPE_JSON}" TYPE_NAME PROP_COUNT)
 
     message(STATUS "[NcoTypeRules] Generating code for type: ${TYPE_NAME}")
+    SET(LOAD_COMMENTS_CODE "")
     SET(LOAD_RULES_CODE "")
     SET(READ_RULES_CODE "")
 
     foreach(PROP_INDEX RANGE ${PROP_COUNT})
-      LoadTypeProperties("${TYPE_JSON}" "${PROP_INDEX}" PROP_NAME PROP_TYPE REQ_CONVERTER REQ_CSV_CONVERTER TEMPLATE_IGNORE)
+      LoadTypeProperties("${TYPE_JSON}" "${PROP_INDEX}" PROP_NAME PROP_COMMENT PROP_TYPE REQ_CONVERTER REQ_CSV_CONVERTER TEMPLATE_IGNORE)
 
       if(${TEMPLATE_IGNORE} STREQUAL "ON")
         continue()
@@ -212,6 +222,11 @@ function(Main)
       endif()
 
       message(STATUS "[NcoTypeRules] Processing property #${PROP_INDEX}: ${PROP_NAME} (type=${PROP_TYPE})")
+
+      if (NOT ${PROP_COMMENT} STREQUAL "-") # ignore placeholder comments
+        string(APPEND LOAD_COMMENTS_CODE "\n        ")
+        string(APPEND LOAD_COMMENTS_CODE ".Set_Var_Comment(${PROP_NAME}, \"${PROP_COMMENT}\")")
+      endif()
 
       if(${REQ_CONVERTER} STREQUAL "OFF" AND ${REQ_CSV_CONVERTER} STREQUAL "OFF")
         string(APPEND LOAD_RULES_CODE ".Load_${PROP_TYPE}_Var(${PROP_NAME})")
@@ -231,6 +246,7 @@ function(Main)
 
     string(TOUPPER ${TYPE_NAME} TYPE_NAME)
 
+    SET("LOAD_${TYPE_NAME}_COMMENTS_CODE" "${LOAD_COMMENTS_CODE}")
     SET("LOAD_${TYPE_NAME}_RULES_CODE" "${LOAD_RULES_CODE}")
     SET("READ_${TYPE_NAME}_RULES_CODE" "${READ_RULES_CODE}")
     SET(RELATIVE_TYPE_FILES "${RELATIVE_TYPE_FILES} ${RELATIVE_TYPE_FILE}")

--- a/common/ini.cpp
+++ b/common/ini.cpp
@@ -374,20 +374,19 @@ int INIClass::Save(Pipe& pipe) const
         */
         INIEntry* entryptr = secptr->EntryList.First();
         while (entryptr && entryptr->Is_Valid()) {
+            total += pipe.Put(entryptr->Entry, (int)strlen(entryptr->Entry));
+            total += pipe.Put("=", 1);
+            total += pipe.Put(entryptr->Value, (int)strlen(entryptr->Value));
+
             /*
             **	Output the entry comment (if present).
             */
             if (entryptr->comment.has_value()) {
                 const auto entry_comment = entryptr->comment->c_str();
 
-                total += pipe.Put(";  ", 2);
+                total += pipe.Put(" ; ", 3);
                 total += pipe.Put(entry_comment, static_cast<int>(strlen(entry_comment)));
-                total += pipe.Put("\r\n", (int)strlen("\r\n"));
             }
-
-            total += pipe.Put(entryptr->Entry, (int)strlen(entryptr->Entry));
-            total += pipe.Put("=", 1);
-            total += pipe.Put(entryptr->Value, (int)strlen(entryptr->Value));
 
             total += pipe.Put("\r\n", (int)strlen("\r\n"));
 

--- a/common/ini.cpp
+++ b/common/ini.cpp
@@ -798,7 +798,13 @@ int INIClass::Get_TextBlock(char const* section, char* buffer, int len) const
  *   07/03/1996 JLB : Created.                                                                 *
  *   07/10/1996 JLB : Handles multiple integer formats.                                        *
  *=============================================================================================*/
-bool INIClass::Put_Int(char const* section, char const* entry, int number, int format)
+bool INIClass::Put_Int(
+    char const* section,
+    char const* entry,
+    int number,
+    int format,
+    std::optional<std::string> comment
+)
 {
     char buffer[MAX_LINE_LENGTH];
 
@@ -816,7 +822,7 @@ bool INIClass::Put_Int(char const* section, char const* entry, int number, int f
         sprintf(buffer, "$%X", number);
         break;
     }
-    return (Put_String(section, entry, buffer));
+    return (Put_String(section, entry, buffer, std::move(comment)));
 }
 
 /***********************************************************************************************

--- a/common/ini.h
+++ b/common/ini.h
@@ -125,7 +125,7 @@ public:
     bool Put_String(char const* section, char const* entry, char const* string, std::optional<std::string> comment = std::nullopt);
     bool Put_String(char const* section, char const* entry, std::string const& string, std::optional<std::string> comment = std::nullopt);
     bool Put_Hex(char const* section, char const* entry, int number);
-    bool Put_Int(char const* section, char const* entry, int number, int format = 0);
+    bool Put_Int(char const* section, char const* entry, int number, int format = 0, std::optional<std::string> comment = std::nullopt);
     bool Put_Bool(char const* section, char const* entry, bool value, std::optional<std::string> comment = std::nullopt);
     bool Put_TextBlock(char const* section, char const* text);
     bool Put_UUBlock(char const* section, void const* block, int len);

--- a/common/logger.cpp
+++ b/common/logger.cpp
@@ -20,13 +20,6 @@ void CncLogger::On_Fatal_Error(std::string errorMessage)
     OnFatalError(std::move(errorMessage));
 }
 
-void CncLogger::Fatal(const std::string_view message) const
-{
-    spdlog::get(Name)->critical(message);
-    spdlog::shutdown();
-    exit(1);
-}
-
 std::shared_ptr<spdlog::logger> CncLogger::operator()() const
 {
     auto logger = spdlog::get(Name);
@@ -84,18 +77,12 @@ void CncLogger::Init_SpdLog()
 
     Sinks.emplace_back(StdoutSink);
 
+    // create log file in user path
     const auto log_file_name = std::format("{}.log", DefaultLoggerName);
-#ifndef __APPLE__
-    // crate log file beside game exe/binary/dll
-    const auto log_file = std::filesystem::path(PathsClass::Try_Get_Program_Path())
-        .append(log_file_name)
-        .string();
-#else
-    // create log file in user path (app bundle is read-only in macos)
+
     const auto log_file = std::filesystem::path(Paths.User_Path())
         .append(log_file_name)
         .string();
-#endif
 
     RotatingSink = std::make_shared<spdlog::sinks::rotating_file_sink_mt>(
         log_file,

--- a/common/logger.h
+++ b/common/logger.h
@@ -52,6 +52,9 @@ public:
     static inline const auto DefaultLoggerName = std::string("nco");
     static inline std::function<void(std::string)> OnFatalError = [](const auto& e) {
         TRIGGER_DEBUGGER;
+
+        spdlog::shutdown();
+
         throw std::runtime_error(e);
     };
 
@@ -70,7 +73,6 @@ public:
     static void On_Fatal_Error(std::string errorMessage);
 
     // TODO: Add PII level/log method to require a special flag or runtime arg to force print them (paths containing usernames etc.)
-    void Fatal(const std::string_view message) const;
 
     std::shared_ptr<spdlog::logger> operator()() const;
 

--- a/common/lua/luaengine.cpp
+++ b/common/lua/luaengine.cpp
@@ -362,7 +362,7 @@ const std::string_view LuaEngine::Get_Variant_Type(const LuaVariant& lua_variant
 LuaResultWithValue<std::string> LuaEngine::To_String(int stack_index) const
 {
     return Get_Value_From_State<LuaResultWithValue<std::string>>([&](auto L) {
-        return LuaResultWithValue<std::string>(
+        return LuaResultWithValue(
             std::string(lua_tostring(L, stack_index))
         );
     });
@@ -383,6 +383,52 @@ void LuaEngine::Push_Nil() const
 bool LuaEngine::Iterate_Over_Table(int stack_index) const
 {
     return Get_Value_From_State<bool>([&](auto L){ return lua_next(L, stack_index) != 0; });
+}
+
+LuaEvalResult LuaEngine::Eval(const std::string& expression) const
+{
+    CNC_LOGGER_TRACE("Attempting to evaluate lua expression: {}", expression);
+
+    return Get_Value_From_State<LuaEvalResult>([&expression](auto L)
+    {
+        // attempt to compile an evaluation first
+        const auto return_expression = std::format("return {}", expression);
+
+        auto status = luaL_loadstring(L, return_expression.c_str());
+        const auto eval_returns_value = status == LUA_OK;
+
+        if (!eval_returns_value) {
+            // expression cannot be evaluated, just compile for execution instead
+            status = luaL_loadstring(L, expression.c_str());
+        }
+
+        if (status != LUA_OK) {
+            auto result = LuaResult(L, status);
+
+            CNC_LOGGER_TRACE(
+                "Error loading lua script due to '{}' error: {}",
+                result.Code_As_String(),
+                result.Error_Message()
+            );
+            return LuaEvalResult(result, eval_returns_value);
+        }
+
+        const auto eval_result = LuaResult(
+            L,
+            lua_pcall(L, 0, LUA_MULTRET, 0)
+        );
+
+        return LuaEvalResult(eval_result, eval_returns_value);
+    });
+}
+
+LuaResultWithValue<std::string> LuaEngine::Eval_To_String(const std::string& expression) const
+{
+    if (const auto result = Eval(expression); !result.Is_Ok() || !result.Returned_Value()) {
+        return { result };
+    }
+
+    return To_String();
 }
 
 luabridge::Namespace LuaEngine::Bridge() const

--- a/common/lua/luaengine.cpp
+++ b/common/lua/luaengine.cpp
@@ -429,7 +429,10 @@ LuaResultWithValue<std::string> LuaEngine::Eval_To_String(const std::string& exp
     auto eval_result = Get_Value_From_State<LuaEvalResult>([&expression](auto L)
     {
         // attempt to compile an evaluation first
-        const auto return_expression = std::format("return tostring({})", expression);
+        const auto return_expression = std::format(
+            "local ___r = {}; return tostring(___r == nil and 'nil' or ___r)", // tostring errors with nil arg
+            expression
+        );
 
         auto status = luaL_loadstring(L, return_expression.c_str());
         const auto eval_returns_value = status == LUA_OK;

--- a/common/lua/luaengine.cpp
+++ b/common/lua/luaengine.cpp
@@ -424,8 +424,42 @@ LuaEvalResult LuaEngine::Eval(const std::string& expression) const
 
 LuaResultWithValue<std::string> LuaEngine::Eval_To_String(const std::string& expression) const
 {
-    if (const auto result = Eval(expression); !result.Is_Ok() || !result.Returned_Value()) {
-        return { result };
+    CNC_LOGGER_TRACE("Attempting to evaluate lua expression as string: {}", expression);
+
+    auto eval_result = Get_Value_From_State<LuaEvalResult>([&expression](auto L)
+    {
+        // attempt to compile an evaluation first
+        const auto return_expression = std::format("return tostring({})", expression);
+
+        auto status = luaL_loadstring(L, return_expression.c_str());
+        const auto eval_returns_value = status == LUA_OK;
+
+        if (!eval_returns_value) {
+            // expression cannot be evaluated, just compile for execution instead
+            status = luaL_loadstring(L, expression.c_str());
+        }
+
+        if (status != LUA_OK) {
+            auto result = LuaResult(L, status);
+
+            CNC_LOGGER_TRACE(
+                "Error loading lua script due to '{}' error: {}",
+                result.Code_As_String(),
+                result.Error_Message()
+            );
+            return LuaEvalResult(result, eval_returns_value);
+        }
+
+        const auto eval_result = LuaResult(
+            L,
+            lua_pcall(L, 0, LUA_MULTRET, 0)
+        );
+
+        return LuaEvalResult(eval_result, eval_returns_value);
+    });
+
+    if (!eval_result.Is_Ok() || !eval_result.Returned_Value()) {
+        return { eval_result };
     }
 
     return To_String();

--- a/common/lua/luaengine.h
+++ b/common/lua/luaengine.h
@@ -3,9 +3,9 @@
 /**
  * C++ API for working with Lua. Uses LuaBridge to provide a
  * fluent interface for declaring classes, functions and variables.
- * 
+ *
  * Class hierarchy:
- * 
+ *
  *   LuaEngine --[uses]--> LuaResult --[uses]--> LuaResultWithValue
  *   LuaArguments --[uses]--> LuaEngine
  *   UniqueLuaEngine --[extends]--> LuaEngine
@@ -295,7 +295,7 @@ public:
     ) const
     {
         auto expected_type = LUA_TNONE;
-        
+
         if constexpr (std::is_same_v<T, bool>) {
             expected_type = LUA_TBOOLEAN;
         } else if constexpr (std::is_same_v<T, int> || std::is_same_v<T, float> || std::is_same_v<T, double>) {
@@ -379,7 +379,7 @@ public:
                     "Unable to set field '{}' as target '{}' is not a table",
                     name,
                     table_expression
-                )  
+                )
             };
         }
 
@@ -396,11 +396,14 @@ public:
 
     #pragma region Expressions
 
+    LuaEvalResult Eval(const std::string& expression) const;
+    LuaResultWithValue<std::string> Eval_To_String(const std::string& expression) const;
+
     template<LuaVariantCompatible T>
-    LuaResultWithValue<T> Eval(const std::string& expression) const
+    LuaResultWithValue<T> Eval_As(const std::string& expression) const
     {
-        if (const auto result = Exec(std::format("return {}", expression)); !result.Is_Ok()) {
-            return LuaResultWithValue<T>(result);
+        if (const auto eval_result = Eval(expression); !eval_result.Is_Ok() || !eval_result.Returned_Value()) {
+            return LuaResultWithValue<T>(eval_result);
         }
 
         return Try_Read<T>();
@@ -414,7 +417,7 @@ public:
 
         std::thread([this, expression, promise]() {
             promise->set_value(
-                Eval<T>(expression)
+                Eval_As<T>(expression)
             );
         }).detach();
 
@@ -461,7 +464,7 @@ private:
  * Instances of this LuaEngine should be created for the lifecycle of a
  * given context to ensure clean state when starting a new context
  * (scenario/screen/thread etc.).
- * 
+ *
  * Aligns with smart pointer unique logic.
  */
 class UniqueLuaEngine final : public LuaEngine
@@ -491,7 +494,7 @@ private:
  * Instances of this LuaEngine should be created to wrap around
  * a state that isn't owned by the current context, e.x. in a
  * Lua CFunction.
- * 
+ *
  * Aligns with smart pointer shared logic.
  */
 class SharedLuaEngine final : public LuaEngine

--- a/common/lua/luaevent.h
+++ b/common/lua/luaevent.h
@@ -3,6 +3,7 @@
 #include <string>
 
 #include "logger.h"
+#include "luaengine.h"
 
 /**
  * Encapsulates a piece of discrete logic that a Lua
@@ -18,7 +19,12 @@ public:
     virtual void Execute() const
     {
         CNC_LOGGER_DEBUG("Executing lua event of type: {}", EventType);
-    };
+    }
+
+    virtual void Execute(const LuaEngine& engine) const
+    {
+        Execute();
+    }
 
 protected:
     static inline const auto& Logger = CncLogger::For(LuaEvent);

--- a/common/lua/luaresult.h
+++ b/common/lua/luaresult.h
@@ -120,3 +120,37 @@ private:
 
     std::optional<T> ValueSource;
 };
+
+
+/**
+ * Models the result of evaluating a lua expression.
+ */
+class LuaEvalResult : public LuaResult
+{
+public:
+    LuaEvalResult(const LuaResult& result) : LuaResult(result), ReturnedValue(false) {}
+
+    LuaEvalResult(const LuaResult& result, const bool eval_returned_value) : LuaResult(result)
+    {
+        ReturnedValue = eval_returned_value;
+    }
+
+    const LuaEvalResult& If_Value(const std::function<void()>& action) const
+    {
+        if (Returned_Value()) {
+            action();
+        }
+
+        return *this;
+    }
+
+    bool Returned_Value() const
+    {
+        return ReturnedValue;
+    }
+
+private:
+    static inline const auto& Logger = CncLogger::For(LuaResultWithValue);
+
+    bool ReturnedValue;
+};

--- a/common/lua/scripts/nco/lib/TypeValidator.lua
+++ b/common/lua/scripts/nco/lib/TypeValidator.lua
@@ -75,27 +75,27 @@ end
 ---@param argumentName string
 ---@param value table|string
 local function isNotEmpty(functionName, argumentName, value)
-    if type(value) == "table" then
-        assert(
-            next(value) ~= nil,
-            string.format("%s: argument %s must not be empty", functionName, argumentName)
-        )
-        return
-    elseif type(value) == "string" then
-        assert(
-            (#value) > 0,
-            string.format("%s: argument %s must not be empty", functionName, argumentName)
-        )
-        return
-    end
-
-    error(
-        string.format(
-            "%s: invalid 'isNotEmpty' for argument %s (must be of type: table OR string)",
-            functionName,
-            argumentName
-        )
+  if type(value) == "table" then
+    assert(
+      next(value) ~= nil,
+      string.format("%s: argument %s must not be empty", functionName, argumentName)
     )
+    return
+  elseif type(value) == "string" then
+    assert(
+      (#value) > 0,
+      string.format("%s: argument %s must not be empty", functionName, argumentName)
+    )
+    return
+  end
+
+  error(
+    string.format(
+      "%s: invalid 'isNotEmpty' for argument %s (must be of type: table OR string)",
+      functionName,
+      argumentName
+    )
+  )
 end
 
 ---@param validValues table

--- a/common/lua/scripts/nco/lib/TypeValidator.lua
+++ b/common/lua/scripts/nco/lib/TypeValidator.lua
@@ -75,27 +75,58 @@ end
 ---@param argumentName string
 ---@param value table|string
 local function isNotEmpty(functionName, argumentName, value)
-  if type(value) == "table" then
-    assert(
-      next(value) ~= nil,
-      string.format("%s: argument %s must not be empty", functionName, argumentName)
+    if type(value) == "table" then
+        assert(
+            next(value) ~= nil,
+            string.format("%s: argument %s must not be empty", functionName, argumentName)
+        )
+        return
+    elseif type(value) == "string" then
+        assert(
+            (#value) > 0,
+            string.format("%s: argument %s must not be empty", functionName, argumentName)
+        )
+        return
+    end
+
+    error(
+        string.format(
+            "%s: invalid 'isNotEmpty' for argument %s (must be of type: table OR string)",
+            functionName,
+            argumentName
+        )
     )
-    return
-  elseif type(value) == "string" then
-    assert(
-      (#value) > 0,
-      string.format("%s: argument %s must not be empty", functionName, argumentName)
-    )
-    return
+end
+
+---@param validValues table
+local function isOneOf(validValues)
+  local valuesString = ""
+
+  for i, validValue in ipairs(validValues) do
+    if i == 1 then
+      valuesString = valuesString .. "|"
+    end
+
+    valuesString = valuesString .. validValue
   end
 
-  error(
-    string.format(
-      "%s: invalid 'isNotEmpty' for argument %s (must be of type: table OR string)",
-      functionName,
-      argumentName
+  ---@param functionName string
+  ---@param argumentName string
+  ---@param value any
+  return function(functionName, argumentName, value)
+    local valueIsValid = false
+
+    for _, validValue in ipairs(valuesString) do
+      if value == validValue then
+        valueIsValid = true
+      end
+    end
+
+    assert(
+      valueIsValid,
+      string.format("%s: argument %s must be equal to value(s) %s", functionName, argumentName, valuesString)
     )
-  )
+  end
 end
 
 ---@param functionName string
@@ -143,7 +174,8 @@ return {
     isType = isType,
     isNotNil = isNotNil,
     isNotBlank = isNotBlank,
-    isNotEmpty = isNotEmpty
+    isNotEmpty = isNotEmpty,
+    isOneOf = isOneOf
   },
   validateCall = validateCall
 }

--- a/common/paths.cpp
+++ b/common/paths.cpp
@@ -138,3 +138,15 @@ const char* PathsClass::User_Lua_Path()
 
     return UserLuaPath.c_str();
 }
+
+const char* PathsClass::User_Save_Path()
+{
+    if (UserSavePath.empty()) {
+        UserSavePath = Concatenate_Paths(User_Path(), "save");
+
+        // ensure lua directory exists in game directory inside user path
+        Create_Directory(UserSavePath.c_str());
+    }
+
+    return UserSavePath.c_str();
+}

--- a/common/paths.h
+++ b/common/paths.h
@@ -47,6 +47,7 @@ public:
     const char* Data_Path();
     const char* User_Path();
     const char* User_Lua_Path();
+    const char* User_Save_Path();
 
 private:
     std::string Suffix;
@@ -55,6 +56,7 @@ private:
     std::string DataPath;
     std::string UserPath;
     std::string UserLuaPath;
+    std::string UserSavePath;
 
     static std::string Argv_Path(const char* cmd_arg);
 };

--- a/common/rulesections.cpp
+++ b/common/rulesections.cpp
@@ -200,25 +200,27 @@ const RuleSection& RuleSection::Save_To_Ini(INIClass& ini, std::string_view name
         Variant_To_String(value_variant)
     );
 
+    const auto comment = Try_Get_Comment(name);
+
     if (const auto value = std::get_if<int>(&value_variant)) {
-        ini.Put_Int(SectionName.data(), name.data(), *value);
+        ini.Put_Int(SectionName.data(), name.data(), *value, 0, comment);
     } else if (const auto value = std::get_if<bool>(&value_variant)) {
-        ini.Put_Bool(SectionName.data(), name.data(), *value);
+        ini.Put_Bool(SectionName.data(), name.data(), *value, comment);
     } else if (const auto value = std::get_if<float>(&value_variant)) {
         const auto value_str = std::format("{}", *value);
-        ini.Put_String(SectionName.data(), name.data(), value_str);
+        ini.Put_String(SectionName.data(), name.data(), value_str, comment);
     } else if (const auto value = std::get_if<ushort>(&value_variant)) {
         const auto value_str = std::format("{}", static_cast<int>(*value));
-        ini.Put_String(SectionName.data(), name.data(), value_str);
+        ini.Put_String(SectionName.data(), name.data(), value_str, comment);
     } else if (const auto value = std::get_if<uint>(&value_variant)) {
         const auto value_str = std::format("{}", *value);
-        ini.Put_String(SectionName.data(), name.data(), value_str);
+        ini.Put_String(SectionName.data(), name.data(), value_str, comment);
     } else if (const auto value = std::get_if<char>(&value_variant)) {
-        ini.Put_Int(SectionName.data(), name.data(), *value);
+        ini.Put_Int(SectionName.data(), name.data(), *value, 0, comment);
     } else if (const auto value = std::get_if<uchar>(&value_variant)) {
-        ini.Put_Int(SectionName.data(), name.data(), *value);
+        ini.Put_Int(SectionName.data(), name.data(), *value, 0, comment);
     } else if (const auto value = std::get_if<std::string>(&value_variant)) {
-        ini.Put_String(SectionName.data(), name.data(), *value);
+        ini.Put_String(SectionName.data(), name.data(), *value, comment);
     } else {
         throw std::invalid_argument("Unsupported RuleValueVariant type - this is normally caused by variant type list being updated without updating supporting code");
     }
@@ -267,6 +269,20 @@ RuleSection& RuleSection::Set(std::string_view name, RuleValueVariant value)
 std::optional<std::string_view>& RuleSection::Get_Converter_Section_Type_Name()
 {
     return ConverterSectionTypeName;
+}
+
+void RuleSection::Set_Comment(const std::string_view name, std::string comment)
+{
+    RuleComments[name.data()] = std::move(comment);
+}
+
+std::optional<std::string> RuleSection::Try_Get_Comment(const std::string_view name) const
+{
+    if (RuleComments.contains(name.data())) {
+        return RuleComments.at(name.data());
+    }
+
+    return std::nullopt;
 }
 
 //IniRuleContext

--- a/common/rulesections.cpp
+++ b/common/rulesections.cpp
@@ -200,7 +200,7 @@ const RuleSection& RuleSection::Save_To_Ini(INIClass& ini, std::string_view name
         Variant_To_String(value_variant)
     );
 
-    const auto comment = Try_Get_Comment(name);
+    const auto comment = Try_Get_Rule_Comment(name);
 
     if (const auto value = std::get_if<int>(&value_variant)) {
         ini.Put_Int(SectionName.data(), name.data(), *value, 0, comment);
@@ -271,12 +271,14 @@ std::optional<std::string_view>& RuleSection::Get_Converter_Section_Type_Name()
     return ConverterSectionTypeName;
 }
 
-void RuleSection::Set_Comment(const std::string_view name, std::string comment)
+RuleSection& RuleSection::Set_Rule_Comment(const std::string_view name, std::string comment)
 {
     RuleComments[name.data()] = std::move(comment);
+
+    return *this;
 }
 
-std::optional<std::string> RuleSection::Try_Get_Comment(const std::string_view name) const
+std::optional<std::string> RuleSection::Try_Get_Rule_Comment(const std::string_view name) const
 {
     if (RuleComments.contains(name.data())) {
         return RuleComments.at(name.data());

--- a/common/rulesections.h
+++ b/common/rulesections.h
@@ -390,8 +390,8 @@ public:
         return Set(name, instances_csv);
     }
 
-    void Set_Comment(std::string_view name, std::string comment);
-    std::optional<std::string> Try_Get_Comment(std::string_view name) const;
+    RuleSection& Set_Rule_Comment(std::string_view name, std::string comment);
+    std::optional<std::string> Try_Get_Rule_Comment(std::string_view name) const;
 
     // TODO: Handle OnRulesChanged, if needed
     NLOHMANN_DEFINE_TYPE_INTRUSIVE(RuleSection, Rules, ConverterSectionTypeName, SectionName)
@@ -471,6 +471,8 @@ private:
     }
 };
 
+// RuleSection macro 'methods' - useful for setting variables and class members from rules
+
 #define Read_Var_With_Type(VAR, T) Get_With_Callback<T>(#VAR, [&](const auto v) { VAR = v; })
 
 // Load a variable/member by its C++ name from an INI context and set its value to equal the INI value
@@ -482,6 +484,8 @@ private:
 #define Read_Char_Var(VAR) Read_Var_With_Type(VAR, char)
 #define Read_UChar_Var(VAR) Read_Var_With_Type(VAR, uchar)
 #define Read_String_Var(VAR) Read_Var_With_Type(VAR, std::string)
+
+#define Set_Var_Comment(VAR, COMMENT) Set_Rule_Comment(#VAR, COMMENT)
 
 class IniRuleContext
 {
@@ -607,14 +611,13 @@ public:
 
     IniRuleContext& Load(std::string_view name);
 
-    template<RuleValueVariantCompatible T>
     IniRuleContext& With_Comment(std::string comment)
     {
         if (!NameInStream.has_value()) {
             CNC_LOGGER_FATAL("Load(..) must be called before With_Comment(..)");
         }
 
-        Section.Set_Comment(NameInStream.value(), std::move(comment));
+        Section.Set_Rule_Comment(NameInStream.value(), std::move(comment));
 
         return *this;
     }
@@ -631,6 +634,11 @@ public:
         NameInStream = std::nullopt;
 
         return *this;
+    }
+
+    RuleSection& Get_Section() const
+    {
+        return Section;
     }
 
 private:

--- a/common/rulesections.h
+++ b/common/rulesections.h
@@ -390,6 +390,9 @@ public:
         return Set(name, instances_csv);
     }
 
+    void Set_Comment(std::string_view name, std::string comment);
+    std::optional<std::string> Try_Get_Comment(std::string_view name) const;
+
     // TODO: Handle OnRulesChanged, if needed
     NLOHMANN_DEFINE_TYPE_INTRUSIVE(RuleSection, Rules, ConverterSectionTypeName, SectionName)
 private:
@@ -404,6 +407,7 @@ private:
     static inline const std::function<bool(int)> ValidateUChar = [](auto v) { return v >= std::numeric_limits<uchar>::min() && v <= std::numeric_limits<uchar>::max(); };
 
     std::map<std::string, RuleValueVariant> Rules;
+    std::map<std::string, std::string> RuleComments;
     std::function<void(RuleSection&, std::string_view, const RuleValueVariant&)> OnRulesChanged;
     std::optional<std::string_view> ConverterSectionTypeName;
 
@@ -602,6 +606,18 @@ public:
     const IniRuleContext& Save(std::string_view name) const;
 
     IniRuleContext& Load(std::string_view name);
+
+    template<RuleValueVariantCompatible T>
+    IniRuleContext& With_Comment(std::string comment)
+    {
+        if (!NameInStream.has_value()) {
+            CNC_LOGGER_FATAL("Load(..) must be called before With_Comment(..)");
+        }
+
+        Section.Set_Comment(NameInStream.value(), std::move(comment));
+
+        return *this;
+    }
 
     template<RuleValueVariantCompatible T>
     IniRuleContext& With_Default(T default_value)

--- a/launcher/App.axaml.cs
+++ b/launcher/App.axaml.cs
@@ -21,7 +21,7 @@ public partial class App : Application
     if (ApplicationLifetime is IClassicDesktopStyleApplicationLifetime desktop)
     {
       desktop.Exit += OnExit;
-      desktop.MainWindow = new MainWindow();
+      desktop.MainWindow = Locator.Current.GetService<MainWindow>();
     }
 
     base.OnFrameworkInitializationCompleted();

--- a/launcher/CNC.NCO.Launcher.csproj
+++ b/launcher/CNC.NCO.Launcher.csproj
@@ -34,25 +34,25 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AnimatedImage.Avalonia" Version="2.1.2" />
-    <PackageReference Include="Autofac" Version="8.4.0" />
-    <PackageReference Include="Avalonia" Version="11.3.6" />
-    <PackageReference Include="Avalonia.Desktop" Version="11.3.6" />
-    <PackageReference Include="Avalonia.ReactiveUI" Version="11.3.6" />
-    <PackageReference Include="Avalonia.Themes.Fluent" Version="11.3.6" />
-    <PackageReference Include="Avalonia.Fonts.Inter" Version="11.3.6" />
+    <PackageReference Include="AnimatedImage.Avalonia" Version="2.1.4" />
+    <PackageReference Include="Autofac" Version="9.1.0" />
+    <PackageReference Include="Avalonia" Version="12.0.2" />
+    <PackageReference Include="Avalonia.Desktop" Version="12.0.2" />
+    <PackageReference Include="Avalonia.ReactiveUI" Version="11.3.8" />
+    <PackageReference Include="Avalonia.Themes.Fluent" Version="12.0.2" />
+    <PackageReference Include="Avalonia.Fonts.Inter" Version="12.0.2" />
     <!--Condition below is needed to remove Avalonia.Diagnostics package from build output in Release configuration.-->
-    <PackageReference Include="Avalonia.Diagnostics" Version="11.3.6">
+    <PackageReference Include="Avalonia.Diagnostics" Version="11.3.14">
       <IncludeAssets Condition="'$(Configuration)' != 'Debug'">None</IncludeAssets>
       <PrivateAssets Condition="'$(Configuration)' != 'Debug'">All</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Blake3" Version="2.0.0" />
+    <PackageReference Include="Blake3" Version="2.2.1" />
     <PackageReference Include="DiscUtils" Version="0.16.13" />
     <PackageReference Include="DotNet.Bundle" Version="0.9.13" />
     <PackageReference Include="GitHub.Octokit.SDK" Version="0.0.31" />
-    <PackageReference Include="SharpCompress" Version="0.40.0" />
+    <PackageReference Include="SharpCompress" Version="0.47.4" />
     <PackageReference Include="Splat.Avalonia.Autofac" Version="15.5.3" />
-    <PackageReference Include="YamlDotNet" Version="16.3.0" />
+    <PackageReference Include="YamlDotNet" Version="17.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/launcher/Model/DiscImageSourceConfig.cs
+++ b/launcher/Model/DiscImageSourceConfig.cs
@@ -5,6 +5,7 @@ namespace CNC.NCO.Launcher.Model;
 #pragma warning disable CS8618 // YAML deserialization populates these members
 public class DiscImageSourceConfig
 {
+  public int SortOrder { get; set; }
   public string Name { get; set; }
   public string DisplayName { get; set; }
   public string Url { get; set; }

--- a/launcher/Model/Events/Download/DownloadFallbackEvent.cs
+++ b/launcher/Model/Events/Download/DownloadFallbackEvent.cs
@@ -1,0 +1,13 @@
+using System;
+
+namespace CNC.NCO.Launcher.Model.Events.Download;
+
+public record DownloadFallbackEvent(
+  GameDataConfig GameData,
+  DiscImageSourceConfig FailedSource,
+  DiscImageSourceConfig FallbackSource,
+  Exception Error
+) : IEvent<IDownloadEventVisitor>
+{
+  public void Accept(IDownloadEventVisitor visitor) => visitor.Visit(this);
+}

--- a/launcher/Model/Events/Download/IDownloadEventVisitor.cs
+++ b/launcher/Model/Events/Download/IDownloadEventVisitor.cs
@@ -13,6 +13,7 @@ public interface IDownloadEventVisitor : IVisitor
   void Visit(WriteGameDataFileEvent e);
   void Visit(FinishDiscImageFileScanEvent e);
   void Visit(FinishDownloadGameDataEvent e);
+  void Visit(DownloadFallbackEvent downloadFallbackEvent);
   void Visit(DownloadGameDataErrorEvent e);
 
   // Mods/addons install

--- a/launcher/Service/GameDataService.cs
+++ b/launcher/Service/GameDataService.cs
@@ -31,7 +31,7 @@ public class GameDataService(
     Stream downloadStream
   )
   {
-    using var zipReader = ReaderFactory.Open(downloadStream);
+    using var zipReader = ReaderFactory.OpenReader(downloadStream);
 
     while (zipReader.MoveToNextEntry())
     {
@@ -153,7 +153,7 @@ public class GameDataService(
       return true;
     }
 
-    using var zipReader = ReaderFactory.Open(responseStream);
+    using var zipReader = ReaderFactory.OpenReader(responseStream);
 
     while (zipReader.MoveToNextEntry())
     {
@@ -253,15 +253,42 @@ public class GameDataService(
   )
   {
     // TODO: Allow user to select source and pass into this method to filter (instead of first)
-    foreach (var imageSource in dataConfig.EnabledDiscImagesBySource.First().Value)
+    var imagesBySource = dataConfig.EnabledDiscImagesBySource;
+    var primarySources = 
+      imagesBySource.First(i => i.Value.All(s => s.Config.SortOrder == 1));
+    var fallbackSources = 
+      imagesBySource.First(i => i.Value.All(s => s.Config.SortOrder > 1));
+
+    for (var idx = 0; idx < imagesBySource.Count; idx++)
     {
-      await ExtractGameDataFromDiscImage(
-        imageSource,
-        downloadEventVisitor,
-        bin2IsoService,
-        installPath,
-        i => OnIsoOpen(imageSource, i)
-      );
+      var primarySource = primarySources.Value[idx];
+      var fallbackSource = fallbackSources.Value[idx];
+
+      try
+      {
+        // attempt to source game data from primary source first
+        await ExtractGameDataFromDiscImage(
+          primarySource,
+          downloadEventVisitor,
+          bin2IsoService,
+          installPath,
+          i => OnIsoOpen(primarySource, i)
+        );
+      }
+      catch (GameDataDownloadException e)
+      {
+        downloadEventVisitor.Visit(
+          new DownloadFallbackEvent(dataConfig, primarySource.Config, fallbackSource.Config, e)
+        );
+
+        await ExtractGameDataFromDiscImage(
+          fallbackSource,
+          downloadEventVisitor,
+          bin2IsoService,
+          installPath,
+          i => OnIsoOpen(fallbackSource, i)
+        );
+      }
     }
 
     return;

--- a/launcher/Service/NcoReleaseService.cs
+++ b/launcher/Service/NcoReleaseService.cs
@@ -203,7 +203,7 @@ public class NcoReleaseService(LauncherConfigService configService, GitHubClient
 
     // process release zip
     await using var stream = await response.Content.ReadAsStreamAsync();
-    using var zipReader = ReaderFactory.Open(stream);
+    using var zipReader = ReaderFactory.OpenReader(stream);
 
     while (zipReader.MoveToNextEntry())
     {

--- a/launcher/ViewModel/Screens/GameInstaller/InstallDownloadEventVistor.cs
+++ b/launcher/ViewModel/Screens/GameInstaller/InstallDownloadEventVistor.cs
@@ -151,6 +151,12 @@ internal sealed class InstallDownloadEventVisitor(InstallGameViewModel host) : I
     AppendToInstallLog($"Created desktop shortcut for game '{e.game.DisplayName}'");
 
   // error handling
+  public void Visit(DownloadFallbackEvent e)
+  {
+    AppendToInstallLog($"Primary game data source '{e.FailedSource.DisplayName}' failed, falling back to " +
+                       $"secondary source '{e.FallbackSource.DisplayName}': {e.Error}");
+  }
+
   public void Visit(DownloadGameDataErrorEvent e)
   {
     var gamePlaceholder = e.GameData is not null ? $" '{e.GameData!.DisplayName}'" : string.Empty;

--- a/launcher/config.yml
+++ b/launcher/config.yml
@@ -24,7 +24,14 @@ TiberianDawn:
       Name: GDI
       Required: true
       Sources:
-        - Name: internet-archive
+        - SortOrder: 1
+          Name: cnc-comm
+          DisplayName: C&C Communications Center
+          Url: https://downloads.cnc-comm.com/command-and-conquer/iso/CNC95_GDI.zip
+          File: CNC95_GDI.iso
+          Checksum: d5382a8f2cb4c60c5cc70fb79169f5e942d1eeb51cba157b695c0dc63cbc8c21
+        - SortOrder: 2
+          Name: internet-archive
           DisplayName: Internet Archive
           Url: https://archive.org/download/CommandConquerUSAWindows95Rerelease/Command%20%26%20Conquer%20%28USA%29%20%28Disc%201%29%20%28Windows%2095%29%20%28Rerelease%29.zip
           File: Command & Conquer (USA) (Disc 1) (Windows 95) (Rerelease).bin
@@ -53,7 +60,14 @@ TiberianDawn:
     - SortOrder: 2
       Name: NOD
       Sources:
-        - Name: internet-archive
+        - SortOrder: 1
+          Name: cnc-comm
+          DisplayName: C&C Communications Center
+          Url: https://downloads.cnc-comm.com/command-and-conquer/iso/CNC95_Nod.zip
+          File: CNC95_Nod.iso
+          Checksum: cf935c0b107518654cd14ba191dc8672f4e5759e035f24c341787f2133d12764
+        - SortOrder: 2
+          Name: internet-archive
           DisplayName: Internet Archive
           Url: https://archive.org/download/CommandConquerUSAWindows95Rerelease/Command%20%26%20Conquer%20%28USA%29%20%28Disc%202%29%20%28Windows%2095%29%20%28Rerelease%29%20%28Rev%201%29.zip
           File: Command & Conquer (USA) (Disc 2) (Windows 95) (Rerelease) (Rev 1).bin
@@ -70,7 +84,14 @@ TiberianDawn:
       DisplayName: >-
         Covert Operations (Expansion)
       Sources:
-        - Name: internet-archive
+        - SortOrder: 1
+          Name: cnc-comm
+          DisplayName: C&C Communications Center
+          Url: https://downloads.cnc-comm.com/command-and-conquer/iso/CNC_Covertops.zip
+          File: CD3_Covertops.bin
+          Checksum: 3b9e0ccb7c66e5d023382d48116d64e05a8c3f6bb16af009c3b38d04be649c26
+        - SortOrder: 2
+          Name: internet-archive
           DisplayName: Internet Archive
           Url: https://archive.org/download/CommandConquerTheCovertOperationsUSA/Command%20%26%20Conquer%20-%20The%20Covert%20Operations%20%28USA%29.zip
           File: Command & Conquer - The Covert Operations (USA) (Track 1).bin
@@ -100,7 +121,14 @@ RedAlert:
       DisplayName: Allies
       Required: true
       Sources:
-        - Name: internet-archive
+        - SortOrder: 1
+          Name: cnc-comm
+          DisplayName: C&C Communications Center
+          Url: https://downloads.cnc-comm.com/red-alert/iso/RA_Allies.zip
+          File: CD1_ALLIES.iso
+          Checksum: c52767a770d1bdf74922cbec13f003cc9ff56514f1127517c56d8fb0bc3033d2
+        - SortOrder: 2
+          Name: internet-archive
           DisplayName: Internet Archive
           Url: https://archive.org/download/command-conquer-red-alert-1/C%26C-RA-CD1.bin
           File: C&C-RA-CD1.bin
@@ -115,7 +143,14 @@ RedAlert:
       Name: SOVIET
       DisplayName: Soviet
       Sources:
-        - Name: internet-archive
+        - SortOrder: 1
+          Name: cnc-comm
+          DisplayName: C&C Communications Center
+          Url: https://downloads.cnc-comm.com/red-alert/iso/RA_Soviet.zip
+          File: CD2_Soviet.iso
+          Checksum: 1127d6f013a4ae7596f19dce5e6ed5b235e0f837849b593dd97a455d4cbcc986
+        - SortOrder: 2
+          Name: internet-archive
           DisplayName: Internet Archive
           Url: https://archive.org/download/command-conquer-red-alert-1/C%26C-RA-CD2.bin
           File: C&C-RA-CD2.bin
@@ -130,7 +165,14 @@ RedAlert:
       Name: COUNTERSTRIKE
       DisplayName: Counterstrike (Expansion)
       Sources:
-        - Name: internet-archive
+        - SortOrder: 1
+          Name: cnc-comm
+          DisplayName: C&C Communications Center
+          Url: https://downloads.cnc-comm.com/red-alert/iso/RA_Counterstrike.zip
+          File: CD3_Counterstrike.bin
+          Checksum: 27e8eb048ad39adb3e541ce809f95e9c684e9819f62243ac2d0acfc567660b01
+        - SortOrder: 2
+          Name: internet-archive
           DisplayName: Internet Archive
           Url: https://archive.org/download/CommandConquerRedAlertCounterstrikeUSA/Command%20%26%20Conquer%20-%20Red%20Alert%20-%20Counterstrike%20%28USA%29.zip
           File: Command & Conquer - Red Alert - Counterstrike (USA) (Track 1).bin
@@ -143,7 +185,14 @@ RedAlert:
       Name: AFTERMATH
       DisplayName: The Aftermath (Expansion)
       Sources:
-        - Name: internet-archive
+        - SortOrder: 1
+          Name: cnc-comm
+          DisplayName: C&C Communications Center
+          Url: https://downloads.cnc-comm.com/red-alert/iso/RA_Aftermath.zip
+          File: CD4_Aftermath.bin
+          Checksum: 04704dffe5a889d9cc4c784b0e3012a2af112e494177e064d2b2e493a624671e
+        - SortOrder: 2
+          Name: internet-archive
           DisplayName: Internet Archive
           Url: https://archive.org/download/CommandConquerRedAlertTheAftermathUSA/Command%20%26%20Conquer%20-%20Red%20Alert%20-%20The%20Aftermath%20%28USA%29.zip
           File: Command & Conquer - Red Alert - The Aftermath (USA) (Track 1).bin

--- a/redalert/loaddlg.cpp
+++ b/redalert/loaddlg.cpp
@@ -667,7 +667,7 @@ void LoadOptionsClass::Fill_List(ListClass* list)
     /*
     ** Find all savegame files
     */
-    snprintf(scan_path, sizeof(scan_path), "%s", Paths.Concatenate_Paths(Paths.User_Path(), "SAVEGAME.*").c_str());
+    snprintf(scan_path, sizeof(scan_path), "%s", Paths.Concatenate_Paths(Paths.User_Save_Path(), "SAVEGAME.*").c_str());
 
     found = Find_First(scan_path, 0, &ff);
     while (found) {

--- a/resources/test/td/lua/scg01ea.lua
+++ b/resources/test/td/lua/scg01ea.lua
@@ -40,6 +40,10 @@ local function timerTriggerSetup()
   Event.handlers.onTimerTrigger = function(triggerName)
     Logger.debug("Handling trigger %s", triggerName)
 
+    Messages.setMessageTimeout(5)
+    Messages.setColour("BROWN")
+    Messages.sendToPlayer("Handling trigger %s", triggerName)
+
     if triggerName == "TMR1" then
       Logger.debug("5 second trigger execute")
     elseif triggerName == "TMR2" then
@@ -81,6 +85,7 @@ end
 
 xpcall(main, function(error)
   -- show the error to the player
+  Messages.setColour("RED")
   Messages.sendToPlayer("LUA ERROR: %s", error)
 
   -- log for debugging later

--- a/scripts/2.deploy.sh
+++ b/scripts/2.deploy.sh
@@ -10,7 +10,10 @@ script_path="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 function deploy_test_files() {
   if [ "${cmake_preset}" == "tiberian-dawn-debug" ]; then
     log_info "Deploying TD test files"
-    cp -rfv "${td_test_resources_path}"/* "${target_dir}"
+
+    mkdir -p "${td_user_path}/lua"
+
+    cp -rfv "${td_test_resources_path}"/* "${td_user_path}"
   fi
 }
 

--- a/scripts/lib/vars.sh
+++ b/scripts/lib/vars.sh
@@ -20,4 +20,7 @@ test_lua_scripts_path="${repo_path}/tests/lua/scripts"
 td_resources_path="${repo_path}/resources/data/td"
 td_test_resources_path="${repo_path}/resources/test/td"
 
+nco_user_path=~/.config/nco
+td_user_path="${nco_user_path}/tiberian-dawn"
+
 remaster_steam_id="1213210"

--- a/tiberiandawn/conquer.cpp
+++ b/tiberiandawn/conquer.cpp
@@ -871,12 +871,13 @@ static void Message_Input(KeyNumType& input)
     */
     if ((GameToPlay == GAME_NORMAL || GameToPlay == GAME_SKIRMISH) && input == KN_F1) {
         memset(txt, 0, 40);
-        strcpy(txt, "Lua Console: ");
+        strcpy(txt, MessageListClass::LuaConsolePrefix.data());
 
         Messages.Add_Edit(YELLOW,
                           TPF_6PT_GRAD | TPF_USE_GRAD_PAL | TPF_FULLSHADOW,
                           txt,
-                          300 * factor);
+                          300 * factor,
+                          true);
 
         Map.Flag_To_Redraw(false);
     }
@@ -986,15 +987,9 @@ static void Message_Input(KeyNumType& input)
     ** Evaluate lua console input, the outcome (result value/error) is shown to the player as a message.
     */
     if (rc == 3 && (GameToPlay == GAME_NORMAL || GameToPlay == GAME_SKIRMISH)) {
-        const auto console_line = Messages.Get_Edit_Buf();
+        const auto console_line = std::string(Messages.Get_Edit_Buf());
 
-        ScenarioLua::Get_Engine().Eval_To_String(console_line)
-            .If_Value([&console_line](const auto& r) {
-                LuaList.Push<AddMessageLuaEvent>(std::format(">> {}", console_line));
-                LuaList.Push<AddMessageLuaEvent>(r);
-            }).On_Error([](const auto& r) {
-                LuaList.Push<AddMessageLuaEvent>(r.Error_Message());
-            });
+        ScenarioLua::Eval_Lua_Console_Input(console_line);
     }
 
     /*

--- a/tiberiandawn/conquer.cpp
+++ b/tiberiandawn/conquer.cpp
@@ -3777,7 +3777,7 @@ bool Force_CD_Available(int cd)
 void Raise_Fatal_CD_Error(const char* caller, const int cd)
 {
     static const std::string cd_display_names[] = {"GDI", "NOD", "Covert Operations"};
-    std::string install_message = "";
+    std::string install_message;
 
     if (cd >= CD_GDI || cd <= CD_COVERTOPS) {
         install_message = std::format(

--- a/tiberiandawn/conquer.cpp
+++ b/tiberiandawn/conquer.cpp
@@ -876,7 +876,7 @@ static void Message_Input(KeyNumType& input)
         Messages.Add_Edit(YELLOW,
                           TPF_6PT_GRAD | TPF_USE_GRAD_PAL | TPF_FULLSHADOW,
                           txt,
-                          180 * factor);
+                          300 * factor);
 
         Map.Flag_To_Redraw(false);
     }
@@ -986,8 +986,11 @@ static void Message_Input(KeyNumType& input)
     ** Evaluate lua console input, the outcome (result value/error) is shown to the player as a message.
     */
     if (rc == 3 && (GameToPlay == GAME_NORMAL || GameToPlay == GAME_SKIRMISH)) {
-        ScenarioLua::Get_Engine().Eval_To_String(Messages.Get_Edit_Buf())
-            .If_Value([](const auto& r) {
+        const auto console_line = Messages.Get_Edit_Buf();
+
+        ScenarioLua::Get_Engine().Eval_To_String(console_line)
+            .If_Value([&console_line](const auto& r) {
+                LuaList.Push<AddMessageLuaEvent>(std::format(">> {}", console_line));
                 LuaList.Push<AddMessageLuaEvent>(r);
             }).On_Error([](const auto& r) {
                 LuaList.Push<AddMessageLuaEvent>(r.Error_Message());

--- a/tiberiandawn/conquer.cpp
+++ b/tiberiandawn/conquer.cpp
@@ -3787,11 +3787,7 @@ void Raise_Fatal_CD_Error(const char* caller, const int cd)
     }
 
     CNC_LOG_ERROR("CD check failed in function: {} (cd={})", caller, cd);
-    CNC_LOG_FATAL("Required game files missing!{}", install_message);
-
-    if (!RunningAsDLL) {
-        exit(EXIT_FAILURE);
-    }
+    CNC_LOG_FATAL("Required game files missing!{}", install_message); // see Init_Game in init.cpp (calls exit process)
 }
 
 /***************************************************************************

--- a/tiberiandawn/conquer.cpp
+++ b/tiberiandawn/conquer.cpp
@@ -3774,6 +3774,26 @@ bool Force_CD_Available(int cd)
 #endif
 }
 
+void Raise_Fatal_CD_Error(const char* caller, const int cd)
+{
+    static const std::string cd_display_names[] = {"GDI", "NOD", "Covert Operations"};
+    std::string install_message = "";
+
+    if (cd >= CD_GDI || cd <= CD_COVERTOPS) {
+        install_message = std::format(
+            " Install {} files to play this scenario",
+            cd_display_names[cd]
+        );
+    }
+
+    CNC_LOG_ERROR("CD check failed in function: {} (cd={})", caller, cd);
+    CNC_LOG_FATAL("Required game files missing!{}", install_message);
+
+    if (!RunningAsDLL) {
+        exit(EXIT_FAILURE);
+    }
+}
+
 /***************************************************************************
  * DISK_SPACE_AVAILABLE -- returns bytes of free disk space                *
  *                                                                         *

--- a/tiberiandawn/conquer.cpp
+++ b/tiberiandawn/conquer.cpp
@@ -69,6 +69,8 @@
 #include "common/vqaloader.h"
 #include "common/settings.h"
 #include "common/winasm.h"
+#include "lua/scenariolua.h"
+#include "lua/events/addmessage_luaevent.h"
 
 #define SHAPE_TRANS 0x40
 
@@ -865,6 +867,21 @@ static void Message_Input(KeyNumType& input)
     int factor = (SeenBuff.Get_Width() == 320) ? 1 : 2;
 
     /*
+    ** Trigger Lua console entry on F1 key, for single player missions only.
+    */
+    if ((GameToPlay == GAME_NORMAL || GameToPlay == GAME_SKIRMISH) && input == KN_F1) {
+        memset(txt, 0, 40);
+        strcpy(txt, "Lua Console: ");
+
+        Messages.Add_Edit(YELLOW,
+                          TPF_6PT_GRAD | TPF_USE_GRAD_PAL | TPF_FULLSHADOW,
+                          txt,
+                          180 * factor);
+
+        Map.Flag_To_Redraw(false);
+    }
+
+    /*
     **	Check keyboard input for a request to send a message.
     **	The 'to' argument for Add_Edit is prefixed to the message buffer; the
     **	message buffer is big enough for the 'to' field plus MAX_MESSAGE_LENGTH.
@@ -963,6 +980,18 @@ static void Message_Input(KeyNumType& input)
     if (rc == 2) {
         Map.Flag_To_Redraw(false);
         Map.DisplayClass::IsToRedraw = true;
+    }
+
+    /*
+    ** Evaluate lua console input, the outcome (result value/error) is shown to the player as a message.
+    */
+    if (rc == 3 && (GameToPlay == GAME_NORMAL || GameToPlay == GAME_SKIRMISH)) {
+        ScenarioLua::Get_Engine().Eval_To_String(Messages.Get_Edit_Buf())
+            .If_Value([](const auto& r) {
+                LuaList.Push<AddMessageLuaEvent>(r);
+            }).On_Error([](const auto& r) {
+                LuaList.Push<AddMessageLuaEvent>(r.Error_Message());
+            });
     }
 
     /*

--- a/tiberiandawn/enumtypeinfo.h
+++ b/tiberiandawn/enumtypeinfo.h
@@ -143,5 +143,5 @@ using EnumTypeInfoVariant = std::variant<
     EnumTypeInfo<ScenarioPlayerType>,
     EnumTypeInfo<LayerType>,
     EnumTypeInfo<UrgencyType>,
-    EnumTypeInfo<ColorType>
+    EnumTypeInfo<CCPaletteType>
 >;

--- a/tiberiandawn/enumtypeinfo.h
+++ b/tiberiandawn/enumtypeinfo.h
@@ -142,5 +142,6 @@ using EnumTypeInfoVariant = std::variant<
     EnumTypeInfo<TerrainType>,
     EnumTypeInfo<ScenarioPlayerType>,
     EnumTypeInfo<LayerType>,
-    EnumTypeInfo<UrgencyType>
+    EnumTypeInfo<UrgencyType>,
+    EnumTypeInfo<ColorType>
 >;

--- a/tiberiandawn/function.h
+++ b/tiberiandawn/function.h
@@ -304,6 +304,7 @@ void Explosion_Damage(COORDINATE coord, unsigned strength, TechnoClass* source, 
 */
 void Center_About_Objects(void);
 bool Force_CD_Available(int cd);
+void Raise_Fatal_CD_Error(const char* caller, int cd);
 void Handle_View(int view, int action = 0);
 void Handle_Team(int team, int action = 0);
 TechnoTypeClass const* Fetch_Techno_Type(RTTIType type, int id);

--- a/tiberiandawn/init.cpp
+++ b/tiberiandawn/init.cpp
@@ -111,6 +111,8 @@ bool Init_Game(int, char*[])
         Fade_Palette_To(GamePalette, FADE_PALETTE_FAST, Call_Back);
         Show_Mouse();
 
+        Speak(VOX_FAIL);
+
         // TODO: Play commando death sound before this or mission failure message :D
         WWMessageBox().Process(err.c_str());
 
@@ -118,6 +120,7 @@ bool Init_Game(int, char*[])
         TRIGGER_DEBUGGER;
 
         Prog_End(err.c_str(), false);
+
         if (!RunningAsDLL) {
             exit(1);
         }

--- a/tiberiandawn/init.cpp
+++ b/tiberiandawn/init.cpp
@@ -952,8 +952,7 @@ bool Select_Game(bool fade)
                 if (cd_index == 2) {
                     RequiredCD = 0;
                     if (!Force_CD_Available(RequiredCD)) {
-                        Prog_End("Select_Game - CD not found", true);
-                        exit(EXIT_FAILURE);
+                        Raise_Fatal_CD_Error(NAMEOF(Select_Game), RequiredCD);
                     }
                 }
 

--- a/tiberiandawn/init.cpp
+++ b/tiberiandawn/init.cpp
@@ -117,7 +117,7 @@ bool Init_Game(int, char*[])
         // If a debugger is attached, trigger a breakpoint
         TRIGGER_DEBUGGER;
 
-        Prog_End(err.c_str());
+        Prog_End(err.c_str(), false);
         if (!RunningAsDLL) {
             exit(1);
         }

--- a/tiberiandawn/intro.cpp
+++ b/tiberiandawn/intro.cpp
@@ -128,11 +128,12 @@ void Choose_Side(void)
     //	speechg = MFCD::Retrieve("GDI_SLCT.AUD");
     //	speechn = MFCD::Retrieve("NOD_SLCT.AUD");
 
+    BreakoutAllowed = true;
+
     if (Special.IsFromInstall) {
         VisiblePage.Clear();
         PreserveVQAScreen = 1;
         Play_Movie("INTRO2", THEME_NONE, false);
-        BreakoutAllowed = true;
     }
 
     // anim = Open_Animation("CHOOSE.WSA",NULL,0L,(WSAOpenType)(WSA_OPEN_FROM_MEM | WSA_OPEN_TO_PAGE),Palette);

--- a/tiberiandawn/intro.cpp
+++ b/tiberiandawn/intro.cpp
@@ -128,12 +128,11 @@ void Choose_Side(void)
     //	speechg = MFCD::Retrieve("GDI_SLCT.AUD");
     //	speechn = MFCD::Retrieve("NOD_SLCT.AUD");
 
-    BreakoutAllowed = true;
-
     if (Special.IsFromInstall) {
         VisiblePage.Clear();
         PreserveVQAScreen = 1;
         Play_Movie("INTRO2", THEME_NONE, false);
+        BreakoutAllowed = true;
     }
 
     // anim = Open_Animation("CHOOSE.WSA",NULL,0L,(WSAOpenType)(WSA_OPEN_FROM_MEM | WSA_OPEN_TO_PAGE),Palette);

--- a/tiberiandawn/jshell.cpp
+++ b/tiberiandawn/jshell.cpp
@@ -152,9 +152,9 @@ void Fatal(char const* message, ...)
 
     if (!RunningAsDLL) {
         exit(EXIT_FAILURE);
-    } else {
-        *((int*)0) = 0;
     }
+
+    throw std::runtime_error(message);
 }
 
 #ifdef NEVER

--- a/tiberiandawn/loaddlg.cpp
+++ b/tiberiandawn/loaddlg.cpp
@@ -610,7 +610,7 @@ void LoadOptionsClass::Fill_List(ListClass* list)
     /*
     ** Find all savegame files
     */
-    snprintf(scan_path, sizeof(scan_path), "%s", Paths.Concatenate_Paths(Paths.User_Path(), "SAVEGAME.*").c_str());
+    snprintf(scan_path, sizeof(scan_path), "%s", Paths.Concatenate_Paths(Paths.User_Save_Path(), "SAVEGAME.*").c_str());
 
     found = Find_First(scan_path, 0, &ff);
     while (found) {

--- a/tiberiandawn/lua/events/addmessage_luaevent.cpp
+++ b/tiberiandawn/lua/events/addmessage_luaevent.cpp
@@ -2,10 +2,15 @@
 
 #include "addmessage_luaevent.h"
 
-AddMessageLuaEvent::AddMessageLuaEvent(std::string message, const ColorType colour): LuaEvent("AddMessage")
+AddMessageLuaEvent::AddMessageLuaEvent(
+    std::string message,
+    const CCPaletteType colour,
+    const int timeoutInTicks
+): LuaEvent("AddMessage")
 {
     Message = std::move(message);
     Colour = colour;
+    TimeoutInTicks = timeoutInTicks;
 }
 
 void AddMessageLuaEvent::Execute() const
@@ -21,7 +26,7 @@ void AddMessageLuaEvent::Execute() const
         message.data(),
         Colour,
         TPF_6PT_GRAD | TPF_USE_GRAD_PAL | TPF_FULLSHADOW,
-        600,
+        TimeoutInTicks,
         0,
         0
     );

--- a/tiberiandawn/lua/events/addmessage_luaevent.cpp
+++ b/tiberiandawn/lua/events/addmessage_luaevent.cpp
@@ -2,9 +2,10 @@
 
 #include "addmessage_luaevent.h"
 
-AddMessageLuaEvent::AddMessageLuaEvent(std::string message): LuaEvent("AddMessage")
+AddMessageLuaEvent::AddMessageLuaEvent(std::string message, const ColorType colour): LuaEvent("AddMessage")
 {
     Message = std::move(message);
+    Colour = colour;
 }
 
 void AddMessageLuaEvent::Execute() const
@@ -18,7 +19,7 @@ void AddMessageLuaEvent::Execute() const
     // ripped off from netdlg.cpp
     Messages.Add_Message(
         message.data(),
-        CC_GREEN,
+        Colour,
         TPF_6PT_GRAD | TPF_USE_GRAD_PAL | TPF_FULLSHADOW,
         600,
         0,

--- a/tiberiandawn/lua/events/addmessage_luaevent.h
+++ b/tiberiandawn/lua/events/addmessage_luaevent.h
@@ -5,12 +5,13 @@
 class AddMessageLuaEvent : public LuaEvent
 {
 public:
-    AddMessageLuaEvent(std::string message, ColorType colour = GREEN);
+    AddMessageLuaEvent(std::string message, CCPaletteType colour = CC_GREEN, int timeoutInTicks = 600);
 
     void Execute() const override;
 
 private:
     // event data
     std::string Message;
-    ColorType Colour;
+    CCPaletteType Colour;
+    int TimeoutInTicks;
 };

--- a/tiberiandawn/lua/events/addmessage_luaevent.h
+++ b/tiberiandawn/lua/events/addmessage_luaevent.h
@@ -5,11 +5,12 @@
 class AddMessageLuaEvent : public LuaEvent
 {
 public:
-    AddMessageLuaEvent(std::string message);
+    AddMessageLuaEvent(std::string message, ColorType colour = GREEN);
 
     void Execute() const override;
 
 private:
     // event data
     std::string Message;
+    ColorType Colour;
 };

--- a/tiberiandawn/lua/messages_luaapi.cpp
+++ b/tiberiandawn/lua/messages_luaapi.cpp
@@ -10,28 +10,40 @@ void MessagesLuaApi::Register_Functions(LuaEngine& engine) const
     With_Api_Namespace(engine, [](auto& n) {
         n.addCFunction("sendToPlayer", [](auto L) {
             const auto engine = SharedLuaEngine(L);
-            auto arguments = LuaArguments(engine, "Messages.sendToPlayer(<string: message>[, <string: colour>])");
+            auto arguments = LuaArguments(
+                engine,
+                "Messages.sendToPlayer(<string: message>, <string: colour>, <number: timeoutInSeconds>)"
+            );
 
-            arguments.Count_Is(2)
+            arguments.Count_Is(3)
                 .First_Argument_Is<std::string>()
                 .Next_Argument_Is<std::string>()
+                .Next_Argument_Is<int>()
                 .Assert();
 
             const auto message = arguments.Read_First<std::string>().Unpack();
+
             const auto colour_str = arguments.Read_Next<std::string>().Unpack();
+            const auto colour = TdTypeConverter::Assert_Parse_Lua_String<CCPaletteType>(engine, colour_str);
 
-            const auto colour = TdTypeConverter::Try_Parse<ColorType>(colour_str);
+            const auto timeoutInSecs = arguments.Read_Next<int>().Unpack();
 
-            if (!colour.has_value()) {
-                engine.Raise_Error_Format(
-                    "Failed to parse instance string '{}' as type: {} | valid_values={}",
-                    colour_str,
-                    TdTypeConverter::Get_Type_Name<ColorType>(),
-                    CncStringUtils::To_Csv(TdTypeConverter::Get_Valid_Strings<ColorType>())
-                );
-            }
+            LuaList.Push<AddMessageLuaEvent>(message, colour, timeoutInSecs * TICKS_PER_SECOND);
 
-            LuaList.Push<AddMessageLuaEvent>(message, *colour);
+            return 0;
+        });
+
+        n.addCFunction("validateColorType", [](auto L) {
+            const auto engine = SharedLuaEngine(L);
+            auto arguments = LuaArguments(engine, "Messages.validateColorType(<string: colour>)");
+
+            arguments.Count_Is(1)
+                .First_Argument_Is<std::string>()
+                .Assert();
+
+            const auto colour_str = arguments.Read_First<std::string>().Unpack();
+
+            TdTypeConverter::Assert_Parse_Lua_String<CCPaletteType>(engine, colour_str);
 
             return 0;
         });

--- a/tiberiandawn/lua/messages_luaapi.cpp
+++ b/tiberiandawn/lua/messages_luaapi.cpp
@@ -10,15 +10,28 @@ void MessagesLuaApi::Register_Functions(LuaEngine& engine) const
     With_Api_Namespace(engine, [](auto& n) {
         n.addCFunction("sendToPlayer", [](auto L) {
             const auto engine = SharedLuaEngine(L);
-            auto arguments = LuaArguments(engine, "Messages.sendToPlayer(<string: message>)");
+            auto arguments = LuaArguments(engine, "Messages.sendToPlayer(<string: message>[, <string: colour>])");
 
-            arguments.Count_Is(1)
+            arguments.Count_Is(2)
                 .First_Argument_Is<std::string>()
+                .Next_Argument_Is<std::string>()
                 .Assert();
 
             const auto message = arguments.Read_First<std::string>().Unpack();
+            const auto colour_str = arguments.Read_Next<std::string>().Unpack();
 
-            LuaList.Push<AddMessageLuaEvent>(message);
+            const auto colour = TdTypeConverter::Try_Parse<ColorType>(colour_str);
+
+            if (!colour.has_value()) {
+                engine.Raise_Error_Format(
+                    "Failed to parse instance string '{}' as type: {} | valid_values={}",
+                    colour_str,
+                    TdTypeConverter::Get_Type_Name<ColorType>(),
+                    CncStringUtils::To_Csv(TdTypeConverter::Get_Valid_Strings<ColorType>())
+                );
+            }
+
+            LuaList.Push<AddMessageLuaEvent>(message, *colour);
 
             return 0;
         });

--- a/tiberiandawn/lua/scenario_luaapi.cpp
+++ b/tiberiandawn/lua/scenario_luaapi.cpp
@@ -59,7 +59,7 @@ void ScenarioLuaApi::Register_Functions(LuaEngine& engine) const
             const auto name = arguments.Read_First<std::string>().Unpack();
 
             const auto house = HouseClass::As_Pointer(
-                Parse_House_Name(engine, name)
+                TdTypeConverter::Assert_Parse_Lua_String<HousesType>(engine, name)
             );
 
             engine.Push_Value(
@@ -80,7 +80,7 @@ void ScenarioLuaApi::Register_Functions(LuaEngine& engine) const
             const auto name = arguments.Read_First<std::string>().Unpack();
             const auto money_modifier = arguments.Read_Next<int>().Unpack();
 
-            const auto house = Parse_House_Name(engine, name);
+            const auto house = TdTypeConverter::Assert_Parse_Lua_String<HousesType>(engine, name);
 
             LuaList.Push<ModifyHouseMoneyLuaEvent>(house, money_modifier);
 
@@ -231,18 +231,4 @@ void ScenarioLuaApi::Register_Functions(LuaEngine& engine) const
             return 1;
         });
     });
-}
-
-HousesType ScenarioLuaApi::Parse_House_Name(const LuaEngine& engine, std::string name)
-{
-    const auto houseType = TdTypeConverter::Try_Parse<HousesType>(name);
-
-    if (!houseType.has_value()) {
-        engine.Raise_Error_Format(
-            "Failed to parse house name from string: {}",
-            name
-        );
-    }
-
-    return *houseType;
 }

--- a/tiberiandawn/lua/scenario_luaapi.h
+++ b/tiberiandawn/lua/scenario_luaapi.h
@@ -31,8 +31,6 @@ protected:
     }
 
 private:
-    static HousesType Parse_House_Name(const LuaEngine& engine, std::string name);
-
     std::string ScenarioName;
     std::string ScenarioType;
     std::string ScenarioFaction;

--- a/tiberiandawn/lua/scenariolua.cpp
+++ b/tiberiandawn/lua/scenariolua.cpp
@@ -167,19 +167,21 @@ void ScenarioLua::On_Clear_Scenario()
 void ScenarioLua::Process_Lua_Events(AtomicQueue<LuaEvent>& events)
 {
     events.Access([](auto& q) {
-       if (q->size() == 0) {
+        if (q->size() == 0) {
             CNC_LOGGER_TRACE("No Lua Events to process");
             return;
-       }
+        }
 
-       CNC_LOGGER_DEBUG("Processing Lua Events");
+        CNC_LOGGER_DEBUG("Processing Lua Events");
 
-       while (!q->empty()) {
-            q->front()->Execute();
+        const auto& engine = Get_Engine();
+
+        while (!q->empty()) {
+            q->front()->Execute(engine);
             q->pop();
-       }
+        }
     });
-    }
+}
 
 void ScenarioLua::Init_Tiberian_Dawn_Lua_Engine(std::string& scenario_name, std::string& scenario_type_name, std::string& faction, std::string& house_name)
 {

--- a/tiberiandawn/lua/scenariolua.cpp
+++ b/tiberiandawn/lua/scenariolua.cpp
@@ -129,8 +129,8 @@ LuaResultWithValue<std::string> ScenarioLua::Eval_Lua_Console_Input(std::string 
             LuaList.Push<AddMessageLuaEvent>(r);
         }).On_Error([&input_line](const auto& r) {
             // output console error and result on separate lines
-            LuaList.Push<AddMessageLuaEvent>(std::format(">> {}", input_line), RED);
-            LuaList.Push<AddMessageLuaEvent>(r.Error_Message(), RED);
+            LuaList.Push<AddMessageLuaEvent>(std::format(">> {}", input_line), CC_NOD_COLOR);
+            LuaList.Push<AddMessageLuaEvent>(r.Error_Message(), CC_NOD_COLOR);
         });
 }
 

--- a/tiberiandawn/lua/scenariolua.cpp
+++ b/tiberiandawn/lua/scenariolua.cpp
@@ -16,6 +16,7 @@
 #include "scenariolua.h"
 #include "tdtypes_luaapi.h"
 #include "ui_luaapi.h"
+#include "events/addmessage_luaevent.h"
 
 RuleSections& TdRuleSectionsProvider::Sections()
 {
@@ -113,6 +114,29 @@ void ScenarioLua::On_Scenario_Load(const GameEnum& game_type, const ScenarioClas
     CNC_LOGGER_INFO("Checking scenario INI file for lua scripts: {}", scenario_ini_file);
 
     On_Scenario_Load(game_type, scenario, player, ini);
+}
+
+LuaResultWithValue<std::string> ScenarioLua::Eval_Lua_Console_Input(std::string input_line)
+{
+    LuaConsoleInputHistory.push_back(input_line);
+
+    // TODO: non-lua commands, /help etc.
+
+    return Get_Engine().Eval_To_String(input_line)
+        .If_Value([&input_line](const auto& r) {
+            // output console input and result on separate lines
+            LuaList.Push<AddMessageLuaEvent>(std::format(">> {}", input_line));
+            LuaList.Push<AddMessageLuaEvent>(r);
+        }).On_Error([&input_line](const auto& r) {
+            // output console error and result on separate lines
+            LuaList.Push<AddMessageLuaEvent>(std::format(">> {}", input_line), RED);
+            LuaList.Push<AddMessageLuaEvent>(r.Error_Message(), RED);
+        });
+}
+
+const std::vector<std::string>& ScenarioLua::Get_Lua_Console_Input_History()
+{
+    return LuaConsoleInputHistory;
 }
 
 bool ScenarioLua::Exec_Event_Trigger(std::string_view trigger_name, std::string_view event_name)

--- a/tiberiandawn/lua/scenariolua.h
+++ b/tiberiandawn/lua/scenariolua.h
@@ -62,6 +62,10 @@ public:
         const HouseClass& player
     );
 
+    static LuaResultWithValue<std::string> Eval_Lua_Console_Input(std::string input_line);
+
+    static const std::vector<std::string>& Get_Lua_Console_Input_History();
+
     /**
      * Scenario state is being reset, so we need to ensure
      * any existing Lua runtime state is destroyed.
@@ -90,6 +94,7 @@ private:
     static constexpr std::string_view NotFoundStr = "__NOT_FOUND__";
     static inline const auto& Logger = CncLogger::For(ScenarioLua);
     static inline std::optional<UniqueLuaEngine> Engine;
+    static inline std::vector<std::string> LuaConsoleInputHistory;
 
     /**
      * API management for TD Lua; think of this like

--- a/tiberiandawn/lua/scripts/nco/TiberianDawn/Messages.lua
+++ b/tiberiandawn/lua/scripts/nco/TiberianDawn/Messages.lua
@@ -1,21 +1,44 @@
+local TypeValidator = require("nco.lib.TypeValidator")
+
 local TdApiModule = require("nco.TiberianDawn.lib.TdApiModule")
+
+local isOneOf = TypeValidator.Validators.isOneOf
+
+-- TODO: add all colours
+---@alias Colour "GREEN" | "RED" | "BLUE"
 
 --[[
   API for showing in-game messages to the player.
 ]]
 ---@class Messages : ApiModule
 ---@field sendToPlayer fun(message: string, ...) Supports string.format style calls
+---@field setColour fun(colour: Colour) Set the display colour for player messages
+---@field resetColour fun() Reset the display colour for player messages to the default (Green)
 
 ---@type Messages
 _G.Messages = TdApiModule({
   name = "Messages",
   cppSource = "tiberiandawn/lua/messages_luaapi.h",
   builder = function(cppApi)
+    local defaultColour = "GREEN"
+    local messageColour = defaultColour
+
     return {
+      resetColour = function()
+         messageColour = defaultColour
+      end,
       sendToPlayer = function(message, ...)
         cppApi.sendToPlayer(
-          string.format(tostring(message), ...)
+          string.format(tostring(message), ...),
+          messageColour
         )
+      end,
+      setColour = function(colour)
+        TypeValidator.validateCall("setColour", {
+          colour = {colour, isOneOf({ "GREEN", "RED", "BLUE" })}
+        })
+
+        messageColour = colour
       end
     }
   end

--- a/tiberiandawn/lua/scripts/nco/TiberianDawn/Messages.lua
+++ b/tiberiandawn/lua/scripts/nco/TiberianDawn/Messages.lua
@@ -2,18 +2,20 @@ local TypeValidator = require("nco.lib.TypeValidator")
 
 local TdApiModule = require("nco.TiberianDawn.lib.TdApiModule")
 
-local isOneOf = TypeValidator.Validators.isOneOf
+local isNotBlank = TypeValidator.Validators.isNotBlank
+local isType = TypeValidator.Validators.isType
 
--- TODO: add all colours
----@alias Colour "GREEN" | "RED" | "BLUE"
+---@alias Colour "YELLOW" | "RED" | "CYAN" | "BLUE" | "ORANGE" | "GREEN" | "BROWN"
 
 --[[
   API for showing in-game messages to the player.
 ]]
 ---@class Messages : ApiModule
----@field sendToPlayer fun(message: string, ...) Supports string.format style calls
 ---@field setColour fun(colour: Colour) Set the display colour for player messages
 ---@field resetColour fun() Reset the display colour for player messages to the default (Green)
+---@field setMessageTimeout fun(seconds: number) Set timeout before message is removed from the screen
+---@field resetMessageTimeout fun() Reset the timeout for messages (30 seconds)
+---@field sendToPlayer fun(message: string, ...) Supports string.format style calls
 
 ---@type Messages
 _G.Messages = TdApiModule({
@@ -21,24 +23,43 @@ _G.Messages = TdApiModule({
   cppSource = "tiberiandawn/lua/messages_luaapi.h",
   builder = function(cppApi)
     local defaultColour = "GREEN"
+    local defaultMessageTimeoutInSecs = 30
     local messageColour = defaultColour
+    local messageTimeoutInSecs = defaultMessageTimeoutInSecs
 
     return {
       resetColour = function()
          messageColour = defaultColour
       end,
+      resetMessageTimeout = function()
+         messageTimeoutInSecs = defaultMessageTimeoutInSecs
+      end,
       sendToPlayer = function(message, ...)
         cppApi.sendToPlayer(
           string.format(tostring(message), ...),
-          messageColour
+          messageColour,
+          messageTimeoutInSecs
         )
       end,
       setColour = function(colour)
         TypeValidator.validateCall("setColour", {
-          colour = {colour, isOneOf({ "GREEN", "RED", "BLUE" })}
+          colour = {colour, isType("string"), isNotBlank}
         })
 
+        cppApi.validateColorType(colour);
+
         messageColour = colour
+      end,
+      setMessageTimeout = function(seconds)
+        TypeValidator.validateCall("setColour", {
+          seconds = {seconds, isType("number")}
+        })
+
+        if seconds < 1 then
+          error("Messages.setMessageTimeout: argument 'seconds' must be greater than 0")
+        end
+
+        messageTimeoutInSecs = seconds
       end
     }
   end

--- a/tiberiandawn/lua/scripts/nco/TiberianDawn/Types.lua
+++ b/tiberiandawn/lua/scripts/nco/TiberianDawn/Types.lua
@@ -25,19 +25,19 @@ local TypeApiProxy = require("nco.TiberianDawn.lib.TypeApiProxy")
   - You can access this by:
     ```lua
       -- get a property
-      local armor = Type.Infantry.E1.Armor -- 'NONE'
+      local armor = Types.Infantry.E1.Armor -- 'NONE'
 
       -- set a property
-      Type.Infantry.E1.Primary = "CHAIN_GUN"
+      Types.Infantry.E1.Primary = "CHAIN_GUN"
 
       -- get the names of all properties for a type
-      local infantryProperties = Type.Infantry.getPropertyNames() -- { 'Armor', 'Cost', ... }
+      local infantryProperties = Types.Infantry.getPropertyNames() -- { 'Armor', 'Cost', ... }
 
       -- get the lua type for a given property
-      local costType = Type.Infantry.E1.getPropertyType("Cost") -- 'number'
+      local costType = Types.Infantry.E1.getPropertyType("Cost") -- 'number'
 
       -- get the names of all Infantry types in the game
-      local infantryNames = Type.Infantry.getInstanceNames() -- { 'E1', 'E2', 'E2', ... }
+      local infantryNames = Types.Infantry.getInstanceNames() -- { 'E1', 'E2', 'E2', ... }
     ```
 
 ]]

--- a/tiberiandawn/lua/scripts/nco/TiberianDawn/lib/TdCncApiMock.lua
+++ b/tiberiandawn/lua/scripts/nco/TiberianDawn/lib/TdCncApiMock.lua
@@ -7,6 +7,10 @@ local function extendCallsTable(calls)
   }
 
   calls.Messages = {
+    setColour = {},
+    resetColour = {},
+    setMessageTimeout = {},
+    resetMessageTimeout = {},
     sendToPlayer = {}
   }
 
@@ -55,7 +59,23 @@ local function extendMockTable(getCalls, mock)
     {},
     {
       __index = function (_, k)
-        if k == "sendToPlayer" then
+        if k == "setColour" then
+          return function(...)
+            table.insert(getCalls().Messages.setColour, {...})
+          end
+        elseif k == "resetColour" then
+          return function(...)
+            table.insert(getCalls().Messages.resetColour, {...})
+          end
+        elseif k == "setMessageTimeout" then
+          return function(...)
+            table.insert(getCalls().Messages.setMessageTimeout, {...})
+          end
+        elseif k == "resetMessageTimeout" then
+          return function(...)
+            table.insert(getCalls().Messages.resetMessageTimeout, {...})
+          end
+        elseif k == "sendToPlayer" then
           return function(...)
             table.insert(getCalls().Messages.sendToPlayer, {...})
           end

--- a/tiberiandawn/lua/scripts/nco/TiberianDawn/lib/TypeApiProxy.lua
+++ b/tiberiandawn/lua/scripts/nco/TiberianDawn/lib/TypeApiProxy.lua
@@ -21,7 +21,7 @@ local isType = TypeValidator.Validators.isType
 ---@field getInstanceNames fun(): string[]
 ---@field getPropertyNames fun(): string[]
 
----@alias TypeApiProxy TypeApi | { [string]: TypeInstanceApi }
+---@alias TypeApiProxy TypeApi | { [string]: TypeInstanceApiProxy }
 
 ---@param api CppTypeApi
 ---@param typeName string

--- a/tiberiandawn/menus.cpp
+++ b/tiberiandawn/menus.cpp
@@ -624,7 +624,7 @@ int Main_Menu(unsigned int timeout)
     starty += ystep;
 
     TextButtonClass editorbtn(BUTTON_MAPEDITOR,
-                             TXT_EDIT,
+                             "Scenario Editor", // TODO: Add mechanism for extending existing locale strings (support non-english)
                              TPF_CENTER | TPF_6PT_GRAD | TPF_USE_GRAD_PAL | TPF_NOSHADOW,
                              D_MAPEDITOR_X,
                              starty,

--- a/tiberiandawn/msglist.cpp
+++ b/tiberiandawn/msglist.cpp
@@ -42,6 +42,7 @@
  * - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - */
 
 #include "function.h"
+#include "lua/scenariolua.h"
 
 // ST = 12/17/2018 5:44PM
 #ifndef WinTickCount
@@ -454,13 +455,16 @@ TextLabelClass* MessageListClass::Add_Message(char* txt,
  * HISTORY:                                                                *
  *   05/22/1995 BRR : Created.                                             *
  *=========================================================================*/
-TextLabelClass* MessageListClass::Add_Edit(int color, TextPrintType style, char* to, int width)
+TextLabelClass* MessageListClass::Add_Edit(int color, TextPrintType style, char* to, int width, bool lua_console_mode)
 {
     /*------------------------------------------------------------------------
     Do nothing if we're already in "edit" mode
     ------------------------------------------------------------------------*/
     if (EditLabel)
         return (NULL);
+
+    InLuaConsoleMode = lua_console_mode;
+    LuaConsoleHistoryPos = 0;
 
     /*------------------------------------------------------------------------
     Initialize the buffer positions; add a new label to the label list.
@@ -623,6 +627,39 @@ int MessageListClass::Input(KeyNumType& input)
     ------------------------------------------------------------------------*/
     if (EditLabel) {
         ascii = (KeyASCIIType)(Keyboard->To_ASCII(input) & 0x00ff);
+
+        /*------------------------------------------------------------------
+        UP/DOWN = fill edit buffer with a previous lua console line (if in console mode)
+        ------------------------------------------------------------------*/
+        if ((input == KN_UP || input == KN_DOWN) && InLuaConsoleMode) {
+            const auto& console_history = ScenarioLua::Get_Lua_Console_Input_History();
+
+            if (console_history.empty()) {
+                input = KN_NONE;
+                return 0;
+            }
+
+            // clear edit string
+            while (EditCurPos >= 1) {
+                EditCurPos--;
+                EditBuf[EditCurPos] = 0;
+            }
+
+            // fetch a previous console line based on history position
+            const auto history_index =
+                console_history.size() - (LuaConsoleHistoryPos % console_history.size() + 1);
+            const auto new_console_line = std::string(LuaConsolePrefix) + console_history.at(history_index);
+
+            // update edit state
+            strcpy(EditBuf, new_console_line.c_str());
+            EditInitPos = static_cast<int>(LuaConsolePrefix.length());
+            EditCurPos = static_cast<int>(strlen(new_console_line.c_str()));
+            input == KN_UP ? LuaConsoleHistoryPos++ : LuaConsoleHistoryPos--;
+
+            input = KN_NONE;
+
+            return 2;
+        }
 
         /*
         ** Allow numeric keypad presses to map to ascii numbers

--- a/tiberiandawn/msglist.h
+++ b/tiberiandawn/msglist.h
@@ -54,6 +54,8 @@
 class MessageListClass
 {
 public:
+    static constexpr std::string_view LuaConsolePrefix = "Lua Console: ";
+
     /*
     **	Constructor/Destructor
     */
@@ -74,7 +76,7 @@ public:
     /*
     **	Message-editing routines
     */
-    TextLabelClass* Add_Edit(int color, TextPrintType style, char* to, int width);
+    TextLabelClass* Add_Edit(int color, TextPrintType style, char* to, int width, bool lua_console_mode = false);
     char* Get_Edit_Buf(void);
 
     /*
@@ -98,6 +100,8 @@ private:
     int EditCurPos;              // current edit position
     int EditInitPos;             // initial edit position
     int Width;                   // Maximum width in pixels of editable string
+    bool InLuaConsoleMode;       // message being edited is for lua console processing
+    int LuaConsoleHistoryPos;    // position in lua console history, i.e. user has pressed UP n times in a row
 
     /*
     ** Static buffers provided for messages.  They must be long enough for

--- a/tiberiandawn/options.cpp
+++ b/tiberiandawn/options.cpp
@@ -796,7 +796,7 @@ void OptionsClass::Load_Settings(void)
  * OptionsClass::Save_Settings -- writes options settings to the INI file                      *
  *                                                                                             *
  * INPUT:                                                                                      *
- *      none.                                                                                  *
+ *      ini -- config file ini instance.                                                       *
  *                                                                                             *
  * OUTPUT:                                                                                     *
  *      none.                                                                                  *
@@ -807,15 +807,8 @@ void OptionsClass::Load_Settings(void)
  * HISTORY:                                                                                    *
  *   02/14/1995 BR : Created.                                                                  *
  *=============================================================================================*/
-void OptionsClass::Save_Settings(void)
+void OptionsClass::Save_Settings(INIClass& ini)
 {
-    /*
-    **	Create filename and read the file.
-    */
-    CCFileClass file(CONFIG_FILE_NAME);
-    INIClass ini;
-    ini.Load(file);
-
     /*
     **	Save Options settings
     */
@@ -884,6 +877,18 @@ void OptionsClass::Save_Settings(void)
     ini.Put_Int(HotkeyName, "KeyTeam8", KeyTeam8);
     ini.Put_Int(HotkeyName, "KeyTeam9", KeyTeam9);
     ini.Put_Int(HotkeyName, "KeyTeam10", KeyTeam10);
+}
+
+void OptionsClass::Save_Settings()
+{
+    /*
+    **	Create filename and read the file.
+    */
+    CCFileClass file(CONFIG_FILE_NAME);
+    INIClass ini;
+    ini.Load(file);
+
+    Save_Settings(ini);
 
     /*
     **	Write the INI data out to a file.

--- a/tiberiandawn/options.cpp
+++ b/tiberiandawn/options.cpp
@@ -151,6 +151,7 @@ OptionsClass::OptionsClass(void)
     IsScoreRepeat = false;
     IsScoreShuffle = false;
     IsFreeScroll = false;
+    SkipExpansionCdCheck = true;
 }
 
 /***********************************************************************************************
@@ -578,6 +579,7 @@ void OptionsClass::Load_Settings(void)
     Set_Shuffle(ini.Get_Int(OPTIONS, "IsScoreShuffle", 0));
     IsDeathAnnounce = ini.Get_Int(OPTIONS, "DeathAnnounce", 0);
     IsFreeScroll = ini.Get_Int(OPTIONS, "FreeScrolling", 0);
+    SkipExpansionCdCheck = ini.Get_Bool(OPTIONS, "SkipExpansionCdCheck", true);
     SlowPalette = ini.Get_Int(OPTIONS, "SlowPalette", 1);
 
     KeyForceMove1 = (KeyNumType)ini.Get_Int(HotkeyName, "KeyForceMove1", KeyForceMove1);
@@ -831,6 +833,7 @@ void OptionsClass::Save_Settings(void)
     ini.Put_Int(OPTIONS, "IsScoreShuffle", IsScoreShuffle);
     ini.Put_Int(OPTIONS, "DeathAnnounce", IsDeathAnnounce);
     ini.Put_Int(OPTIONS, "FreeScrolling", IsFreeScroll);
+    ini.Put_Bool(OPTIONS, NAMEOF(SkipExpansionCdCheck), SkipExpansionCdCheck);
 
     ini.Put_Int(HotkeyName, "KeyForceMove1", KeyForceMove1);
     ini.Put_Int(HotkeyName, "KeyForceMove2", KeyForceMove2);

--- a/tiberiandawn/options.h
+++ b/tiberiandawn/options.h
@@ -91,6 +91,7 @@ public:
     unsigned IsScoreShuffle : 1;  // Score list should shuffle?
     unsigned IsDeathAnnounce : 1; // Announce enemy deaths?
     unsigned IsFreeScroll : 1;    // Allow free direction scrolling?
+    unsigned SkipExpansionCdCheck : 1; // Skip the CD check for Covert Operations and Console scenarios?
 
     /*
     **	These are the hotkeys used for keyboard control.

--- a/tiberiandawn/options.h
+++ b/tiberiandawn/options.h
@@ -69,6 +69,7 @@ public:
     ** File I/O routines
     */
     void Load_Settings(void);
+    void Save_Settings(INIClass& ini);
     void Save_Settings(void);
 
     void Set(void);

--- a/tiberiandawn/saveload.cpp
+++ b/tiberiandawn/saveload.cpp
@@ -161,7 +161,7 @@ bool Save_Game_Binary(const char* file_name, const char* descr)
 #ifndef REMASTER_BUILD
     if (!file.Open(PathsClass::Concatenate_Paths(Paths.User_Save_Path(), file_name).c_str(), WRITE)) {
 #else
-    if (!save_file.Open(file_name, WRITE)) {
+    if (!file.Open(file_name, WRITE)) {
 #endif
         Decode_All_Pointers_Binary();
         return (false);

--- a/tiberiandawn/saveload.cpp
+++ b/tiberiandawn/saveload.cpp
@@ -124,7 +124,11 @@ bool Save_Game(const char* file_name, const char* descr)
 {
     CDFileClass save_file;
 
+#ifndef REMASTER_BUILD
+    if (!save_file.Open(Paths.Concatenate_Paths(Paths.User_Save_Path(), file_name).c_str(), WRITE)) {
+#else
     if (!save_file.Open(file_name, WRITE)) {
+#endif
         return false;
     }
 
@@ -154,7 +158,11 @@ bool Save_Game_Binary(const char* file_name, const char* descr)
     /*
     **	Open the file
     */
-    if (!file.Open(file_name, WRITE)) {
+#ifndef REMASTER_BUILD
+    if (!file.Open(Paths.Concatenate_Paths(Paths.User_Save_Path(), file_name).c_str(), WRITE)) {
+#else
+    if (!save_file.Open(file_name, WRITE)) {
+#endif
         Decode_All_Pointers_Binary();
         return (false);
     }
@@ -361,7 +369,11 @@ bool Load_Game(const char* file_name)
 
     Call_Back();
 
+#ifndef REMASTER_BUILD
+    const auto save_header = SaveGameResolver::Load(Paths.Concatenate_Paths(Paths.User_Save_Path(), file_name));
+#else
     const auto save_header = SaveGameResolver::Load(file_name);
+#endif
 
     if (!save_header.has_value()) {
         return false;
@@ -378,7 +390,7 @@ bool Load_Game(const char* file_name)
     */
     if (RequiredCD != -2) {
         if (scenario >= 20 && scenario < 60 && GameToPlay == GAME_NORMAL) {
-            RequiredCD = 2;
+            RequiredCD = Options.SkipExpansionCdCheck ? -1 : 2;
         } else {
             if (scenario >= 60) {
                 /*
@@ -478,7 +490,11 @@ bool Load_Game_Binary(const char* file_name)
     /*
     **	Open the file
     */
+#ifndef REMASTER_BUILD
+    if (!file.Open(Paths.Concatenate_Paths(Paths.User_Save_Path(), file_name).c_str(), READ)) {
+#else
     if (!file.Open(file_name, READ)) {
+#endif
         return (false);
     }
 #ifdef REMASTER_BUILD
@@ -544,7 +560,7 @@ bool Load_Game_Binary(const char* file_name)
     */
     if (RequiredCD != -2) {
         if (scenario >= 20 && scenario < 60 && GameToPlay == GAME_NORMAL) {
-            RequiredCD = 2;
+            RequiredCD = Options.SkipExpansionCdCheck ? -1 : 2;
         } else {
             if (scenario >= 60) {
                 /*
@@ -1255,7 +1271,9 @@ bool Get_Savefile_Info(const int& id, char* buf, unsigned& scenp, HousesType& ho
 {
     const auto file_name = std::format("SAVEGAME.{:03d}", id);
 
-    const auto header = SaveGameResolver::Load_Header(file_name);
+    const auto header = SaveGameResolver::Load_Header(
+        Paths.Concatenate_Paths(Paths.User_Save_Path(), file_name.c_str())
+    );
 
     if (!header.has_value()) {
         return false;
@@ -1284,7 +1302,11 @@ bool Get_Savefile_Info_Binary(int id, char* buf, unsigned* scenp, HousesType* ho
     /*
     **	If the file opens OK, read the file
     */
+#ifndef REMASTER_BUILD
+    if (file.Open(Paths.Concatenate_Paths(Paths.User_Save_Path(), name).c_str(), READ)) {
+#else
     if (file.Open(name, READ)) {
+#endif
 
         /*
         **	Read in the description, scenario #, and the house

--- a/tiberiandawn/saveload.cpp
+++ b/tiberiandawn/saveload.cpp
@@ -125,7 +125,7 @@ bool Save_Game(const char* file_name, const char* descr)
     CDFileClass save_file;
 
 #ifndef REMASTER_BUILD
-    if (!save_file.Open(Paths.Concatenate_Paths(Paths.User_Save_Path(), file_name).c_str(), WRITE)) {
+    if (!save_file.Open(PathsClass::Concatenate_Paths(Paths.User_Save_Path(), file_name).c_str(), WRITE)) {
 #else
     if (!save_file.Open(file_name, WRITE)) {
 #endif
@@ -159,7 +159,7 @@ bool Save_Game_Binary(const char* file_name, const char* descr)
     **	Open the file
     */
 #ifndef REMASTER_BUILD
-    if (!file.Open(Paths.Concatenate_Paths(Paths.User_Save_Path(), file_name).c_str(), WRITE)) {
+    if (!file.Open(PathsClass::Concatenate_Paths(Paths.User_Save_Path(), file_name).c_str(), WRITE)) {
 #else
     if (!save_file.Open(file_name, WRITE)) {
 #endif
@@ -370,7 +370,8 @@ bool Load_Game(const char* file_name)
     Call_Back();
 
 #ifndef REMASTER_BUILD
-    const auto save_header = SaveGameResolver::Load(Paths.Concatenate_Paths(Paths.User_Save_Path(), file_name));
+    const auto save_header =
+        SaveGameResolver::Load(PathsClass::Concatenate_Paths(Paths.User_Save_Path(), file_name));
 #else
     const auto save_header = SaveGameResolver::Load(file_name);
 #endif
@@ -488,7 +489,7 @@ bool Load_Game_Binary(const char* file_name)
     **	Open the file
     */
 #ifndef REMASTER_BUILD
-    if (!file.Open(Paths.Concatenate_Paths(Paths.User_Save_Path(), file_name).c_str(), READ)) {
+    if (!file.Open(PathsClass::Concatenate_Paths(Paths.User_Save_Path(), file_name).c_str(), READ)) {
 #else
     if (!file.Open(file_name, READ)) {
 #endif
@@ -1266,7 +1267,7 @@ bool Get_Savefile_Info(const int& id, char* buf, unsigned& scenp, HousesType& ho
     const auto file_name = std::format("SAVEGAME.{:03d}", id);
 
     const auto header = SaveGameResolver::Load_Header(
-        Paths.Concatenate_Paths(Paths.User_Save_Path(), file_name.c_str())
+        PathsClass::Concatenate_Paths(Paths.User_Save_Path(), file_name.c_str())
     );
 
     if (!header.has_value()) {
@@ -1297,7 +1298,7 @@ bool Get_Savefile_Info_Binary(int id, char* buf, unsigned* scenp, HousesType* ho
     **	If the file opens OK, read the file
     */
 #ifndef REMASTER_BUILD
-    if (file.Open(Paths.Concatenate_Paths(Paths.User_Save_Path(), name).c_str(), READ)) {
+    if (file.Open(PathsClass::Concatenate_Paths(Paths.User_Save_Path(), name).c_str(), READ)) {
 #else
     if (file.Open(name, READ)) {
 #endif

--- a/tiberiandawn/saveload.cpp
+++ b/tiberiandawn/saveload.cpp
@@ -407,10 +407,7 @@ bool Load_Game(const char* file_name)
         }
     }
     if (!Force_CD_Available(RequiredCD)) {
-        Prog_End("Load_Game - CD not found", true);
-        if (!RunningAsDLL) {
-            exit(EXIT_FAILURE);
-        }
+        Raise_Fatal_CD_Error(NAMEOF(Load_Game), RequiredCD);
         return false;
     }
 
@@ -577,10 +574,7 @@ bool Load_Game_Binary(const char* file_name)
         }
     }
     if (!Force_CD_Available(RequiredCD)) {
-        Prog_End("Load_Game - CD not found", true);
-        if (!RunningAsDLL) {
-            exit(EXIT_FAILURE);
-        }
+        Raise_Fatal_CD_Error(NAMEOF(Load_Game_Binary), RequiredCD);
         return false;
     }
 

--- a/tiberiandawn/scenario.cpp
+++ b/tiberiandawn/scenario.cpp
@@ -474,7 +474,7 @@ void Do_Win(void)
     */
     if (RequiredCD != -2) {
         if (Scen.Scenario >= 20 && Scen.Scenario < 60 && GameToPlay == GAME_NORMAL) {
-            RequiredCD = 2;
+            RequiredCD = Options.SkipExpansionCdCheck ? -1 : 2;
         } else {
             if (Scen.Scenario >= 60) {
                 RequiredCD = -1;

--- a/tiberiandawn/scenarioini.cpp
+++ b/tiberiandawn/scenarioini.cpp
@@ -255,21 +255,7 @@ bool Read_Scenario_Ini(char* root, bool fresh)
     }
 
     if (!Force_CD_Available(RequiredCD)) {
-        // TODO: Roll fatal log logic into Force_CD_Available calls (ensure game is consistent in error messages)
-        static const std::string cd_display_names[] = {"GDI", "NOD", "Covert Operations"};
-        std::string install_message = "";
-
-        if (RequiredCD > -1 || RequiredCD < 2) {
-            install_message = std::format(
-                " Install {} files to play this scenario",
-                cd_display_names[RequiredCD]
-            );
-        }
-
-        CNC_LOG_FATAL("Required game files missing!{}", install_message);
-        if (!RunningAsDLL) {
-            exit(EXIT_FAILURE);
-        }
+        Raise_Fatal_CD_Error(NAMEOF(Read_Scenario_Ini), RequiredCD);
     }
 
     /*
@@ -1058,10 +1044,7 @@ bool Read_Movies_From_Scenario_Ini(char* root, bool fresh)
         }
     }
     if (!Force_CD_Available(RequiredCD)) {
-        Prog_End("Read_Scenario_Ini - CD not found", true);
-        if (!RunningAsDLL) {
-            exit(EXIT_FAILURE);
-        }
+        Raise_Fatal_CD_Error(NAMEOF(Read_Movies_From_Scenario_Ini), RequiredCD);
     }
 
     /*

--- a/tiberiandawn/scenarioini.cpp
+++ b/tiberiandawn/scenarioini.cpp
@@ -255,6 +255,7 @@ bool Read_Scenario_Ini(char* root, bool fresh)
     }
 
     if (!Force_CD_Available(RequiredCD)) {
+        // TODO: Roll fatal log logic into Force_CD_Available calls (ensure game is consistent in error messages)
         static const std::string cd_display_names[] = {"GDI", "NOD", "Covert Operations"};
         std::string install_message = "";
 

--- a/tiberiandawn/scenarioini.cpp
+++ b/tiberiandawn/scenarioini.cpp
@@ -230,7 +230,7 @@ bool Read_Scenario_Ini(char* root, bool fresh)
     */
     if (RequiredCD != -2) {
         if (Scen.Scenario >= 20 && Scen.Scenario < 60 && GameToPlay == GAME_NORMAL) {
-            RequiredCD = 2;
+            RequiredCD = Options.SkipExpansionCdCheck ? -1 : 2;
         } else {
             if (Scen.Scenario != 1) {
                 if (Scen.Scenario >= 60) {

--- a/tiberiandawn/scenarioini.cpp
+++ b/tiberiandawn/scenarioini.cpp
@@ -253,8 +253,19 @@ bool Read_Scenario_Ini(char* root, bool fresh)
             }
         }
     }
+
     if (!Force_CD_Available(RequiredCD)) {
-        Prog_End("Read_Scenario_Ini - CD not found", true);
+        static const std::string cd_display_names[] = {"GDI", "NOD", "Covert Operations"};
+        std::string install_message = "";
+
+        if (RequiredCD > -1 || RequiredCD < 2) {
+            install_message = std::format(
+                " Install {} files to play this scenario",
+                cd_display_names[RequiredCD]
+            );
+        }
+
+        CNC_LOG_FATAL("Required game files missing!{}", install_message);
         if (!RunningAsDLL) {
             exit(EXIT_FAILURE);
         }

--- a/tiberiandawn/scenarioini.cpp
+++ b/tiberiandawn/scenarioini.cpp
@@ -1033,7 +1033,7 @@ bool Read_Movies_From_Scenario_Ini(char* root, bool fresh)
     */
     if (RequiredCD != -2) {
         if (Scen.Scenario >= 20 && Scen.Scenario < 60 && GameToPlay == GAME_NORMAL) {
-            RequiredCD = 2;
+            RequiredCD = Options.SkipExpansionCdCheck ? -1 : 2;
         } else {
             if (Scen.Scenario != 1) {
                 if (Scen.Scenario >= 60) {

--- a/tiberiandawn/startup.cpp
+++ b/tiberiandawn/startup.cpp
@@ -567,6 +567,8 @@ void Prog_End(const char* why, bool fatal) // Added why and fatal parameters. ST
         Palette = NULL;
     }
 
+    spdlog::shutdown();
+
     ProgEndCalled = true;
 }
 

--- a/tiberiandawn/startup.cpp
+++ b/tiberiandawn/startup.cpp
@@ -435,13 +435,12 @@ int main(int argc, char** argv)
         }
         SlowPalette = ini.Get_Bool("Options", "SlowPalette", false);
 
-        BreakoutAllowed = true;
-
         /*
         ** Regardless of whether we should run it or not, here we're
         ** gonna change it to say "no" in the future.
         */
         if (Special.IsFromInstall) {
+            BreakoutAllowed = true;
             ini.Put_Bool("Intro", "PlayIntro", false);
             ini.Save(cfile);
         }

--- a/tiberiandawn/startup.cpp
+++ b/tiberiandawn/startup.cpp
@@ -456,10 +456,11 @@ int main(int argc, char** argv)
         }
 
         /*
-        ** Save settings if they were changed during gameplay.
+        ** Save settings and options if they were changed during gameplay.
         */
         ini.Load(cfile);
         Settings.Save(ini);
+        Options.Save_Settings(ini);
         ini.Save(cfile);
 
         VisiblePage.Clear();

--- a/tiberiandawn/startup.cpp
+++ b/tiberiandawn/startup.cpp
@@ -533,11 +533,15 @@ void Prog_End(const char* why, bool fatal) // Added why and fatal parameters. ST
 {
     GlyphX_Debug_Print("Prog_End()");
 
-    if (why) {
-        GlyphX_Debug_Print(why);
-    }
     if (fatal) {
+        if (why) {
+            GlyphX_Debug_Print(why);
+        }
+
+        CNC_LOG_FATAL(why == nullptr ? "Unknown fatal error" : why);
         *((int*)0) = 0;
+    } else if (why) {
+        GlyphX_Debug_Print(why);
     }
 
 #ifndef DEMO

--- a/tiberiandawn/startup.cpp
+++ b/tiberiandawn/startup.cpp
@@ -435,12 +435,13 @@ int main(int argc, char** argv)
         }
         SlowPalette = ini.Get_Bool("Options", "SlowPalette", false);
 
+        BreakoutAllowed = true;
+
         /*
         ** Regardless of whether we should run it or not, here we're
         ** gonna change it to say "no" in the future.
         */
         if (Special.IsFromInstall) {
-            BreakoutAllowed = true;
             ini.Put_Bool("Intro", "PlayIntro", false);
             ini.Save(cfile);
         }

--- a/tiberiandawn/startup.cpp
+++ b/tiberiandawn/startup.cpp
@@ -541,8 +541,10 @@ void Prog_End(const char* why, bool fatal) // Added why and fatal parameters. ST
         }
 
         CNC_LOG_FATAL(why == nullptr ? "Unknown fatal error" : why);
-        *((int*)0) = 0;
-    } else if (why) {
+        throw std::runtime_error(why);
+    }
+
+    if (why) {
         GlyphX_Debug_Print(why);
     }
 

--- a/tiberiandawn/typeconverter.cpp
+++ b/tiberiandawn/typeconverter.cpp
@@ -23,6 +23,7 @@ static const TwoWayMap<UnitType, std::string> UnitPatchTable = {{ UNIT_HTANK, "H
 static const TwoWayMap<WarheadType, std::string> WarheadPatchTable = {{ WARHEAD_HE, "HE_WARHEAD" }, { WARHEAD_LASER, "LASER_WARHEAD" }};
 static const TwoWayMap<WeaponType, std::string> WeaponPatchTable = {{ WEAPON_GRENADE, "GRENADE_WEAPON" }, { WEAPON_MLRS, "WEAPON_MLRS" }, { WEAPON_NAPALM, "NAPALM_WEAPON" }, { WEAPON_STEG, "STEG_WEAPON" }, { WEAPON_TREX, "TREX_WEAPON" }};
 static const TwoWayMap<HousesType, std::string> HousesPatchTable = {{ HOUSE_GOOD, "GOODGUY" }, { HOUSE_BAD, "BADGUY" }};
+static const TwoWayMap<CCPaletteType, std::string> CCPalettePatchTable = {{ CC_GDI_COLOR, "YELLOW" }, { CC_NOD_COLOR, "RED"}, {CC_BLUE_GREEN, "CYAN"}, {CC_BLUE_GREY, "BLUE"}, {CC_TAN, "BROWN"}};
 
 /**
  * Internal enum values that should not be used in INI or Lua APIs.
@@ -36,57 +37,57 @@ static const std::vector TemplateExcludes = {TEMPLATE_COUNT};
 
 // Info about each enum supported type, indexed against it's typename
 const std::map<std::string_view, EnumTypeInfoVariant> TdTypeConverter::EnumTypes = {
-    //                [Typename]                    [Prefix]        [Min Valid Val]                         [Max Valid Val]                           [INI Patch Table]   [Excluded Vals]      [Allow non-enum values?]
-    ENUM_TYPE_PAIR(ArmorType,                    "ARMOR_",       ARMOR_NONE,                             ARMOR_LAST,                               {},                 {},                  false),
-    ENUM_TYPE_PAIR(MPHType,                      "MPH_",         MPH_IMMOBILE,                           MPH_LIGHT_SPEED,                          {},                 {},                  true),
-    ENUM_TYPE_PAIR(WeaponType,                   "WEAPON_",      WEAPON_NONE,                            WEAPON_LAST,                              WeaponPatchTable,   {},                  false),
-    ENUM_TYPE_PAIR(HousesType,                   "HOUSE_",       HOUSE_NONE,                             HOUSE_LAST,                               HousesPatchTable,   {},                  false),
-    ENUM_TYPE_PAIR(StructType,                   "STRUCT_",      STRUCT_NONE,                            STRUCT_LAST,                              StructPatchTable,   {},                  false),
-    ENUM_TYPE_PAIR(FactoryType,                  "FACTORY_",     FACTORY_TYPE_NONE,                      FACTORY_TYPE_BUILDING,                    {},                 {},                  false),
-    ENUM_TYPE_PAIR(DirType,                      "DIR_",         DIR_MIN,                                DIR_MAX,                                  {},                 {},                  true),
-    ENUM_TYPE_PAIR(BSizeType,                    "BSIZE_",       BSIZE_NONE,                             BSIZE_LAST,                               {},                 {},                  false),
-    ENUM_TYPE_PAIR(AircraftType,                 "AIRCRAFT_",    AIRCRAFT_NONE,                          AIRCRAFT_LAST,                            AircraftPatchTable, {},                  false),
-    ENUM_TYPE_PAIR(MissionType,                  "MISSION_",     MISSION_NONE,                           MISSION_LAST,                             {},                 {},                  false),
-    ENUM_TYPE_PAIR(AnimType,                     "ANIM_",        ANIM_NONE,                              ANIM_LAST,                                AnimPatchTable,     {},                  false),
-    ENUM_TYPE_PAIR(InfantryType,                 "INFANTRY_",    INFANTRY_NONE,                          INFANTRY_LAST,                            InfantryPatchTable, {},                  false),
-    ENUM_TYPE_PAIR(UnitType,                     "UNIT_",        UNIT_NONE,                              UNIT_LAST,                                UnitPatchTable,     {},                  false),
-    ENUM_TYPE_PAIR(SpeedType,                    "SPEED_",       SPEED_NONE,                             SPEED_LAST,                               {},                 {},                  false),
-    ENUM_TYPE_PAIR(BulletType,                   "BULLET_",      BULLET_NONE,                            BULLET_LAST,                              BulletPatchTable,   {},                  false),
-    ENUM_TYPE_PAIR(WarheadType,                  "WARHEAD_",     WARHEAD_NONE,                           WARHEAD_LAST,                             WarheadPatchTable,  {},                  false),
-    ENUM_TYPE_PAIR(VocType,                      "VOC_",         VOC_NONE,                               VOC_BEACON,                               {},                 VocExcludes,         false),
-    ENUM_TYPE_PAIR(PlayerColorType,              "REMAP_",       REMAP_NONE,                             REMAP_LAST,                               {},                 {},                  false),
-    ENUM_TYPE_PAIR(HouseColorType,               "HOUSE_COLOR_", HOUSE_COLOR_BAD,                        HOUSE_COLOR_NEUTRAL,                      {},                 {},                  false),
-    ENUM_TYPE_PAIR(DiffType,                     "DIFF_",        DIFF_FIRST,                             DIFF_LAST,                                {},                 {},                  false),
-    ENUM_TYPE_PAIR(ScenarioDirType,              "SCEN_DIR_",    SCEN_DIR_NONE,                          SCEN_DIR_LAST,                            {},                 {},                  false),
-    ENUM_TYPE_PAIR(ScenarioVarType,              "SCEN_VAR_",    SCEN_VAR_NONE,                          SCEN_VAR_LOSE,                            {},                 ScenarioVarExcludes, false),
-    ENUM_TYPE_PAIR(SourceType,                   "SOURCE_",      SOURCE_NONE,                            SOURCE_OCEAN,                             {},                 {},                  false),
-    ENUM_TYPE_PAIR(RadarEnum,                    "RADAR_",       RADAR_NONE,                             RADAR_OFF,                                {},                 {},                  false),
-    ENUM_TYPE_PAIR(RTTIType,                     "RTTI_",        RTTI_NONE,                              RTTI_LAST,                                {},                 {},                  false),
-    ENUM_TYPE_PAIR(ZoneType,                     "ZONE_",        ZONE_NONE,                              ZONE_LAST,                                {},                 {},                  false),
-    ENUM_TYPE_PAIR(StateType,                    "STATE_",       STATE_BUILDUP,                          STATE_ENDGAME,                            {},                 {},                  false),
-    ENUM_TYPE_PAIR(VoxType,                      "VOX_",         VOX_NONE,                               VOX_LAST,                                 {},                 {},                  false),
-    ENUM_TYPE_PAIR(MouseType,                    "MOUSE_",       MOUSE_NORMAL,                           MOUSE_AREA_GUARD,                         {},                 {},                  false),
-    ENUM_TYPE_PAIR(TheaterType,                  "THEATER_",     THEATER_NONE,                           THEATER_LAST,                             {},                 {},                  false),
-    ENUM_TYPE_PAIR(TemplateType,                 "TEMPLATE_",    TEMPLATE_FIRST,                         TEMPLATE_NONE,                            {},                 TemplateExcludes,    false),
-    ENUM_TYPE_PAIR(OverlayType,                  "OVERLAY_",     OVERLAY_NONE,                           OVERLAY_LAST,                             {},                 {},                  false),
-    ENUM_TYPE_PAIR(SmudgeType,                   "SMUDGE_",      SMUDGE_NONE,                            SMUDGE_LAST,                              {},                 {},                  false),
-    ENUM_TYPE_PAIR(LandType,                     "LAND_",        LAND_CLEAR,                             LAND_COUNT,                               {},                 {},                  false),
-    ENUM_TYPE_PAIR(TeamMissionType,              "TMISSION_",    TMISSION_NONE,                          TMISSION_LAST,                            {},                 {},                  false),
-    ENUM_TYPE_PAIR(RadioMessageType,             "RADIO_",       RADIO_STATIC,                           RADIO_ON_DEPOT,                           {},                 {},                  false),
-    ENUM_TYPE_PAIR(CloakType,                    "",             UNCLOAKED,                              UNCLOAKING,                               {},                 {},                  false),
-    ENUM_TYPE_PAIR(FacingType,                   "FACING_",      FACING_NONE,                            FACING_LAST,                              {},                 {},                  false),
-    ENUM_TYPE_PAIR(DoorClass::DoorStateType,     "IS_",          DoorClass::IS_CLOSED,                   DoorClass::IS_CLOSING,                    {},                 {},                  false),
-    ENUM_TYPE_PAIR(KindType,                     "KIND_",        KIND_NONE,                              KIND_TEAMTYPE,                            {},                 {},                  false),
-    ENUM_TYPE_PAIR(DoType,                       "DO_",          DO_NOTHING,                             DO_PLEAD_DEATH,                           {},                 {},                  false),
-    ENUM_TYPE_PAIR(BStateType,                   "BSTATE_",      BSTATE_NONE,                            BSTATE_AUX2,                              {},                 {},                  false),
-    ENUM_TYPE_PAIR(EventType,                    "EVENT_",       EVENT_NONE,                             EVENT_LAST,                               {},                 {},                  false),
-    ENUM_TYPE_PAIR(TriggerClass::ActionType,     "ACTION_",      TriggerClass::ActionType::ACTION_NONE,  TriggerClass::ActionType::ACTION_LAST,    {},                 {},                  false),
-    ENUM_TYPE_PAIR(TriggerClass::PersistantType, "",             TriggerClass::PersistantType::VOLATILE, TriggerClass::PersistantType::PERSISTANT, {},                 {},                  false),
-    ENUM_TYPE_PAIR(TerrainType,                  "TERRAIN_",     TERRAIN_NONE,                           TERRAIN_LAST,                             {},                 {},                  false),
-    ENUM_TYPE_PAIR(ScenarioPlayerType,           "SCEN_PLAYER_", SCEN_PLAYER_NONE,                       SCEN_PLAYER_LAST,                         {},                 {},                  false),
-    ENUM_TYPE_PAIR(LayerType,                    "LAYER_",       LAYER_NONE,                             LAYER_LAST,                               {},                 {},                  false),
-    ENUM_TYPE_PAIR(UrgencyType,                  "URGENCY_",     URGENCY_NONE,                           URGENCY_FIRST,                            {},                 {},                  false),
-    ENUM_TYPE_PAIR(ColorType,                    "",             TBLACK,                                 WHITE,                                    {},                 {},                  false)
+    //            [Typename]                     [Prefix]        [Min Valid Val]                         [Max Valid Val]                           [INI Patch Table]    [Excluded Vals]      [Allow non-enum values?]
+    ENUM_TYPE_PAIR(ArmorType,                    "ARMOR_",       ARMOR_NONE,                             ARMOR_LAST,                               {},                  {},                  false),
+    ENUM_TYPE_PAIR(MPHType,                      "MPH_",         MPH_IMMOBILE,                           MPH_LIGHT_SPEED,                          {},                  {},                  true),
+    ENUM_TYPE_PAIR(WeaponType,                   "WEAPON_",      WEAPON_NONE,                            WEAPON_LAST,                              WeaponPatchTable,    {},                  false),
+    ENUM_TYPE_PAIR(HousesType,                   "HOUSE_",       HOUSE_NONE,                             HOUSE_LAST,                               HousesPatchTable,    {},                  false),
+    ENUM_TYPE_PAIR(StructType,                   "STRUCT_",      STRUCT_NONE,                            STRUCT_LAST,                              StructPatchTable,    {},                  false),
+    ENUM_TYPE_PAIR(FactoryType,                  "FACTORY_",     FACTORY_TYPE_NONE,                      FACTORY_TYPE_BUILDING,                    {},                  {},                  false),
+    ENUM_TYPE_PAIR(DirType,                      "DIR_",         DIR_MIN,                                DIR_MAX,                                  {},                  {},                  true),
+    ENUM_TYPE_PAIR(BSizeType,                    "BSIZE_",       BSIZE_NONE,                             BSIZE_LAST,                               {},                  {},                  false),
+    ENUM_TYPE_PAIR(AircraftType,                 "AIRCRAFT_",    AIRCRAFT_NONE,                          AIRCRAFT_LAST,                            AircraftPatchTable,  {},                  false),
+    ENUM_TYPE_PAIR(MissionType,                  "MISSION_",     MISSION_NONE,                           MISSION_LAST,                             {},                  {},                  false),
+    ENUM_TYPE_PAIR(AnimType,                     "ANIM_",        ANIM_NONE,                              ANIM_LAST,                                AnimPatchTable,      {},                  false),
+    ENUM_TYPE_PAIR(InfantryType,                 "INFANTRY_",    INFANTRY_NONE,                          INFANTRY_LAST,                            InfantryPatchTable,  {},                  false),
+    ENUM_TYPE_PAIR(UnitType,                     "UNIT_",        UNIT_NONE,                              UNIT_LAST,                                UnitPatchTable,      {},                  false),
+    ENUM_TYPE_PAIR(SpeedType,                    "SPEED_",       SPEED_NONE,                             SPEED_LAST,                               {},                  {},                  false),
+    ENUM_TYPE_PAIR(BulletType,                   "BULLET_",      BULLET_NONE,                            BULLET_LAST,                              BulletPatchTable,    {},                  false),
+    ENUM_TYPE_PAIR(WarheadType,                  "WARHEAD_",     WARHEAD_NONE,                           WARHEAD_LAST,                             WarheadPatchTable,   {},                  false),
+    ENUM_TYPE_PAIR(VocType,                      "VOC_",         VOC_NONE,                               VOC_BEACON,                               {},                  VocExcludes,         false),
+    ENUM_TYPE_PAIR(PlayerColorType,              "REMAP_",       REMAP_NONE,                             REMAP_LAST,                               {},                  {},                  false),
+    ENUM_TYPE_PAIR(HouseColorType,               "HOUSE_COLOR_", HOUSE_COLOR_BAD,                        HOUSE_COLOR_NEUTRAL,                      {},                  {},                  false),
+    ENUM_TYPE_PAIR(DiffType,                     "DIFF_",        DIFF_FIRST,                             DIFF_LAST,                                {},                  {},                  false),
+    ENUM_TYPE_PAIR(ScenarioDirType,              "SCEN_DIR_",    SCEN_DIR_NONE,                          SCEN_DIR_LAST,                            {},                  {},                  false),
+    ENUM_TYPE_PAIR(ScenarioVarType,              "SCEN_VAR_",    SCEN_VAR_NONE,                          SCEN_VAR_LOSE,                            {},                  ScenarioVarExcludes, false),
+    ENUM_TYPE_PAIR(SourceType,                   "SOURCE_",      SOURCE_NONE,                            SOURCE_OCEAN,                             {},                  {},                  false),
+    ENUM_TYPE_PAIR(RadarEnum,                    "RADAR_",       RADAR_NONE,                             RADAR_OFF,                                {},                  {},                  false),
+    ENUM_TYPE_PAIR(RTTIType,                     "RTTI_",        RTTI_NONE,                              RTTI_LAST,                                {},                  {},                  false),
+    ENUM_TYPE_PAIR(ZoneType,                     "ZONE_",        ZONE_NONE,                              ZONE_LAST,                                {},                  {},                  false),
+    ENUM_TYPE_PAIR(StateType,                    "STATE_",       STATE_BUILDUP,                          STATE_ENDGAME,                            {},                  {},                  false),
+    ENUM_TYPE_PAIR(VoxType,                      "VOX_",         VOX_NONE,                               VOX_LAST,                                 {},                  {},                  false),
+    ENUM_TYPE_PAIR(MouseType,                    "MOUSE_",       MOUSE_NORMAL,                           MOUSE_AREA_GUARD,                         {},                  {},                  false),
+    ENUM_TYPE_PAIR(TheaterType,                  "THEATER_",     THEATER_NONE,                           THEATER_LAST,                             {},                  {},                  false),
+    ENUM_TYPE_PAIR(TemplateType,                 "TEMPLATE_",    TEMPLATE_FIRST,                         TEMPLATE_NONE,                            {},                  TemplateExcludes,    false),
+    ENUM_TYPE_PAIR(OverlayType,                  "OVERLAY_",     OVERLAY_NONE,                           OVERLAY_LAST,                             {},                  {},                  false),
+    ENUM_TYPE_PAIR(SmudgeType,                   "SMUDGE_",      SMUDGE_NONE,                            SMUDGE_LAST,                              {},                  {},                  false),
+    ENUM_TYPE_PAIR(LandType,                     "LAND_",        LAND_CLEAR,                             LAND_COUNT,                               {},                  {},                  false),
+    ENUM_TYPE_PAIR(TeamMissionType,              "TMISSION_",    TMISSION_NONE,                          TMISSION_LAST,                            {},                  {},                  false),
+    ENUM_TYPE_PAIR(RadioMessageType,             "RADIO_",       RADIO_STATIC,                           RADIO_ON_DEPOT,                           {},                  {},                  false),
+    ENUM_TYPE_PAIR(CloakType,                    "",             UNCLOAKED,                              UNCLOAKING,                               {},                  {},                  false),
+    ENUM_TYPE_PAIR(FacingType,                   "FACING_",      FACING_NONE,                            FACING_LAST,                              {},                  {},                  false),
+    ENUM_TYPE_PAIR(DoorClass::DoorStateType,     "IS_",          DoorClass::IS_CLOSED,                   DoorClass::IS_CLOSING,                    {},                  {},                  false),
+    ENUM_TYPE_PAIR(KindType,                     "KIND_",        KIND_NONE,                              KIND_TEAMTYPE,                            {},                  {},                  false),
+    ENUM_TYPE_PAIR(DoType,                       "DO_",          DO_NOTHING,                             DO_PLEAD_DEATH,                           {},                  {},                  false),
+    ENUM_TYPE_PAIR(BStateType,                   "BSTATE_",      BSTATE_NONE,                            BSTATE_AUX2,                              {},                  {},                  false),
+    ENUM_TYPE_PAIR(EventType,                    "EVENT_",       EVENT_NONE,                             EVENT_LAST,                               {},                  {},                  false),
+    ENUM_TYPE_PAIR(TriggerClass::ActionType,     "ACTION_",      TriggerClass::ActionType::ACTION_NONE,  TriggerClass::ActionType::ACTION_LAST,    {},                  {},                  false),
+    ENUM_TYPE_PAIR(TriggerClass::PersistantType, "",             TriggerClass::PersistantType::VOLATILE, TriggerClass::PersistantType::PERSISTANT, {},                  {},                  false),
+    ENUM_TYPE_PAIR(TerrainType,                  "TERRAIN_",     TERRAIN_NONE,                           TERRAIN_LAST,                             {},                  {},                  false),
+    ENUM_TYPE_PAIR(ScenarioPlayerType,           "SCEN_PLAYER_", SCEN_PLAYER_NONE,                       SCEN_PLAYER_LAST,                         {},                  {},                  false),
+    ENUM_TYPE_PAIR(LayerType,                    "LAYER_",       LAYER_NONE,                             LAYER_LAST,                               {},                  {},                  false),
+    ENUM_TYPE_PAIR(UrgencyType,                  "URGENCY_",     URGENCY_NONE,                           URGENCY_FIRST,                            {},                  {},                  false),
+    ENUM_TYPE_PAIR(CCPaletteType,                "CC_",          CC_GDI_COLOR,                           CC_TAN,                                   CCPalettePatchTable, {},                  false)
 };
 
 bool TdTypeConverter::Rule_Requires_Converter(
@@ -183,7 +184,7 @@ void TdTypeConverter::Set_Rule_With_Variant(
     RULE_VARIANT(ScenarioPlayerType)
     RULE_VARIANT(LayerType)
     RULE_VARIANT(UrgencyType)
-    RULE_VARIANT(ColorType)
+    RULE_VARIANT(CCPaletteType)
 
     throw std::invalid_argument("Unsupported ConverterTypeVariant type - this is normally caused by variant being updated without updating supporting code");
 }
@@ -249,7 +250,7 @@ void TdTypeConverter::Set_Csv_Rule_With_Variant(
     CSV_RULE_VARIANT(ScenarioPlayerType)
     CSV_RULE_VARIANT(LayerType)
     CSV_RULE_VARIANT(UrgencyType)
-    CSV_RULE_VARIANT(ColorType)
+    CSV_RULE_VARIANT(CCPaletteType)
 
     throw std::invalid_argument("Unsupported ConverterTypeVariant type - this is normally caused by variant being updated without updating supporting code");
 }
@@ -308,7 +309,7 @@ std::string_view TdTypeConverter::Get_Type_Name_Variant(const ConverterTypeVaria
     TYPE_NAME_VARIANT(ScenarioPlayerType)
     TYPE_NAME_VARIANT(LayerType)
     TYPE_NAME_VARIANT(UrgencyType)
-    TYPE_NAME_VARIANT(ColorType)
+    TYPE_NAME_VARIANT(CCPaletteType)
 
     throw std::invalid_argument("Unsupported ConverterTypeVariant type - this is normally caused by variant being updated without updating supporting code");
 }
@@ -368,7 +369,7 @@ std::string TdTypeConverter::To_String_Variant(const ConverterTypeVariant& varia
     TO_STRING_VARIANT(ScenarioPlayerType)
     TO_STRING_VARIANT(LayerType)
     TO_STRING_VARIANT(UrgencyType)
-    TO_STRING_VARIANT(ColorType)
+    TO_STRING_VARIANT(CCPaletteType)
 
     throw std::invalid_argument("Unsupported ConverterTypeVariant type - this is normally caused by variant being updated without updating supporting code");
 }

--- a/tiberiandawn/typeconverter.cpp
+++ b/tiberiandawn/typeconverter.cpp
@@ -22,6 +22,7 @@ static const TwoWayMap<StructType, std::string> StructPatchTable = {{ STRUCT_GTO
 static const TwoWayMap<UnitType, std::string> UnitPatchTable = {{ UNIT_HTANK, "HTNK" }, { UNIT_MTANK, "MTNK" }, { UNIT_LTANK, "LTNK" }, { UNIT_STANK, "STNK" }, { UNIT_FTANK, "FTNK" }, { UNIT_MLRS, "MSAM" }, { UNIT_BUGGY, "BGGY" }, { UNIT_HARVESTER, "HARV" }, { UNIT_MSAM, "MLRS" }, { UNIT_HOVER, "LST" }, { UNIT_GUNBOAT, "BOAT" }};
 static const TwoWayMap<WarheadType, std::string> WarheadPatchTable = {{ WARHEAD_HE, "HE_WARHEAD" }, { WARHEAD_LASER, "LASER_WARHEAD" }};
 static const TwoWayMap<WeaponType, std::string> WeaponPatchTable = {{ WEAPON_GRENADE, "GRENADE_WEAPON" }, { WEAPON_MLRS, "WEAPON_MLRS" }, { WEAPON_NAPALM, "NAPALM_WEAPON" }, { WEAPON_STEG, "STEG_WEAPON" }, { WEAPON_TREX, "TREX_WEAPON" }};
+static const TwoWayMap<HousesType, std::string> HousesPatchTable = {{ HOUSE_GOOD, "GOODGUY" }, { HOUSE_BAD, "BADGUY" }};
 
 /**
  * Internal enum values that should not be used in INI or Lua APIs.
@@ -35,11 +36,11 @@ static const std::vector TemplateExcludes = {TEMPLATE_COUNT};
 
 // Info about each enum supported type, indexed against it's typename
 const std::map<std::string_view, EnumTypeInfoVariant> TdTypeConverter::EnumTypes = {
-    //             [Typename]                     [Prefix]        [Min Valid Val]                         [Max Valid Val]                           [INI Patch Table]   [Excluded Vals]      [Allow non-enum values?]
+    //                [Typename]                    [Prefix]        [Min Valid Val]                         [Max Valid Val]                           [INI Patch Table]   [Excluded Vals]      [Allow non-enum values?]
     ENUM_TYPE_PAIR(ArmorType,                    "ARMOR_",       ARMOR_NONE,                             ARMOR_LAST,                               {},                 {},                  false),
     ENUM_TYPE_PAIR(MPHType,                      "MPH_",         MPH_IMMOBILE,                           MPH_LIGHT_SPEED,                          {},                 {},                  true),
     ENUM_TYPE_PAIR(WeaponType,                   "WEAPON_",      WEAPON_NONE,                            WEAPON_LAST,                              WeaponPatchTable,   {},                  false),
-    ENUM_TYPE_PAIR(HousesType,                   "HOUSE_",       HOUSE_NONE,                             HOUSE_LAST,                               {},                 {},                  false),
+    ENUM_TYPE_PAIR(HousesType,                   "HOUSE_",       HOUSE_NONE,                             HOUSE_LAST,                               HousesPatchTable,   {},                  false),
     ENUM_TYPE_PAIR(StructType,                   "STRUCT_",      STRUCT_NONE,                            STRUCT_LAST,                              StructPatchTable,   {},                  false),
     ENUM_TYPE_PAIR(FactoryType,                  "FACTORY_",     FACTORY_TYPE_NONE,                      FACTORY_TYPE_BUILDING,                    {},                 {},                  false),
     ENUM_TYPE_PAIR(DirType,                      "DIR_",         DIR_MIN,                                DIR_MAX,                                  {},                 {},                  true),
@@ -84,7 +85,8 @@ const std::map<std::string_view, EnumTypeInfoVariant> TdTypeConverter::EnumTypes
     ENUM_TYPE_PAIR(TerrainType,                  "TERRAIN_",     TERRAIN_NONE,                           TERRAIN_LAST,                             {},                 {},                  false),
     ENUM_TYPE_PAIR(ScenarioPlayerType,           "SCEN_PLAYER_", SCEN_PLAYER_NONE,                       SCEN_PLAYER_LAST,                         {},                 {},                  false),
     ENUM_TYPE_PAIR(LayerType,                    "LAYER_",       LAYER_NONE,                             LAYER_LAST,                               {},                 {},                  false),
-    ENUM_TYPE_PAIR(UrgencyType,                  "URGENCY_",     URGENCY_NONE,                           URGENCY_FIRST,                            {},                 {},                  false)
+    ENUM_TYPE_PAIR(UrgencyType,                  "URGENCY_",     URGENCY_NONE,                           URGENCY_FIRST,                            {},                 {},                  false),
+    ENUM_TYPE_PAIR(ColorType,                    "",             TBLACK,                                 WHITE,                                    {},                 {},                  false)
 };
 
 bool TdTypeConverter::Rule_Requires_Converter(
@@ -181,6 +183,7 @@ void TdTypeConverter::Set_Rule_With_Variant(
     RULE_VARIANT(ScenarioPlayerType)
     RULE_VARIANT(LayerType)
     RULE_VARIANT(UrgencyType)
+    RULE_VARIANT(ColorType)
 
     throw std::invalid_argument("Unsupported ConverterTypeVariant type - this is normally caused by variant being updated without updating supporting code");
 }
@@ -246,6 +249,7 @@ void TdTypeConverter::Set_Csv_Rule_With_Variant(
     CSV_RULE_VARIANT(ScenarioPlayerType)
     CSV_RULE_VARIANT(LayerType)
     CSV_RULE_VARIANT(UrgencyType)
+    CSV_RULE_VARIANT(ColorType)
 
     throw std::invalid_argument("Unsupported ConverterTypeVariant type - this is normally caused by variant being updated without updating supporting code");
 }
@@ -304,6 +308,7 @@ std::string_view TdTypeConverter::Get_Type_Name_Variant(const ConverterTypeVaria
     TYPE_NAME_VARIANT(ScenarioPlayerType)
     TYPE_NAME_VARIANT(LayerType)
     TYPE_NAME_VARIANT(UrgencyType)
+    TYPE_NAME_VARIANT(ColorType)
 
     throw std::invalid_argument("Unsupported ConverterTypeVariant type - this is normally caused by variant being updated without updating supporting code");
 }
@@ -363,6 +368,7 @@ std::string TdTypeConverter::To_String_Variant(const ConverterTypeVariant& varia
     TO_STRING_VARIANT(ScenarioPlayerType)
     TO_STRING_VARIANT(LayerType)
     TO_STRING_VARIANT(UrgencyType)
+    TO_STRING_VARIANT(ColorType)
 
     throw std::invalid_argument("Unsupported ConverterTypeVariant type - this is normally caused by variant being updated without updating supporting code");
 }

--- a/tiberiandawn/typeconverter.h
+++ b/tiberiandawn/typeconverter.h
@@ -10,6 +10,7 @@
 #include "common/twowaymap.h"
 #include "common/rulesections.h"
 #include "common/stringutils.h"
+#include "common/lua/luaengine.h"
 
 #include "enumtypeinfo.h"
 #include "target.h"
@@ -243,6 +244,19 @@ public:
         }
 
         return *result;
+    }
+
+    template<class T>
+    requires SupportedByTdTypeConverter<T>
+    static T Assert_Parse_Lua_String(const SharedLuaEngine& engine, std::string instance_string)
+    {
+        const auto instance = Try_Parse<T>(instance_string);
+
+        if (!instance.has_value()) {
+            engine.Raise_Error_Format("Failed to parse {} from string: {}", Get_Type_Name<T>(), instance_string);
+        }
+
+        return *instance;
     }
 
     template<class T>

--- a/tiberiandawn/types-nco.cpp.in
+++ b/tiberiandawn/types-nco.cpp.in
@@ -10,6 +10,8 @@
 
 const IniRuleContext& BulletTypeClass::Read_INI(const IniRuleContext& ini)
 {
+    ini.Get_Section()@LOAD_BULLET_COMMENTS_CODE@;
+
     return ObjectTypeClass::Read_INI(ini)
         @LOAD_BULLET_RULES_CODE@;
 }
@@ -22,6 +24,8 @@ const RuleSection& BulletTypeClass::Read_Rules(const RuleSection& rules)
 
 const IniRuleContext& BuildingTypeClass::Read_INI(const IniRuleContext& ini)
 {
+    ini.Get_Section()@LOAD_BUILDING_COMMENTS_CODE@;
+
     return TechnoTypeClass::Read_INI(ini)
         @LOAD_BUILDING_RULES_CODE@;
 }
@@ -34,6 +38,8 @@ const RuleSection& BuildingTypeClass::Read_Rules(const RuleSection& rules)
 
 const IniRuleContext& HouseTypeClass::Read_INI(const IniRuleContext& ini)
 {
+    ini.Get_Section()@LOAD_HOUSE_COMMENTS_CODE@;
+
     auto set_suffix = std::bind(&HouseTypeClass::Set_Suffix, this, std::placeholders::_1);
     auto set_prefix = std::bind(&HouseTypeClass::Set_Prefix, this, std::placeholders::_1);
 
@@ -65,6 +71,8 @@ const RuleSection& HouseTypeClass::Read_Rules(const RuleSection& rules)
 // TODO: IsImmuneToTiberium and HasC4Charges
 const IniRuleContext& InfantryTypeClass::Read_INI(const IniRuleContext& ini)
 {
+    ini.Get_Section()@LOAD_INFANTRY_COMMENTS_CODE@;
+
     return TechnoTypeClass::Read_INI(ini)
         @LOAD_INFANTRY_RULES_CODE@;
 }
@@ -77,6 +85,8 @@ const RuleSection& InfantryTypeClass::Read_Rules(const RuleSection& rules)
 
 const IniRuleContext& AnimTypeClass::Read_INI(const IniRuleContext& ini)
 {
+    ini.Get_Section()@LOAD_ANIMATION_COMMENTS_CODE@;
+
     // TODO: Consider removing ObjectTypeClass::Read_INI as those values are the same for all instances
     // (or move to dedicated section in main rules file)
     return ObjectTypeClass::Read_INI(ini)
@@ -91,6 +101,8 @@ const RuleSection& AnimTypeClass::Read_Rules(const RuleSection& rules)
 
 const IniRuleContext& AircraftTypeClass::Read_INI(const IniRuleContext& ini)
 {
+    ini.Get_Section()@LOAD_AIRCRAFT_COMMENTS_CODE@;
+
     return TechnoTypeClass::Read_INI(ini)
         @LOAD_AIRCRAFT_RULES_CODE@;
 }
@@ -104,6 +116,8 @@ const RuleSection& AircraftTypeClass::Read_Rules(const RuleSection& rules)
 // TODO: Logic to allow selecting FullName by text file const name (or wait until lang file refactored into text format)
 const IniRuleContext& ObjectTypeClass::Read_INI(const IniRuleContext& ini)
 {
+    ini.Get_Section()@LOAD_OBJECT_COMMENTS_CODE@;
+
     return ini@LOAD_OBJECT_RULES_CODE@;
 }
 
@@ -114,6 +128,8 @@ const RuleSection& ObjectTypeClass::Read_Rules(const RuleSection& rules)
 
 const IniRuleContext& TechnoTypeClass::Read_INI(const IniRuleContext& ini)
 {
+    ini.Get_Section()@LOAD_TECHNO_COMMENTS_CODE@;
+
     ObjectTypeClass::Read_INI(ini)
         @LOAD_TECHNO_RULES_CODE@;
 
@@ -140,6 +156,8 @@ const RuleSection& TechnoTypeClass::Read_Rules(const RuleSection& rules)
 
 const IniRuleContext& UnitTypeClass::Read_INI(const IniRuleContext& ini)
 {
+    ini.Get_Section()@LOAD_UNIT_COMMENTS_CODE@;
+
     return TechnoTypeClass::Read_INI(ini)
         @LOAD_UNIT_RULES_CODE@; // TODO: IsImmuneToTiberium and HasC4Charges
 }
@@ -152,6 +170,8 @@ const RuleSection& UnitTypeClass::Read_Rules(const RuleSection& rules)
 
 const IniRuleContext& WeaponTypeClass::Read_INI(const IniRuleContext& ini)
 {
+    ini.Get_Section()@LOAD_WEAPON_COMMENTS_CODE@;
+
     return ini@LOAD_WEAPON_RULES_CODE@;
 }
 
@@ -162,6 +182,8 @@ const RuleSection& WeaponTypeClass::Read_Rules(const RuleSection& rules)
 
 const IniRuleContext& WarheadTypeClass::Read_INI(const IniRuleContext& ini)
 {
+    ini.Get_Section()@LOAD_WARHEAD_COMMENTS_CODE@;
+
     return ini@LOAD_WARHEAD_RULES_CODE@;
 }
 

--- a/tiberiandawn/types/01.Object.json
+++ b/tiberiandawn/types/01.Object.json
@@ -18,7 +18,7 @@
     {
       "name": "IsSelectable",
       "type": "Bool",
-      "comment": "It is legal to \"select\" some objects in the game. If it is legal to select this object type then this flag will be true. Selected game objects typically display a floating health bar and allows special user I/O control."
+      "comment": "It is legal to 'select' some objects in the game. If it is legal to select this object type then this flag will be true. Selected game objects typically display a floating health bar and allows special user I/O control."
     },
     {
       "name": "IsLegalTarget",
@@ -28,7 +28,7 @@
     {
       "name": "IsInsignificant",
       "type": "Bool",
-      "comment": "\"Insignificant\" objects will not be announced when they are destroyed or when they appear. Terrain elements and some lesser vehicles have this characteristic."
+      "comment": "'Insignificant' objects will not be announced when they are destroyed or when they appear. Terrain elements and some lesser vehicles have this characteristic."
     },
     {
       "name": "IsImmune",
@@ -43,7 +43,7 @@
     {
       "name": "IsSentient",
       "type": "Bool",
-      "comment": "\"Sentient\" objects are ones that have logic AI processing performed on them. All vehicles, buildings, infantry, and aircraft are so flagged. Terrain elements also fall under this category, but only because certain animation effects require this."
+      "comment": "'Sentient' objects are ones that have logic AI processing performed on them. All vehicles, buildings, infantry, and aircraft are so flagged. Terrain elements also fall under this category, but only because certain animation effects require this."
     },
     {
       "name": "Armor",

--- a/tiberiandawn/types/03.Infantry.json
+++ b/tiberiandawn/types/03.Infantry.json
@@ -16,7 +16,7 @@
     {
       "name": "IsCrawling",
       "type": "Bool",
-      "comment": "Does this infantry unit have crawling animation? If not, then this means that the \"crawling\" frames are actually running animation frames."
+      "comment": "Does this infantry unit have crawling animation? If not, then this means that the 'crawling' frames are actually running animation frames."
     },
     {
       "name": "IsCapture",
@@ -36,7 +36,7 @@
     {
       "name": "IsAvoidingTiberium",
       "type": "Bool",
-      "comment": "For \"fraidycat\" infantry types that will run away from any damage causing events, this controls whether they avoid wandering into Tiberium."
+      "comment": "For 'fraidycat' infantry types that will run away from any damage causing events, this controls whether they avoid wandering into Tiberium."
     },
     {
       "name": "Type",

--- a/tiberiandawn/types/04.Units.json
+++ b/tiberiandawn/types/04.Units.json
@@ -31,7 +31,7 @@
     {
       "name": "IsChunkyShape",
       "type": "Bool",
-      "comment": "Does this unit's shape data consist of \"chunky\" facings? This kind of unit art has the unit in only 4 facings (N, W, S, and E) and in each of those directions, the unit's turrets rotates 32 facings (counter clockwise from north). This will result in 32 x 4 = 128 unit shapes in the shape data file."
+      "comment": "Does this unit's shape data consist of 'chunky' facings? This kind of unit art has the unit in only 4 facings (N, W, S, and E) and in each of those directions, the unit's turrets rotates 32 facings (counter clockwise from north). This will result in 32 x 4 = 128 unit shapes in the shape data file."
     },
     {
       "name": "IsRadarEquipped",
@@ -56,7 +56,7 @@
     {
       "name": "IsGigundo",
       "type": "Bool",
-      "comment": "Is this unit of the humongous size? Harvesters and mobile construction vehicles are of this size. If the vehicle is greater than 24 x 24 but less than 48 x 48, it is considered \"Gigundo\"."
+      "comment": "Is this unit of the humongous size? Harvesters and mobile construction vehicles are of this size. If the vehicle is greater than 24 x 24 but less than 48 x 48, it is considered 'Gigundo'."
     },
     {
       "name": "IsCloakable",

--- a/tiberiandawn/types/06.Buildings.json
+++ b/tiberiandawn/types/06.Buildings.json
@@ -28,7 +28,7 @@
       "type": "FactoryType",
       "requires_converter": true,
       "valid_values": "NONE, INFANTRY, UNIT, AIRCRAFT, BUILDING",
-      "comment": "This flag specifies the type of object this factory building can \"produce\". For non factory buildings, this value will be RTTI_NONE."
+      "comment": "This flag specifies the type of object this factory building can 'produce'. For non factory buildings, this value will be RTTI_NONE."
     },
     {
       "name": "IsSimpleDamage",
@@ -89,7 +89,7 @@
       "type": "BSizeType",
       "requires_converter": true,
       "valid_values": "NONE, 11, 21, 12, 22, 23, 32, 33, 42, 55",
-      "comment": "This is the size of the building. This size value is a rough indication of the building's \"footprint\"."
+      "comment": "This is the size of the building. This size value is a rough indication of the building's 'footprint'."
     }
   ]
 }

--- a/tiberiandawn/types/08.Bullets.json
+++ b/tiberiandawn/types/08.Bullets.json
@@ -61,7 +61,7 @@
       "name": "IsTranslucent",
       "type": "Bool",
 
-      "comment": "If the bullet contains translucent pixels, then this flag will be true. These translucent pixels really are \"shadow\" pixels in the same style as the shadow cast by regular ground units."
+      "comment": "If the bullet contains translucent pixels, then this flag will be true. These translucent pixels really are 'shadow' pixels in the same style as the shadow cast by regular ground units."
     },
     {
       "name": "IsAntiAircraft",
@@ -94,7 +94,7 @@
       "type": "AnimType",
       "requires_converter": true,
       "valid_values": "NONE, ART_EXP1, ATOMDOOR, ATOMSFX, BEACON, BEACON_V, BURN_L, BURN_M, BURN_S, CHEMBALL, CHEM_E, CHEM_N, CHEM_NE, CHEM_NW, CHEM_S, CHEM_SE, CHEM_SW, CHEM_W, DEVIATOR, DOLLAR, EARTH, EMPULSE, FBALL1, FIR2_M_V, FIRE_M, FIRE_ME, FIRE_M_V, FIRE_S, FIRE_S_V, FIRE_T, FIRE_T_V, FLAG, FLAME_E, FLAME_N, FLAME_NE, FLAME_NW, FLAME_S, FLAME_SE, FLAME_SW, FLAME_W, FLMSPT, FRAG1, FRAG2, GRENADEA, GUNFIRE, GUN_N, GUN_NW, GUN_SW, GUN_W, INVUN, IONSFX, LZ_SMOKE, MGUN_E, MGUN_NE, MGUN_S, MGUN_SE, MINE, MISSILE, MV_FLASH, NAPALM1, NAPALM2, NAPALM3, ONFIRE_L, ONFIRE_M, ONFIRE_S, PIFF, PIFFPIFF, RAPID, RAPT_DIE, SAM_E, SAM_NE, SAM_S, SAM_SE, SFIRE_N, SFIRE_NW, SFIRE_SW, SFIRE_W, SMOKEY, SMOKE_M, STEALTH, STEG_DIE, TREX_DIE, TRIC_DIE, VEH_HIT1, VEH_HIT2, VEH_HIT3 - See: [animation.ini](#animationini)",
-      "comment": "This is the \"explosion\" effect to use when this projectile impacts."
+      "comment": "This is the 'explosion' effect to use when this projectile impacts."
     },
     {
       "name": "ROT",

--- a/tiberiandawn/types/10.Animations.json
+++ b/tiberiandawn/types/10.Animations.json
@@ -71,12 +71,12 @@
     {
       "name": "Size",
       "type": "Int",
-      "comment": "This is the frame that the animation is biggest. The biggest frame of animation will hide any changes to underlying ground (e.g., craters) that the animation causes, so these effects are delayed until this frame is reached. The end result is to prevent the player from seeing craters \"pop\" into existence."
+      "comment": "This is the frame that the animation is biggest. The biggest frame of animation will hide any changes to underlying ground (e.g., craters) that the animation causes, so these effects are delayed until this frame is reached. The end result is to prevent the player from seeing craters 'pop' into existence."
     },
     {
       "name": "Biggest",
       "type": "Int",
-      "comment": "This is the frame that the animation is biggest. The biggest frame of animation will hide any changes to underlying ground (e.g., craters) that the animation causes, so these effects are delayed until this frame is reached. The end result is to prevent the player from seeing craters \"pop\" into existence."
+      "comment": "This is the frame that the animation is biggest. The biggest frame of animation will hide any changes to underlying ground (e.g., craters) that the animation causes, so these effects are delayed until this frame is reached. The end result is to prevent the player from seeing craters 'pop' into existence."
     },
     {
       "name": "Damage",

--- a/tiberiandawn/types/11.Houses.json
+++ b/tiberiandawn/types/11.Houses.json
@@ -51,7 +51,7 @@
       "name": "Prefix",
       "type": "String",
       "template_ignore": true,
-      "comment": "This is a unique ASCII character used when constructing filenames. It serves a similar purpose as the \"Suffix\" element, but is only one character long.",
+      "comment": "This is a unique ASCII character used when constructing filenames. It serves a similar purpose as the 'Suffix' element, but is only one character long.",
       "example_value": "G",
       "valid_values": "One character maximum, in uppercase"
     },

--- a/tiberiandawn/typevariants.h
+++ b/tiberiandawn/typevariants.h
@@ -55,7 +55,8 @@ concept SupportedByTdTypeConverter = (
     std::is_same_v<T, TerrainType> ||
     std::is_same_v<T, ScenarioPlayerType> ||
     std::is_same_v<T, LayerType> ||
-    std::is_same_v<T, UrgencyType>
+    std::is_same_v<T, UrgencyType> ||
+    std::is_same_v<T, ColorType>
 );
 
 // Matches the SupportedByTdTypeConverter Concept types
@@ -108,5 +109,6 @@ using ConverterTypeVariant = std::variant<
     TerrainType,
     ScenarioPlayerType,
     LayerType,
-    UrgencyType
+    UrgencyType,
+    ColorType
 >;

--- a/tiberiandawn/typevariants.h
+++ b/tiberiandawn/typevariants.h
@@ -56,7 +56,7 @@ concept SupportedByTdTypeConverter = (
     std::is_same_v<T, ScenarioPlayerType> ||
     std::is_same_v<T, LayerType> ||
     std::is_same_v<T, UrgencyType> ||
-    std::is_same_v<T, ColorType>
+    std::is_same_v<T, CCPaletteType>
 );
 
 // Matches the SupportedByTdTypeConverter Concept types
@@ -110,5 +110,5 @@ using ConverterTypeVariant = std::variant<
     ScenarioPlayerType,
     LayerType,
     UrgencyType,
-    ColorType
+    CCPaletteType
 >;

--- a/wiki/4.Planned-Features.md
+++ b/wiki/4.Planned-Features.md
@@ -44,7 +44,7 @@ As I decide what items to work on next, I'll add a feature request to this repo 
     - Presets for default rules that can be selected in game or in launcher
       - Vanilla, Enhanced, Enhanced /w Cheats
       - Need to ship these as rules.ini files with game and/or launcher
-      - Maybe have CLI args to tell the game to load multiple rules.ini, in a certain order (load in in sequence, using values resolved from last load as default to inherit changes)
+      - Maybe have CLI args to tell the game to load multiple rules.ini, in a certain order (loading each in sequence, using values resolved from last load as default to inherit changes)
       - Could reload rules when new preset is chosen
     - More event handling using Lua scripts
       - Ability to control scenario flow from Lua scripts, similar to OpenRA


### PR DESCRIPTION
Provide a simple in-game console using the existing message functionality. On press of F1 user can enter a line of Lua code which is evaluated and result is printed to the screen. The console only works in campaign and skirmish games. Logic also holds the console history for the lifetime of a scenario and allows scrolling during console mode using UP and DOWN keys.

## Feature

- **td**: Lua Console pop-up on F1 (campaign and skirmish only)
- **lua**: Support eval for any lua expression and evaluating to any lua type
- **common**: Support INI comments for rules 
- **td**: Generate comment code for rules and types
- **cmake**: Ensure rules and types cmake scripts change hash on script code change
- **td**: CONQUER.INI option to ignore missing Covert Ops files `SkipExpansionCdCheck`
- **td**: Use `save` sub-directory of user path instead of writing saves beside binary
- **td**: Messages Lua API support for setting colour and timeout
- **td**: `spdlog` shutdown before program exit
- **td**: Play sound effect on fatal error popup
- **launcher**: Add CNC Comm Center sources back and logic to failover to secondary source (internet archive)

## Fixes

- **launcher**: IOC issue causing install journey showing start page twice
- **td**: Throw an exception instead of de-referencing a NULL pointer for prog end calls
- **td**: Show popup when data files missing (cd check)
- **td**: Custom text for Map Editor option on Main Menu

## Chores

- **scripts**: Deploy test files to user path rather than binary path