### PR TITLE
fix(td): Remaster Skirmish Saves Causing Crash

### DIFF
--- a/common/logger.cpp
+++ b/common/logger.cpp
@@ -89,10 +89,6 @@ std::shared_ptr<spdlog::logger> CncLogger::operator()() const
 {
     auto logger = spdlog::get(Name);
 
-#ifdef REMASTER_BUILD
-    logger->flush();
-#endif
-
     return logger;
 }
 
@@ -122,6 +118,13 @@ std::shared_ptr<spdlog::async_logger> CncLogger::Build_Logger(const std::string 
         spdlog::async_overflow_policy::block
     );
 
+#ifndef REMASTER_BUILD
+    // ensure any error/critical messages trigger a flush, due to increased likelyhood that the process might crash
+    logger->flush_on(spdlog::level::err);
+#else
+    // BUG: not all log messages reach the file in remaster, so make everything other than debug/trace trigger a flush
+    logger->flush_on(spdlog::level::info);
+#endif
     return logger;
 }
 
@@ -136,11 +139,14 @@ void CncLogger::Init_SpdLog()
 
     spdlog::init_thread_pool(8192, 1);
 
+// remaster dll has no stdout handle, so disable console logging in that build
+#ifndef REMASTER_BUILD
     // console logging
     auto stdout_sink = std::make_shared<spdlog::sinks::stdout_color_sink_mt>();
     stdout_sink->set_pattern("%^%L [%=15!n] %v%$");
 
     Sinks.emplace_back(std::move(stdout_sink));
+#endif
 
     // create log file in user path, filename matches program binary (nco-td.log, TIBERIANDAWN.DLL.log etc.)
     const auto log_file_name = std::format("{}.log", PathsClass::Try_Get_Program_Binary_Name());

--- a/common/rulesections.cpp
+++ b/common/rulesections.cpp
@@ -237,7 +237,7 @@ void RuleSection::Save_All_To_Ini(INIClass& ini) const
 
 RuleSection& RuleSection::Set(std::string_view name, RuleValueVariant value)
 {
-    CNC_LOGGER_WARN(
+    CNC_LOGGER_DEBUG(
         "Updating rule at runtime: [{}] -> {} = {}",
         SectionName,
         name,
@@ -260,7 +260,7 @@ RuleSection& RuleSection::Set(std::string_view name, RuleValueVariant value)
 
     Rules[name.data()] = value;
 
-    CNC_LOGGER_WARN("Running OnRulesChanged() handler");
+    CNC_LOGGER_DEBUG("Running OnRulesChanged() handler");
     OnRulesChanged(*this, name, value);
 
     return *this;

--- a/common/rulesections.h
+++ b/common/rulesections.h
@@ -476,7 +476,6 @@ private:
 #define Read_Var_With_Type(VAR, T) Get_With_Callback<T>(#VAR, [&](const auto v) { VAR = v; })
 
 // Load a variable/member by its C++ name from an INI context and set its value to equal the INI value
-#define Read_Var(VAR) Read_Var_With_Type(#VAR, VAR, [&](const auto v) { VAR = v; })
 #define Read_Bool_Var(VAR) Read_Var_With_Type(VAR, bool)
 #define Read_UShort_Var(VAR) Read_Var_With_Type(VAR, ushort)
 #define Read_Int_Var(VAR) Read_Var_With_Type(VAR, int)
@@ -484,6 +483,12 @@ private:
 #define Read_Char_Var(VAR) Read_Var_With_Type(VAR, char)
 #define Read_UChar_Var(VAR) Read_Var_With_Type(VAR, uchar)
 #define Read_String_Var(VAR) Read_Var_With_Type(VAR, std::string)
+
+#define Read_Var_With_Name_And_Type(VAR, NAME, T) Get_With_Callback<T>(NAME, [&](const auto v) { VAR = v; })
+
+// Load a variable/member by its C++ name from an INI context and set its value to equal the INI value
+#define Read_Bool_Var_With_Name(VAR, NAME) Read_Var_With_Name_And_Type(VAR, NAME, bool)
+#define Read_Negated_Bool_Var_With_Name(VAR, NAME) Get_With_Callback<bool>(NAME, [&](const auto v) { VAR = !v; })
 
 #define Set_Var_Comment(VAR, COMMENT) Set_Rule_Comment(#VAR, COMMENT)
 

--- a/tiberiandawn/dllinterface.cpp
+++ b/tiberiandawn/dllinterface.cpp
@@ -7791,9 +7791,6 @@ void SaveGameRemasterState_v1::Read_Dll_State()
     for (const auto& sidebar : DLLExportClass::MultiplayerSidebars) {
         RemasterMultiplayerSidebars.emplace_back(sidebar);
     }
-
-    RemasterSpecial = Special;
-    NotAllowSuperWeapons = !Rule.AllowSuperWeapons;
 }
 
 bool SaveGameRemasterState_v1::Validate() const
@@ -7824,13 +7821,6 @@ bool SaveGameRemasterState_v1::Validate() const
                 MAX_PLAYERS,
                 json_value.size());
         }
-    }
-
-    if (!RemasterSpecial.is_object()) {
-        result = false;
-        CNC_LOGGER_ERROR("Invalid RemasterState.{} save game value - json object expected, actual type: {}",
-                         NAMEOF(RemasterSpecial),
-                         RemasterSpecial.type_name());
     }
 
     return result;
@@ -7865,9 +7855,6 @@ bool SaveGameRemasterState_v1::Write_Dll_State() const
     for (auto i = 0; i < std::size(DLLExportClass::MultiplayerSidebars); i++) {
         from_json(RemasterMultiplayerSidebars.at(i), DLLExportClass::MultiplayerSidebars[i]);
     }
-
-    from_json(RemasterSpecial, Special);
-    Rule.AllowSuperWeapons = !NotAllowSuperWeapons;
 
     return true;
 }

