### PR TITLE
fix(common): Incorrect User Path Resolution

### DIFF
--- a/common/logger.cpp
+++ b/common/logger.cpp
@@ -77,10 +77,10 @@ void CncLogger::Init_SpdLog()
 
     Sinks.emplace_back(StdoutSink);
 
-    // create log file in user path
-    const auto log_file_name = std::format("{}.log", DefaultLoggerName);
+    // create log file in user path, filename matches program binary (nco-td.log, TIBERIANDAWN.DLL.log etc.)
+    const auto log_file_name = std::format("{}.log", PathsClass::Try_Get_Program_Binary_Name());
 
-    const auto log_file = std::filesystem::path(Paths.User_Path())
+    const auto log_file = std::filesystem::path(PathsClass::Try_Get_User_Path_Root())
         .append(log_file_name)
         .string();
 

--- a/common/paths.h
+++ b/common/paths.h
@@ -22,6 +22,8 @@ public:
     static constexpr char SEP = std::filesystem::path::preferred_separator;
 
     static std::string Try_Get_Program_Path();
+    static std::string Try_Get_Program_Binary_Name();
+    static std::string Try_Get_User_Path_Root();
     static bool Create_Directory(const char* path);
     static bool Is_Absolute(const char* path);
     static std::string Concatenate_Paths(const char* path1, const char* path2);

--- a/common/paths_posix.cpp
+++ b/common/paths_posix.cpp
@@ -16,6 +16,7 @@
 #include <cstdlib>
 #include <cstring>
 #include <errno.h>
+#include <iostream>
 #include <pwd.h>
 #include <stdexcept>
 #include <sys/stat.h>
