### PR TITLE
fix(ra): Ensure score screens zoomed in hi-res modes

### DIFF
--- a/redalert/conquer.cpp
+++ b/redalert/conquer.cpp
@@ -3891,7 +3891,7 @@ static bool Change_Local_Dir(int cd)
 {
     static bool _initialised = false;
     static unsigned _detected = 0;
-    static const char* _vol_labels[CD_COUNT] = {"allied", "soviet", "counterstrike", "aftermath", "."};
+    static const char* _vol_labels[CD_COUNT] = {"allies", "soviet", "counterstrike", "aftermath", "."};
     std::string paths[3] = {Paths.User_Path(), Paths.Data_Path(), Paths.Program_Path()};
 
     // Detect which if any of the discs have had their data copied to an appropriate local folder.

--- a/redalert/score.cpp
+++ b/redalert/score.cpp
@@ -381,6 +381,8 @@ void ScoreClass::Presentation(void)
     Set_Logic_Page(SysMemPage);
     BlackPalette.Set();
 
+    Enter_Zoomed_Resolution_Mode();
+
     void const* country4 = MFCD::Retrieve("COUNTRY4.AUD");
     void const* sfx4 = MFCD::Retrieve("SFX4.AUD");
     Beepy6 = MFCD::Retrieve("BEEPY6.AUD");
@@ -1696,6 +1698,9 @@ void Multi_Score_Presentation(void)
     SeenPage.Clear();
     HidPage.Clear();
     Hide_Mouse();
+
+    Enter_Zoomed_Resolution_Mode();
+
     void* anim = Open_Animation(
         "MLTIPLYR.WSA", (WSAOpenType)(WSA_OPEN_FROM_MEM | WSA_OPEN_TO_PAGE), (unsigned char*)ScorePalette.Get_Data());
     /*


### PR DESCRIPTION
## Fixes

- **ra**: Multiplayer score screen not zoomed in hi-res mode
- **ra**: Campaign score screen not zoomed in hi-res mode
- **ra**: Allied disc directory name typo ('allied' -> 'allies')