--- a/tiberiandawn/dllinterface.cpp
+++ b/tiberiandawn/dllinterface.cpp
@@ -1791,8 +1791,6 @@ extern "C" __declspec(dllexport) bool __cdecl CNC_Save_Load(bool save,
             : Load_Game_Binary(file_path_and_name);
 
         if (result == false) {
-            MessageBoxA(
-                MainWindow, "Failed to load remaster save", "Command & Conquer", MB_ICONEXCLAMATION | MB_OK);
             CNC_LOG_ERROR("Failed to load remaster save");
 
             return false;

--- a/tiberiandawn/dllinterface.cpp
+++ b/tiberiandawn/dllinterface.cpp
@@ -1765,6 +1765,10 @@ extern "C" __declspec(dllexport) bool __cdecl CNC_Save_Load(bool save,
         result = Get_Bool_Rule(ENHANCEMENTS_SECTION, NEW_SAVE_GAME_FORMAT_RULE)
             ? Save_Game(file_path_and_name, "internal")
             : Save_Game_Binary(file_path_and_name, "internal");
+
+        if (result == false) {
+            CNC_LOG_ERROR("Failed to save remaster game");
+        }
     } else {
 
         if (game_type == NULL) {
@@ -1787,6 +1791,8 @@ extern "C" __declspec(dllexport) bool __cdecl CNC_Save_Load(bool save,
             : Load_Game_Binary(file_path_and_name);
 
         if (result == false) {
+            MessageBoxA(
+                MainWindow, "Failed to load remaster save", "Command & Conquer", MB_ICONEXCLAMATION | MB_OK);
             CNC_LOG_ERROR("Failed to load remaster save");
 
             return false;
@@ -7770,20 +7776,20 @@ void SaveGameRemasterState_v1::Read_Dll_State()
 {
     CNC_LOGGER_DEBUG("Reading DLL state into save data");
 
-    MultiplayerStartPositions = DLLExportClass::MultiplayerStartPositions;
+    RemasterMultiplayerStartPositions = DLLExportClass::MultiplayerStartPositions;
     RemasterPlayerIDs = DLLExportClass::GlyphxPlayerIDs;
     RemasterClientSidebarWidthInLeptons = GlyphXClientSidebarWidthInLeptons;
     RemasterMPlayerIsHuman = MPlayerIsHuman;
 
-    PlacementType = nlohmann::json::array();
+    RemasterPlacementType = nlohmann::json::array();
     for (const auto& building_type : DLLExportClass::PlacementType) {
-        PlacementType.emplace_back(TdTypeConverter::Techno_Type_To_Reference_Json(building_type));
+        RemasterPlacementType.emplace_back(TdTypeConverter::Techno_Type_To_Reference_Json(building_type));
     }
 
-    MultiplayerSidebars = nlohmann::json::array();
+    RemasterMultiplayerSidebars = nlohmann::json::array();
 
     for (const auto& sidebar : DLLExportClass::MultiplayerSidebars) {
-        MultiplayerSidebars.emplace_back(sidebar);
+        RemasterMultiplayerSidebars.emplace_back(sidebar);
     }
 
     RemasterSpecial = Special;
@@ -7797,11 +7803,11 @@ bool SaveGameRemasterState_v1::Validate() const
     auto result = true;
 
     std::map<std::string, nlohmann::json> player_fields = {
-        {NAMEOF(MultiplayerStartPositions), MultiplayerStartPositions},
+        {NAMEOF(RemasterMultiplayerStartPositions), RemasterMultiplayerStartPositions},
         {NAMEOF(RemasterPlayerIDs), RemasterPlayerIDs},
         {NAMEOF(RemasterMPlayerIsHuman), RemasterMPlayerIsHuman},
-        {NAMEOF(PlacementType), PlacementType},
-        {NAMEOF(MultiplayerSidebars), MultiplayerSidebars}
+        {NAMEOF(RemasterPlacementType), RemasterPlacementType},
+        {NAMEOF(RemasterMultiplayerSidebars), RemasterMultiplayerSidebars}
 };
 
     for (const auto& [field, json_value] : player_fields) {
@@ -7840,7 +7846,7 @@ bool SaveGameRemasterState_v1::Write_Dll_State() const
 
     CNC_LOGGER_DEBUG("Writing DLL state from save data");
 
-    from_json(MultiplayerStartPositions, DLLExportClass::MultiplayerStartPositions);
+    from_json(RemasterMultiplayerStartPositions, DLLExportClass::MultiplayerStartPositions);
     from_json(RemasterPlayerIDs, DLLExportClass::GlyphxPlayerIDs);
 
     GlyphXClientSidebarWidthInLeptons = RemasterClientSidebarWidthInLeptons;
@@ -7849,7 +7855,7 @@ bool SaveGameRemasterState_v1::Write_Dll_State() const
 
     for (auto i = 0; i < std::size(DLLExportClass::PlacementType); i++) {
         TdTypeConverter::Techno_Type_Target_From_Json<BuildingTypeClass, StructType>(
-            PlacementType.at(i),
+            RemasterPlacementType.at(i),
             std::format("RemasterState.{}", NAMEOF(PlacementType)),
             std::format("{}", i),
             DLLExportClass::PlacementType[i]
@@ -7857,7 +7863,7 @@ bool SaveGameRemasterState_v1::Write_Dll_State() const
     }
 
     for (auto i = 0; i < std::size(DLLExportClass::MultiplayerSidebars); i++) {
-        from_json(MultiplayerSidebars.at(i), DLLExportClass::MultiplayerSidebars[i]);
+        from_json(RemasterMultiplayerSidebars.at(i), DLLExportClass::MultiplayerSidebars[i]);
     }
 
     from_json(RemasterSpecial, Special);

--- a/tiberiandawn/dllinterface.cpp
+++ b/tiberiandawn/dllinterface.cpp
@@ -1762,7 +1762,9 @@ extern "C" __declspec(dllexport) bool __cdecl CNC_Save_Load(bool save,
     bool result = false;
 
     if (save) {
-        result = Save_Game(file_path_and_name, "internal");
+        result = Get_Bool_Rule(ENHANCEMENTS_SECTION, NEW_SAVE_GAME_FORMAT_RULE)
+            ? Save_Game(file_path_and_name, "internal")
+            : Save_Game_Binary(file_path_and_name, "internal");
     } else {
 
         if (game_type == NULL) {
@@ -1780,7 +1782,9 @@ extern "C" __declspec(dllexport) bool __cdecl CNC_Save_Load(bool save,
             }
         }
 
-        result = Load_Game(file_path_and_name);
+        result = Get_Bool_Rule(ENHANCEMENTS_SECTION, NEW_SAVE_GAME_FORMAT_RULE)
+            ? Load_Game(file_path_and_name)
+            : Load_Game_Binary(file_path_and_name);
 
         if (result == false) {
             CNC_LOG_ERROR("Failed to load remaster save");
@@ -7843,15 +7847,18 @@ bool SaveGameRemasterState_v1::Write_Dll_State() const
 
     from_json(RemasterMPlayerIsHuman, MPlayerIsHuman);
 
-    for (auto i = 0; i < PlacementType.size(); i++) {
+    for (auto i = 0; i < std::size(DLLExportClass::PlacementType); i++) {
         TdTypeConverter::Techno_Type_Target_From_Json<BuildingTypeClass, StructType>(
             PlacementType.at(i),
             std::format("RemasterState.{}", NAMEOF(PlacementType)),
             std::format("{}", i),
-            DLLExportClass::PlacementType[i]);
+            DLLExportClass::PlacementType[i]
+        );
     }
 
-    from_json(MultiplayerSidebars, DLLExportClass::MultiplayerSidebars);
+    for (auto i = 0; i < std::size(DLLExportClass::MultiplayerSidebars); i++) {
+        from_json(MultiplayerSidebars.at(i), DLLExportClass::MultiplayerSidebars[i]);
+    }
 
     from_json(RemasterSpecial, Special);
     Rule.AllowSuperWeapons = !NotAllowSuperWeapons;

--- a/tiberiandawn/function.h
+++ b/tiberiandawn/function.h
@@ -488,7 +488,7 @@ void Set_Scenario_Name(char* buf,
                        ScenarioDirType dir = SCEN_DIR_NONE,
                        ScenarioVarType var = SCEN_VAR_NONE);
 void Write_Scenario_Ini(char* root);
-bool Read_Scenario_Ini(char* root, bool fresh = true);
+bool Read_Scenario_Ini(char* root, SpecialClass special_options, bool allow_superweapons, bool fresh = true);
 bool Read_Scenario_Ini_File(char* scenario_file_name, char* bin_file_name, const char* root, bool fresh);
 int Scan_Place_Object(ObjectClass* obj, CELL cell);
 

--- a/tiberiandawn/init.cpp
+++ b/tiberiandawn/init.cpp
@@ -118,10 +118,10 @@ bool Init_Game(int, char*[])
         // TODO: Play commando death sound before this or mission failure message :D
         WWMessageBox().Process(err.c_str());
 
+        Prog_End(err.c_str(), false);
+
         // If a debugger is attached, trigger a breakpoint
         TRIGGER_DEBUGGER;
-
-        Prog_End(err.c_str(), false);
 
         if (!RunningAsDLL) {
             exit(1);

--- a/tiberiandawn/map.cpp
+++ b/tiberiandawn/map.cpp
@@ -1363,7 +1363,7 @@ bool MapClass::Write_Binary_Big(char const* root)
 void MapClass::Logic(void)
 {
     if (Debug_Force_Crash) {
-        *((int*)0) = 1;
+        Prog_End("Debug_Force_Crash was set to true", true);
     }
 
     /*

--- a/tiberiandawn/mapeddlg.cpp
+++ b/tiberiandawn/mapeddlg.cpp
@@ -232,7 +232,7 @@ int MapEditClass::Load_Scenario(void)
     /*
     ------------------------------ Read the INI ------------------------------
     */
-    if (Read_Scenario_Ini(Scen.ScenarioName) == 0) {
+    if (Read_Scenario_Ini(Scen.ScenarioName, Special, Rule.AllowSuperWeapons) == 0) {
         WWMessageBox().Process("Unable to read scenario!");
         HiddenPage.Clear();
         Flag_To_Redraw(true);

--- a/tiberiandawn/rules-nco.cpp.in
+++ b/tiberiandawn/rules-nco.cpp.in
@@ -58,25 +58,28 @@ RuleSections& SpecialClass::Read_Rules(RuleSections& rules)
 RuleSections& SpecialClass::Write_Rules(RuleSections& rules) const
 {
     // map
-    rules[GAME_MAP_SECTION].Set(TIBERIUM_GROWS_RULE, (bool)IsTGrowth);
-    rules[GAME_MAP_SECTION].Set(TIBERIUM_SPREADS_RULE, (bool)IsTSpread);
-    rules[GAME_MAP_SECTION].Set(SLOW_TIBERIUM_GROWTH_AND_SPREAD_RULE, !(bool)IsTFast);
+    rules[GAME_MAP_SECTION]
+        .Set(TIBERIUM_GROWS_RULE, static_cast<bool>(IsTGrowth))
+        .Set(TIBERIUM_SPREADS_RULE, static_cast<bool>(IsTSpread))
+        .Set(SLOW_TIBERIUM_GROWTH_AND_SPREAD_RULE, !static_cast<bool>(IsTFast));
 
     // misc
-    rules[GAME_MISC_SECTION].Set(SMART_DEFENSE_RULE, (bool)IsSmartDefense);
-    rules[GAME_MISC_SECTION].Set(TARGET_TREES_RULE, (bool)IsTreeTarget);
-    rules[GAME_MISC_SECTION].Set(MCV_REDEPLOYABLE_RULE, (bool)IsMCVDeploy);
-    rules[GAME_MISC_SECTION].Set(SPAWN_VISCEROIDS_RULE, (bool)IsVisceroids);
-    rules[GAME_MISC_SECTION].Set(VEHICLES_DO_THREE_POINT_TURNS_RULE, (bool)IsThreePoint);
-    rules[GAME_MISC_SECTION].Set(SHOW_BIBS_ON_BUILDINGS_RULE, !(bool)IsRoad);
-    rules[GAME_MISC_SECTION].Set(SHOW_CIVILIAN_NAMES_RULE, (bool)IsNamed);
-    rules[GAME_MISC_SECTION].Set(HELIPADS_AND_AIRCRAFT_BOUGHT_SEPARATELY_RULE, (bool)IsSeparate);
+    rules[GAME_MISC_SECTION]
+        .Set(SMART_DEFENSE_RULE, static_cast<bool>(IsSmartDefense))
+        .Set(TARGET_TREES_RULE, static_cast<bool>(IsTreeTarget))
+        .Set(MCV_REDEPLOYABLE_RULE, static_cast<bool>(IsMCVDeploy))
+        .Set(SPAWN_VISCEROIDS_RULE, static_cast<bool>(IsVisceroids))
+        .Set(VEHICLES_DO_THREE_POINT_TURNS_RULE, static_cast<bool>(IsThreePoint))
+        .Set(SHOW_BIBS_ON_BUILDINGS_RULE, !static_cast<bool>(IsRoad))
+        .Set(SHOW_CIVILIAN_NAMES_RULE, static_cast<bool>(IsNamed))
+        .Set(HELIPADS_AND_AIRCRAFT_BOUGHT_SEPARATELY_RULE, static_cast<bool>(IsSeparate));
 
     // cheats
-    rules[GAME_CHEATS_SECTION].Set(UNITS_ARE_INDESTRUCTIBLE_RULE, (bool)IsInert);
-    rules[GAME_CHEATS_SECTION].Set(INFANTRY_AUTO_SCATTERS_RULE, (bool)IsScatter);
-    rules[GAME_CHEATS_SECTION].Set(GIVE_ATTACKERS_AN_ADVANTAGE_RULE, !(bool)IsDefenderAdvantage);
-    rules[GAME_CHEATS_SECTION].Set(SPEEDY_SUPERWEAPONS_RULE, (bool)IsSpeedBuild);
+    rules[GAME_CHEATS_SECTION]
+        .Set(UNITS_ARE_INDESTRUCTIBLE_RULE, static_cast<bool>(IsInert))
+        .Set(INFANTRY_AUTO_SCATTERS_RULE, static_cast<bool>(IsScatter))
+        .Set(GIVE_ATTACKERS_AN_ADVANTAGE_RULE, !static_cast<bool>(IsDefenderAdvantage))
+        .Set(SPEEDY_SUPERWEAPONS_RULE, static_cast<bool>(IsSpeedBuild));
 
     return rules;
 }

--- a/tiberiandawn/rules-nco.cpp.in
+++ b/tiberiandawn/rules-nco.cpp.in
@@ -19,41 +19,70 @@ void RulesClass::Init_Sections(CCINIClass& ini)
     });
 }
 
-void RulesClass::Apply_Special_Properties() {
+RuleSections& SpecialClass::Read_Rules(RuleSections& rules)
+{
     // map
-    Special.IsTGrowth = Get_Bool_Rule(GAME_MAP_SECTION, TIBERIUM_GROWS_RULE);
-    Special.IsTSpread = Get_Bool_Rule(GAME_MAP_SECTION, TIBERIUM_SPREADS_RULE);
-    Special.IsTFast = !Get_Bool_Rule(GAME_MAP_SECTION, SLOW_TIBERIUM_GROWTH_AND_SPREAD_RULE);
+    IsTGrowth = rules[GAME_MAP_SECTION].Get<bool>(TIBERIUM_GROWS_RULE);
+    IsTSpread = rules[GAME_MAP_SECTION].Get<bool>(TIBERIUM_SPREADS_RULE);
+    IsTFast = !rules[GAME_MAP_SECTION].Get<bool>(SLOW_TIBERIUM_GROWTH_AND_SPREAD_RULE);
 
     // misc
-    Special.IsSmartDefense = Get_Bool_Rule(GAME_MISC_SECTION, SMART_DEFENSE_RULE);
-    Special.IsTreeTarget = Get_Bool_Rule(GAME_MISC_SECTION, TARGET_TREES_RULE);
-    Special.IsMCVDeploy = Get_Bool_Rule(GAME_MISC_SECTION, MCV_REDEPLOYABLE_RULE);
-    Special.IsVisceroids = Get_Bool_Rule(GAME_MISC_SECTION, SPAWN_VISCEROIDS_RULE);
-    Special.IsThreePoint = Get_Bool_Rule(GAME_MISC_SECTION, VEHICLES_DO_THREE_POINT_TURNS_RULE);
-    Special.IsRoad = !Get_Bool_Rule(GAME_MISC_SECTION, SHOW_BIBS_ON_BUILDINGS_RULE);
-    Special.IsNamed = Get_Bool_Rule(GAME_MISC_SECTION, SHOW_CIVILIAN_NAMES_RULE);
-    Special.IsSeparate = Get_Bool_Rule(GAME_MISC_SECTION, HELIPADS_AND_AIRCRAFT_BOUGHT_SEPARATELY_RULE);
+    IsSmartDefense = rules[GAME_MISC_SECTION].Get<bool>(SMART_DEFENSE_RULE);
+    IsTreeTarget = rules[GAME_MISC_SECTION].Get<bool>(TARGET_TREES_RULE);
+    IsMCVDeploy = rules[GAME_MISC_SECTION].Get<bool>(MCV_REDEPLOYABLE_RULE);
+    IsVisceroids = rules[GAME_MISC_SECTION].Get<bool>(SPAWN_VISCEROIDS_RULE);
+    IsThreePoint = rules[GAME_MISC_SECTION].Get<bool>(VEHICLES_DO_THREE_POINT_TURNS_RULE);
+    IsRoad = !rules[GAME_MISC_SECTION].Get<bool>(SHOW_BIBS_ON_BUILDINGS_RULE);
+    IsNamed = rules[GAME_MISC_SECTION].Get<bool>(SHOW_CIVILIAN_NAMES_RULE);
+    IsSeparate = rules[GAME_MISC_SECTION].Get<bool>(HELIPADS_AND_AIRCRAFT_BOUGHT_SEPARATELY_RULE);
 
     // cheats
-    Special.IsInert = Get_Bool_Rule(GAME_CHEATS_SECTION, UNITS_ARE_INDESTRUCTIBLE_RULE);
-    Special.IsScatter = Get_Bool_Rule(GAME_CHEATS_SECTION, INFANTRY_AUTO_SCATTERS_RULE);
-    Special.IsDefenderAdvantage = !Get_Bool_Rule(GAME_CHEATS_SECTION, GIVE_ATTACKERS_AN_ADVANTAGE_RULE);
-    Special.IsSpeedBuild = Get_Bool_Rule(GAME_CHEATS_SECTION, SPEEDY_SUPERWEAPONS_RULE);
+    IsInert = rules[GAME_CHEATS_SECTION].Get<bool>(UNITS_ARE_INDESTRUCTIBLE_RULE);
+    IsScatter = rules[GAME_CHEATS_SECTION].Get<bool>(INFANTRY_AUTO_SCATTERS_RULE);
+    IsDefenderAdvantage = !rules[GAME_CHEATS_SECTION].Get<bool>(GIVE_ATTACKERS_AN_ADVANTAGE_RULE);
+    IsSpeedBuild = rules[GAME_CHEATS_SECTION].Get<bool>(SPEEDY_SUPERWEAPONS_RULE);
 
     // TODO: Make rule and restore audio if missing
-    // Special.IsJuvenile = false;
+    // IsJuvenile = false;
 
     // TODO: Make rules for the below
-    // Special.IsVisibleTarget = false;
-    // Special.IsShowPath = false;
-    // Special.HealthBarDisplayMode = HB_SELECTED;
-    // Special.ResourceBarDisplayMode = RB_SELECTED;
-    // Special.ModernBalance = false;
+    // IsVisibleTarget = false;
+    // IsShowPath = false;
+    // HealthBarDisplayMode = HB_SELECTED;
+    // ResourceBarDisplayMode = RB_SELECTED;
+    // ModernBalance = false;
+
+    return rules;
+}
+
+RuleSections& SpecialClass::Write_Rules(RuleSections& rules) const
+{
+    // map
+    rules[GAME_MAP_SECTION].Set(TIBERIUM_GROWS_RULE, (bool)IsTGrowth);
+    rules[GAME_MAP_SECTION].Set(TIBERIUM_SPREADS_RULE, (bool)IsTSpread);
+    rules[GAME_MAP_SECTION].Set(SLOW_TIBERIUM_GROWTH_AND_SPREAD_RULE, !(bool)IsTFast);
+
+    // misc
+    rules[GAME_MISC_SECTION].Set(SMART_DEFENSE_RULE, (bool)IsSmartDefense);
+    rules[GAME_MISC_SECTION].Set(TARGET_TREES_RULE, (bool)IsTreeTarget);
+    rules[GAME_MISC_SECTION].Set(MCV_REDEPLOYABLE_RULE, (bool)IsMCVDeploy);
+    rules[GAME_MISC_SECTION].Set(SPAWN_VISCEROIDS_RULE, (bool)IsVisceroids);
+    rules[GAME_MISC_SECTION].Set(VEHICLES_DO_THREE_POINT_TURNS_RULE, (bool)IsThreePoint);
+    rules[GAME_MISC_SECTION].Set(SHOW_BIBS_ON_BUILDINGS_RULE, !(bool)IsRoad);
+    rules[GAME_MISC_SECTION].Set(SHOW_CIVILIAN_NAMES_RULE, (bool)IsNamed);
+    rules[GAME_MISC_SECTION].Set(HELIPADS_AND_AIRCRAFT_BOUGHT_SEPARATELY_RULE, (bool)IsSeparate);
+
+    // cheats
+    rules[GAME_CHEATS_SECTION].Set(UNITS_ARE_INDESTRUCTIBLE_RULE, (bool)IsInert);
+    rules[GAME_CHEATS_SECTION].Set(INFANTRY_AUTO_SCATTERS_RULE, (bool)IsScatter);
+    rules[GAME_CHEATS_SECTION].Set(GIVE_ATTACKERS_AN_ADVANTAGE_RULE, !(bool)IsDefenderAdvantage);
+    rules[GAME_CHEATS_SECTION].Set(SPEEDY_SUPERWEAPONS_RULE, (bool)IsSpeedBuild);
+
+    return rules;
 }
 
 void RulesClass::Apply_Static_And_Global_Values() {
-    Apply_Special_Properties();
+    Special.Read_Rules(Sections);
 
     FactoryClass::STEP_COUNT = Get_Int_Rule(GAME_FACTORIES_SECTION, TOTAL_PRODUCTION_STEPS_RULE);
 }

--- a/tiberiandawn/rules.cpp
+++ b/tiberiandawn/rules.cpp
@@ -267,7 +267,12 @@ void RulesClass::Init(CCINIClass& ini)
     Apply_Static_And_Global_Values();
 }
 
-void RulesClass::Init_For_Scenario(const ScenarioClass& scenario)
+void RulesClass::Init_For_Scenario(
+    const ScenarioClass& scenario,
+    const GameType& game_to_play,
+    const SpecialClass special_options,
+    const std::optional<bool> superweapons_allowed
+)
 {
     const std::string scenario_ini_file = scenario.FileName;
 
@@ -294,6 +299,12 @@ void RulesClass::Init_For_Scenario(const ScenarioClass& scenario)
 
     Init(ini);
     Init_Types(ini);
+
+    // ensure we restore any skirmish game options after reading rules
+    if (game_to_play == GAME_SKIRMISH || game_to_play == GAME_GLYPHX_MULTIPLAYER) {
+        special_options.Write_Rules(Sections);
+        AllowSuperWeapons = superweapons_allowed.value_or(AllowSuperWeapons);
+    }
 }
 
 /**

--- a/tiberiandawn/rules.h
+++ b/tiberiandawn/rules.h
@@ -287,6 +287,7 @@ public:
 
     /*
     **	Are superweapons allowed?
+    **  // TODO: Add to rules.ini
     */
     bool AllowSuperWeapons;
 

--- a/tiberiandawn/rules.h
+++ b/tiberiandawn/rules.h
@@ -310,7 +310,12 @@ public:
     void Init_Types();
     void Init_Types(CCINIClass& ini);
 
-    void Init_For_Scenario(const ScenarioClass& scenario);
+    void Init_For_Scenario(
+        const ScenarioClass& scenario,
+        const GameType& game_to_play,
+        SpecialClass special_options,
+        std::optional<bool> superweapons_allowed
+    );
 
     template<EnumSignedChar T>
     RuleSections& Get_Rule_Sections_For_Type()

--- a/tiberiandawn/savegame_v1.cpp
+++ b/tiberiandawn/savegame_v1.cpp
@@ -26,6 +26,9 @@ void SaveGameScenarioState_v1::Read_Globals()
     HasTempleBeenHitWithIonCannon = TempleIoned;
     AreThingiesEnabledFlag = AreThingiesEnabled;
 
+    MultiPlayerName = MPlayerName;
+    MultiPlayerPrefColor = TdTypeConverter::To_String(static_cast<PlayerColorType>(MPlayerPrefColor));
+    MultiPlayerHouse = TdTypeConverter::To_String(MPlayerHouse);
     MultiPlayerCount = MPlayerCount;
     MultiPlayerGhosts = MPlayerGhosts;
     MultiPlayerBases = MPlayerCount;
@@ -113,6 +116,25 @@ bool SaveGameScenarioState_v1::Validate(const GameType scenario_game_type) const
 
     if (!TdTypeConverter::Try_Parse<DiffType>(AiDifficulty).has_value()) {
         CNC_LOGGER_ERROR("Unable to parse ScenarioState.AiDifficulty save game value: {}", AiDifficulty);
+        result = false;
+    }
+
+    if (MultiPlayerName.size() > std::size(MPlayerName) - 1) {
+        CNC_LOGGER_ERROR(
+            "Invalid ScenarioState.MultiPlayerName save game value, expected string with maximum length of {} - actual size: {}",
+            std::size(MPlayerName) - 1,
+            MultiPlayerName.size()
+        );
+        result = false;
+    }
+
+    if (!TdTypeConverter::Try_Parse<PlayerColorType>(MultiPlayerPrefColor).has_value()) {
+        CNC_LOGGER_ERROR("Unable to parse ScenarioState.MultiPlayerPrefColor save game value: {}", MultiPlayerPrefColor);
+        result = false;
+    }
+
+    if (!TdTypeConverter::Try_Parse<HousesType>(MultiPlayerHouse).has_value()) {
+        CNC_LOGGER_ERROR("Unable to parse ScenarioState.MultiPlayerHouse save game value: {}", MultiPlayerHouse);
         result = false;
     }
 
@@ -254,6 +276,9 @@ bool SaveGameScenarioState_v1::Write_Globals() const
     TempleIoned = HasTempleBeenHitWithIonCannon;
     AreThingiesEnabled = AreThingiesEnabledFlag;
 
+    strcpy(MPlayerName, MultiPlayerName.c_str());
+    MPlayerPrefColor = TdTypeConverter::Try_Parse<PlayerColorType>(MultiPlayerPrefColor).value();
+    MPlayerHouse = TdTypeConverter::Try_Parse<HousesType>(MultiPlayerHouse).value();
     MPlayerCount = MultiPlayerCount;
     MPlayerGhosts = MultiPlayerGhosts;
     MPlayerCount = MultiPlayerBases;

--- a/tiberiandawn/savegame_v1.cpp
+++ b/tiberiandawn/savegame_v1.cpp
@@ -40,6 +40,8 @@ void SaveGameScenarioState_v1::Read_Globals()
     MultiPlayerLocalID = MPlayerLocalID;
     MultiPlayerIds = MPlayerID;
     MultiPlayerNames = MPlayerNames;
+    MultiSpecial = Special;
+    MultiSuperweaponsEnabled = !Rule.AllowSuperWeapons;
 
     MultiPlayerHouses = nlohmann::json::array();
     for (const auto& house : MPlayerHouses) {
@@ -186,6 +188,13 @@ bool SaveGameScenarioState_v1::Validate(const GameType scenario_game_type) const
         }
     }
 
+    if (!MultiSpecial.is_object()) {
+        result = false;
+        CNC_LOGGER_ERROR("Invalid ScenarioState.{} save game value - json object expected, actual type: {}",
+                         NAMEOF(MultiSpecial),
+                         MultiSpecial.type_name());
+    }
+
     // map state
     if (!SelectedObjects.is_object()) {
         CNC_LOGGER_ERROR(
@@ -242,6 +251,11 @@ ScenarioVarType SaveGameScenarioState_v1::Parse_Scenario_Variation() const
         ScenarioVariation,
         "Attempted to parse invalid ScenarioState.ScenarioVariation save game value: {}"
     );
+}
+
+SpecialClass SaveGameScenarioState_v1::Parse_MultiPlayer_Special() const
+{
+    return MultiSpecial;
 }
 
 bool SaveGameScenarioState_v1::Write_Globals() const
@@ -303,6 +317,8 @@ bool SaveGameScenarioState_v1::Write_Globals() const
 
         MPlayerHouses[i] = TdTypeConverter::Try_Parse<HousesType>(player_house).value();
     }
+
+    // MultiSpecial and MultiSuperweaponsEnabled are handled by saveload.cpp to not conflict with scenario rules logic
 
     from_json(SelectedObjects, CurrentObject);
     from_json(Waypoints, Scen.Waypoint);

--- a/tiberiandawn/savegame_v1.cpp
+++ b/tiberiandawn/savegame_v1.cpp
@@ -75,7 +75,10 @@ bool SaveGameScenarioState_v1::Validate(const GameType scenario_game_type) const
     for (const auto& [field, value] : stringFields) {
         const auto bufferSize = GlobalBufferSizes.at(field);
 
-        if (scenario_game_type == GAME_SKIRMISH && field == NAMEOF(BriefText)) {
+        if (
+            (scenario_game_type == GAME_SKIRMISH || scenario_game_type == GAME_GLYPHX_MULTIPLAYER)
+            && field == NAMEOF(BriefText)
+        ) {
             // don't validate briefing text for Skirmish scenarios
             continue;
         }

--- a/tiberiandawn/savegame_v1.h
+++ b/tiberiandawn/savegame_v1.h
@@ -62,6 +62,8 @@ public:
     nlohmann::json MultiPlayerIds;
     nlohmann::json MultiPlayerNames;
     nlohmann::json MultiPlayerHouses;
+    nlohmann::json MultiSpecial;
+    bool MultiSuperweaponsEnabled;
 
     // map state
 
@@ -73,6 +75,7 @@ public:
     bool Validate(GameType scenario_game_type) const;
     ScenarioDirType Parse_Scenario_Direction() const;
     ScenarioVarType Parse_Scenario_Variation() const;
+    SpecialClass Parse_MultiPlayer_Special() const;
     bool Write_Globals() const;
 
     NLOHMANN_DEFINE_TYPE_INTRUSIVE(
@@ -110,6 +113,8 @@ public:
         MultiPlayerIds,
         MultiPlayerNames,
         MultiPlayerHouses,
+        MultiSpecial,
+        MultiSuperweaponsEnabled,
         SelectedObjects,
         Waypoints,
         Views
@@ -192,8 +197,6 @@ public:
     nlohmann::json RemasterMPlayerIsHuman;
     nlohmann::json RemasterPlacementType;
     nlohmann::json RemasterMultiplayerSidebars;
-    nlohmann::json RemasterSpecial;
-    bool NotAllowSuperWeapons;
 
     void Read_Dll_State();
     bool Validate() const;
@@ -206,9 +209,7 @@ public:
         RemasterClientSidebarWidthInLeptons,
         RemasterMPlayerIsHuman,
         RemasterPlacementType,
-        RemasterMultiplayerSidebars,
-        RemasterSpecial,
-        NotAllowSuperWeapons
+        RemasterMultiplayerSidebars
     )
 
 private:

--- a/tiberiandawn/savegame_v1.h
+++ b/tiberiandawn/savegame_v1.h
@@ -47,6 +47,9 @@ public:
 
     // skirmish state
 
+    std::string MultiPlayerName;
+    std::string MultiPlayerPrefColor;
+    std::string MultiPlayerHouse;
     int MultiPlayerCount;
     int MultiPlayerGhosts;
     bool MultiPlayerBases;
@@ -92,6 +95,9 @@ public:
         EndCountdownNumber,
         HasTempleBeenHitWithIonCannon,
         AreThingiesEnabledFlag,
+        MultiPlayerName,
+        MultiPlayerPrefColor,
+        MultiPlayerHouse,
         MultiPlayerCount,
         MultiPlayerGhosts,
         MultiPlayerBases,

--- a/tiberiandawn/savegame_v1.h
+++ b/tiberiandawn/savegame_v1.h
@@ -180,13 +180,12 @@ private:
 class SaveGameRemasterState_v1
 {
 public:
-    nlohmann::json MultiplayerStartPositions;
+    nlohmann::json RemasterMultiplayerStartPositions;
     nlohmann::json RemasterPlayerIDs;
     int RemasterClientSidebarWidthInLeptons;
-    // TODO: Remove all MPlayer fields, these are absorbed into main save game sceanrio now
     nlohmann::json RemasterMPlayerIsHuman;
-    nlohmann::json PlacementType;
-    nlohmann::json MultiplayerSidebars;
+    nlohmann::json RemasterPlacementType;
+    nlohmann::json RemasterMultiplayerSidebars;
     nlohmann::json RemasterSpecial;
     bool NotAllowSuperWeapons;
 
@@ -196,12 +195,12 @@ public:
 
     NLOHMANN_DEFINE_TYPE_INTRUSIVE(
         SaveGameRemasterState_v1,
-        MultiplayerStartPositions,
+        RemasterMultiplayerStartPositions,
         RemasterPlayerIDs,
         RemasterClientSidebarWidthInLeptons,
         RemasterMPlayerIsHuman,
-        PlacementType,
-        MultiplayerSidebars,
+        RemasterPlacementType,
+        RemasterMultiplayerSidebars,
         RemasterSpecial,
         NotAllowSuperWeapons
     )

--- a/tiberiandawn/savegameresolver.cpp
+++ b/tiberiandawn/savegameresolver.cpp
@@ -60,7 +60,11 @@ std::optional<SaveGameHeader> SaveGameResolver::Load_Header(const std::string& p
     return header;
 }
 
-std::optional<SaveGameHeader> SaveGameResolver::Load(const std::string& path)
+std::optional<SaveGameHeader> SaveGameResolver::Load(
+    const std::string& path,
+    SpecialClass& skirmish_special,
+    bool& skirmish_superweapons_enabled
+)
 {
     SaveGameHeader header;
 
@@ -78,6 +82,9 @@ std::optional<SaveGameHeader> SaveGameResolver::Load(const std::string& path)
                     const auto header_globals_written = header.Write_Globals();
 
                     if (header_globals_written && save.Write_Globals()) {
+                        skirmish_special = save.ScenarioState.Parse_MultiPlayer_Special();
+                        skirmish_superweapons_enabled = save.ScenarioState.MultiSuperweaponsEnabled;
+
                         return header;
                     }
                 } catch (const CncJsonException& e) {

--- a/tiberiandawn/savegameresolver.h
+++ b/tiberiandawn/savegameresolver.h
@@ -46,9 +46,14 @@ public:
 
     /**
      * Attempt to load a save game from a file path. The save game version in the header
-     * will determine load behavior.
+     * will determine load behavior. References for skirmish options will be assigned values
+     * from save data.
      */
-    static std::optional<SaveGameHeader> Load(const std::string& path);
+    static std::optional<SaveGameHeader> Load(
+        const std::string& path,
+        SpecialClass& skirmish_special,
+        bool& skirmish_superweapons_enabled
+    );
 
 private:
     static inline const CncLogger Logger = CncLogger::For(SaveGameResolver);

--- a/tiberiandawn/saveload.cpp
+++ b/tiberiandawn/saveload.cpp
@@ -348,24 +348,17 @@ bool Load_Game(int id)
 
 /**
  * Ensure Rules from the scenario INI file recorded in the save game
- * are loaded. Also, init Lua runtime so all scripts are re-ran in prep
- * for continuing the scenario.
+ * are loaded and init Lua runtime so all scripts are re-ran in prep
+ * for continuing the scenario. If the save is from a Skirmish game
+ * we also apply the game options using Rules API.
  *
  * TODO: Pass flag to lua script so they know they are being called on save load (not fresh scenario)
  * TODO: Store RuleSections as map in save game, refactor RulesClass to accept this instead of INI file for scenario rules
  */
 static void Load_INI_Rules_And_Lua(const SpecialClass& skirmish_special, const bool& skirmish_superweapons_enabled)
 {
-    Rule.Init_For_Scenario(Scen);
+    Rule.Init_For_Scenario(Scen, GameToPlay, skirmish_special, skirmish_superweapons_enabled);
     ScenarioLua::On_Scenario_Load(GameToPlay, Scen, *PlayerPtr);
-
-    if (GameToPlay == GAME_GLYPHX_MULTIPLAYER || GameToPlay == GAME_SKIRMISH) {
-        CNC_LOG_WARN("Setting skirmish gameplay options using save data");
-
-        // ensure rules match skirmish game settings
-        skirmish_special.Write_Rules(Rule.Sections);
-        Rule.AllowSuperWeapons = skirmish_superweapons_enabled;
-    }
 }
 
 /*

--- a/tiberiandawn/saveload.cpp
+++ b/tiberiandawn/saveload.cpp
@@ -354,10 +354,18 @@ bool Load_Game(int id)
  * TODO: Pass flag to lua script so they know they are being called on save load (not fresh scenario)
  * TODO: Store RuleSections as map in save game, refactor RulesClass to accept this instead of INI file for scenario rules
  */
-static void Load_INI_Rules_And_Lua()
+static void Load_INI_Rules_And_Lua(const SpecialClass& skirmish_special, const bool& skirmish_superweapons_enabled)
 {
     Rule.Init_For_Scenario(Scen);
     ScenarioLua::On_Scenario_Load(GameToPlay, Scen, *PlayerPtr);
+
+    if (GameToPlay == GAME_GLYPHX_MULTIPLAYER || GameToPlay == GAME_SKIRMISH) {
+        CNC_LOG_WARN("Setting skirmish gameplay options using save data");
+
+        // ensure rules match skirmish game settings
+        skirmish_special.Write_Rules(Rule.Sections);
+        Rule.AllowSuperWeapons = skirmish_superweapons_enabled;
+    }
 }
 
 /*
@@ -374,12 +382,18 @@ bool Load_Game(const char* file_name)
     Leave_Zoomed_Resolution_Mode();
     Call_Back();
 
+    SpecialClass skirmish_special;
+    bool skirmish_superweapons_enabled;
+
+    const auto save_header = SaveGameResolver::Load(
 #ifndef REMASTER_BUILD
-    const auto save_header =
-        SaveGameResolver::Load(PathsClass::Concatenate_Paths(Paths.User_Save_Path(), file_name));
+        PathsClass::Concatenate_Paths(Paths.User_Save_Path(), file_name),
 #else
-    const auto save_header = SaveGameResolver::Load(file_name);
+        file_name,
 #endif
+        skirmish_special,
+        skirmish_superweapons_enabled
+    );
 
     if (!save_header.has_value()) {
         Set_Current_Resolution_Mode(resolution_mode);
@@ -453,7 +467,7 @@ bool Load_Game(const char* file_name)
 
     Fixup_Scenario();
 
-    Load_INI_Rules_And_Lua();
+    Load_INI_Rules_And_Lua(skirmish_special, skirmish_superweapons_enabled);
 
     ScenarioInit = 0;
 

--- a/tiberiandawn/scenario.cpp
+++ b/tiberiandawn/scenario.cpp
@@ -252,9 +252,14 @@ void Set_Scenario_Difficulty(int difficulty)
 bool Read_Scenario(char* root)
 {
     CCDebugString("C&C95 - In Read_Scenario.\n");
+
+    // capture any setup that was done for a skirmish scenario before clear
+    const auto special_options = Special;
+    const auto allow_superweapons = Rule.AllowSuperWeapons;
+
     Clear_Scenario();
     ScenarioInit++;
-    if (Read_Scenario_Ini(root)) {
+    if (Read_Scenario_Ini(root, special_options, allow_superweapons)) {
 
         Fill_In_Data();
 

--- a/tiberiandawn/scenarioini.cpp
+++ b/tiberiandawn/scenarioini.cpp
@@ -196,9 +196,13 @@ extern void GlyphX_Assign_Houses(void); // ST - 6/25/2019 11:08AM
  *    The remaining necessary interpolated data is generated elsewhere.                        *
  *                                                                                             *
  * INPUT:                                                                                      *
- *          root      root filename for scenario file to read                                  *
+ *          root                root filename for scenario file to read                        *
  *                                                                                             *
- *          fresh      true = should the current scenario be cleared?                          *
+ *          special_options     scenarion options to set for the scenario (skirmish only)      *
+ *                                                                                             *
+ *          allow_superweapons  true = allow superweapons for this scenario (skirmish only)    *
+ *                                                                                             *
+ *          fresh               true = should the current scenario be cleared?                 *
  *                                                                                             *
  * OUTPUT:  bool; Was the scenario read successful?                                            *
  *                                                                                             *
@@ -207,7 +211,7 @@ extern void GlyphX_Assign_Houses(void); // ST - 6/25/2019 11:08AM
  * HISTORY:                                                                                    *
  *   10/07/1992 JLB : Created.                                                                 *
  *=============================================================================================*/
-bool Read_Scenario_Ini(char* root, bool fresh)
+bool Read_Scenario_Ini(char* root, SpecialClass special_options, bool allow_superweapons, bool fresh)
 {
     char fname[_MAX_FNAME + _MAX_EXT]; // full INI filename
     char buf[128];                     // Working string staging buffer.
@@ -302,7 +306,7 @@ bool Read_Scenario_Ini(char* root, bool fresh)
     /**
      * Load any rule sections embedded in the scenario file.
      */
-    Rule.Init_For_Scenario(Scen);
+    Rule.Init_For_Scenario(Scen, GameToPlay, special_options, allow_superweapons);
 
     /*
     **	For single-player scenarios, 'BuildLevel' is the scenario number.

--- a/tiberiandawn/sidebarglyphx.cpp
+++ b/tiberiandawn/sidebarglyphx.cpp
@@ -871,5 +871,5 @@ FROM_JSON(SidebarGlyphxClass)
     );
 
     p.Column[0].Set_Parent_Sidebar(&p);
-    p.Column[0].Set_Parent_Sidebar(&p);
+    p.Column[1].Set_Parent_Sidebar(&p);
 }

--- a/tiberiandawn/special.h
+++ b/tiberiandawn/special.h
@@ -37,6 +37,7 @@
 
 #include "common/bitfields.h"
 #include "common/json.h"
+#include "common/rulesections.h"
 #include <stdint.h>
 
 #pragma pack(push, 1)
@@ -272,6 +273,16 @@ public:
     // Fixes issue from Change 738397 2020/07/17 14:06:03
     //
     //
+
+    /**
+     * Set values in this instance based on rule section values.
+     */
+    RuleSections& Read_Rules(RuleSections& rules);
+
+    /**
+     * Set rule section values based on values in this instance.
+     */
+    RuleSections& Write_Rules(RuleSections& rules) const;
 
     JSON_FUNCTIONS(SpecialClass)
 };

--- a/tiberiandawn/startup.cpp
+++ b/tiberiandawn/startup.cpp
@@ -101,6 +101,8 @@ BOOL WINAPI DllMain(HINSTANCE instance, unsigned int fdwReason, void* lpvReserve
 
         Uninit_Game();
 
+        spdlog::shutdown();
+
         break;
 
     case DLL_THREAD_ATTACH:


### PR DESCRIPTION
Remaster skirmish saves caused a crash on load. This was due to globals being used instead of instance fields for JSON save remaster data. Additionally scenario options were not correctly restored on remaster save load, to fix this and enable the same functionality for non-remaster, these JSON save game fields were moved to `SaveGameScenarioState_v1`.

 `SpecialClass` was updated to have methods similar to types for read/write rules to the Rules API directly, so a parsed instance from JSON save game can be quickly have it's options loaded, and reuse the same code as the Rules API.

Additionally remaster TD only ever used JSON save games, ignoring the rules.ini enhancement rule - this has been updated to behave as non-remaster build does.

## Feature

- **common**: Use `flush_on` to trigger a flush if error/critical occurs (info or higher in remaster)
- **common**: Disable console logger in remaster (no stdout)
- **td**: Record special options in skirmish save and restore on load

## Fixes

- **remaster-td**: `BriefText` incorrectly validated for skirmish saves
- **remaster-td**: Sidebar columns not restored on skirmish save game load (nullptr crash)
- **remaster-td**: Save game enhancement rule not respected for save/load
- **remaster-td**: Global vars used instead of instance fields for remaster save data
- **td**: Special options for skirmish not captured, rules reset to INI settings/defaults instead
- **td**: Debug force crash too agressive
- **td**: Capture more skirmish info in save (name, colour, house) to make dialog restore correctly