@@ -97,22 +98,17 @@ namespace
 
     std::string Get_Posix_Default(const char* env_var, const char* relative_path)
     {
-        const char* tmp = std::getenv(env_var);
-
-        if (tmp != nullptr && tmp[0] != '\0') {
-            if (tmp[0] != '/') {
-                char buffer[200];
-                std::snprintf(buffer,
-                              sizeof(buffer),
-                              "'%s' should start with '/' as per XDG specification that the value must be absolute. "
-                              "The current value is: "
-                              "'%s'.",
-                              tmp,
-                              env_var);
-                CNC_LOG_WARN(buffer);
-            } else {
+        if (const auto tmp = std::getenv(env_var); tmp != nullptr && tmp[0] != '\0') {
+            if (tmp[0] == '/') {
                 return tmp;
             }
+
+            std::cout << std::format(
+                "'{}' should start with '/' as per XDG specification (the value must be absolute). "
+                "The current value is: '{}'.",
+                tmp,
+                env_var
+            );
         }
 
         return User_Home() + "/" + relative_path;
@@ -131,7 +127,6 @@ std::string PathsClass::Try_Get_Program_Path()
     ** Adapted from https://github.com/gpakosz/whereami
     ** dual licensed under the WTFPL v2 and MIT licenses without any warranty. by Gregory Pakosz (@gpakosz)
     */
-    std::string tmp;
     char buffer[PATH_MAX];
     char* resolved = nullptr;
 #if defined(__linux__) || defined(__CYGWIN__) || defined(__sun)
@@ -175,14 +170,20 @@ std::string PathsClass::Try_Get_Program_Path()
         throw std::runtime_error("Failed to get game binary path");
     }
 
-    tmp = resolved;
-    return tmp.substr(0, tmp.find_last_of("/"));
+    return resolved;
+}
+
+std::string PathsClass::Try_Get_Program_Binary_Name()
+{
+    const auto program_path = Try_Get_Program_Path();
+    return program_path.substr(program_path.find_last_of(SEP) + 1);
 }
 
 const char* PathsClass::Program_Path()
 {
     if (ProgramPath.empty()) {
-        ProgramPath = Try_Get_Program_Path();
+        const auto program_path = Try_Get_Program_Path();
+        ProgramPath = program_path.substr(0, program_path.find_last_of(SEP));
     }
 
     return ProgramPath.c_str();
@@ -206,14 +207,19 @@ const char* PathsClass::Data_Path()
     return DataPath.c_str();
 }
 
+std::string PathsClass::Try_Get_User_Path_Root()
+{
+#ifdef __APPLE__
+    return User_Home() + "/Library/Application Support/nco";
+#else
+    return Get_Posix_Default("XDG_CONFIG_HOME", ".config") + SEP + "nco";
+#endif
+}
+
 const char* PathsClass::User_Path()
 {
     if (UserPath.empty()) {
-#ifdef __APPLE__
-        UserPath = User_Home() + "/Library/Application Support/nco";
-#else
-        UserPath = Get_Posix_Default("XDG_CONFIG_HOME", ".config") + "/nco";
-#endif
+        UserPath = Try_Get_User_Path_Root();
 
         if (!Suffix.empty()) {
             UserPath += SEP + Suffix;

--- a/common/paths_win.cpp
+++ b/common/paths_win.cpp
@@ -72,7 +72,7 @@ std::string PathsClass::Try_Get_Program_Path()
                 free(path);
             }
 
-            return tmp.substr(0, tmp.find_last_of("\\/"));
+            return tmp;
         }
 #else
         TCHAR path[MAX_PATH];
@@ -89,16 +89,22 @@ std::string PathsClass::Try_Get_Program_Path()
             throw std::runtime_error(std::format("Failed to get DLL filename: {}", GetLastError()));
         }
 
-        const std::string tmp((TCHARToUTF8(path)));
-        return tmp.substr(0, tmp.find_last_of('\\'));
+        return std::string((TCHARToUTF8(path)));
 #endif
+}
+
+std::string PathsClass::Try_Get_Program_Binary_Name()
+{
+    const auto program_path = Try_Get_Program_Path();
+    return program_path.substr(program_path.find_last_of("\\/") + 1);
 }
 
 const char* PathsClass::Program_Path()
 {
     if (ProgramPath.empty()) {
         try {
-            ProgramPath = Try_Get_Program_Path();
+            const auto program_path = Try_Get_Program_Path();
+            ProgramPath = program_path.substr(0, program_path.find_last_of("\\/"));
             CNC_LOGGER_INFO("Resolved ProgramPath: {}", ProgramPath);
         } catch (const std::runtime_error& e) {
             CNC_LOGGER_FATAL("Failed to resolve ProgramPath: {}", e.what());
@@ -133,16 +139,26 @@ const char* PathsClass::Data_Path()
     return DataPath.c_str();
 }
 
+std::string PathsClass::Try_Get_User_Path_Root()
+{
+    TCHAR path[MAX_PATH];
+
+    if (!SHGetSpecialFolderPath(nullptr, path, CSIDL_APPDATA, TRUE)) {
+        throw std::runtime_error(
+            std::format(
+                "Failed to retrieve FOLDERID_RoamingAppData for PathsClass::Get_User_Path_Root(): {}",
+                GetLastError()
+            )
+        );
+    }
+
+    return std::string(TCHARToUTF8(path)) + SEP + "nco";
+}
+
 const char* PathsClass::User_Path()
 {
     if (UserPath.empty()) {
-        TCHAR path[MAX_PATH];
-
-        if (!SHGetSpecialFolderPath(nullptr, path, CSIDL_APPDATA, TRUE)) {
-            CNC_LOGGER_FATAL("Failed to retrieve FOLDERID_RoamingAppData for PathsClass::User_Path(): {}", GetLastError());
-        }
-
-        UserPath = std::format("{}{}{}", static_cast<const char*>(TCHARToUTF8(path)), SEP, "nco");
+        UserPath = Try_Get_User_Path_Root();
 
         if (!Suffix.empty()) {
             UserPath += SEP + Suffix;


### PR DESCRIPTION
Moving log files to the user path caused a bug due to logger logic running during static initialization (before Init in PathsClass could be run). The Init sets the suffix so the user path has `tiberian-dawn` for example, this was missing. Refactored logger logic to use root user path and binary filename as log filename - these are both static methods in PathsClass and don't interfere with the singleton state.

## Fixes

- common: Prevent logger using singleton from causing user path to be set missing the suffix

## Chores

- vcpkg: Bump submodule commit to latest