### PR TITLE
fix(common): Center mouse on zoom in/out

### DIFF
--- a/common/video_sdl2.cpp
+++ b/common/video_sdl2.cpp
@@ -48,6 +48,13 @@
 
 #include <SDL.h>
 
+// C&C 95 Resolution
+static constexpr auto DefaultWidth = 640;
+static constexpr auto DefaultHeight = 400;
+// C&C DOS Resolution
+static constexpr auto DefaultDosWidth = DefaultWidth / 2;
+static constexpr auto DefaultDosHeight = DefaultHeight / 2;
+
 extern WWKeyboardClass* Keyboard;
 static SDL_Window* window;
 static SDL_Renderer* renderer;
@@ -135,11 +142,11 @@ static void Update_HWCursor_Settings()
         hwcursor.GameW = Settings.Video.Width;
         hwcursor.GameH = Settings.Video.Height;
     } else if (resolution_mode == MODE_DEFAULT) {
-        hwcursor.GameW = 640;
-        hwcursor.GameH = 400;
+        hwcursor.GameW = DefaultWidth;
+        hwcursor.GameH = DefaultHeight;
     } else if (resolution_mode == MODE_DOS) {
-        hwcursor.GameW = 320;
-        hwcursor.GameH = 200;
+        hwcursor.GameW = DefaultDosWidth;
+        hwcursor.GameH = DefaultDosHeight;
     }
 
     hwcursor.ScaleX = win_w / (float)hwcursor.GameW;
@@ -515,21 +522,8 @@ void Move_Video_Mouse(float xrel, float yrel)
 
 void Move_Video_Mouse_Absolute(const int x, const int y)
 {
-    if (x == 0 && y == 0) {
-        hwcursor.X = x;
-        hwcursor.Y = y;
-        return;
-    }
-
-    Move_Video_Mouse_Absolute(0, 0);
-
-    for (auto i = 0; i < x; i++) {
-        Move_Video_Mouse(i, 0);
-    }
-
-    for (auto j = 0; j < y; j++) {
-        Move_Video_Mouse(x, j);
-    }
+    hwcursor.X = x;
+    hwcursor.Y = y;
 }
 
 void Get_Video_Mouse(int& x, int& y)
@@ -935,8 +929,8 @@ public:
 
             src_rect->x = 0;
             src_rect->y = 0;
-            src_rect->w = 640;
-            src_rect->h = 400;
+            src_rect->w = DefaultWidth;
+            src_rect->h = DefaultHeight;
         }
 
         SDL_RenderCopy(renderer, texture, src_rect.get(), &render_dst);
@@ -1009,7 +1003,7 @@ std::optional<int> Try_Get_Resolution_Mode_Width()
     }
 
     if (Get_Current_Resolution_Mode() == MODE_ZOOM) {
-        return 640;
+        return DefaultWidth;
     }
 
     return frontSurface->GetWidth();
@@ -1022,7 +1016,7 @@ std::optional<int> Try_Get_Resolution_Mode_Height()
     }
 
     if (Get_Current_Resolution_Mode() == MODE_ZOOM) {
-        return 400;
+        return DefaultHeight;
     }
 
     return frontSurface->GetHeight();
@@ -1038,7 +1032,9 @@ void Enter_Zoomed_Resolution_Mode()
     }
 
     Set_Current_Resolution_Mode(MODE_ZOOM);
-    Move_Video_Mouse_Absolute(0, 0);
+
+    // center mouse in zoomed view
+    Move_Video_Mouse_Absolute(DefaultWidth / 2, DefaultHeight / 2);
 }
 
 void Leave_Zoomed_Resolution_Mode()
@@ -1051,4 +1047,12 @@ void Leave_Zoomed_Resolution_Mode()
     }
 
     Set_Current_Resolution_Mode(MODE_HIGH_RES);
+
+    if (frontSurface == nullptr) {
+        CNC_LOG_WARN("Failed to center mouse due to uninitialised video surface");
+        return;
+    }
+
+    // center mouse on screen
+    Move_Video_Mouse_Absolute(frontSurface->GetWidth() / 2, frontSurface->GetHeight() / 2);
 }

--- a/common/video_sdl2.cpp
+++ b/common/video_sdl2.cpp
@@ -500,24 +500,35 @@ void Set_Video_Cursor_Clip(bool clipped)
     }
 }
 
-void Move_Video_Mouse(float xrel, float yrel)
+void Move_Video_Mouse(const float xrel, const float yrel)
 {
+    auto next_x = hwcursor.X;
+    auto next_y = hwcursor.Y;
+
     if (Keyboard->Is_Gamepad_Active() || hwcursor.Clip || !Settings.Video.Windowed) {
-        hwcursor.X += xrel * (Settings.Mouse.Sensitivity / 100.0f);
-        hwcursor.Y += yrel * (Settings.Mouse.Sensitivity / 100.0f);
+        next_x += xrel * (Settings.Mouse.Sensitivity / 100.0f);
+        next_y += yrel * (Settings.Mouse.Sensitivity / 100.0f);
     }
 
-    if (hwcursor.X >= hwcursor.GameW) {
-        hwcursor.X = hwcursor.GameW - 1;
-    } else if (hwcursor.X < 0) {
-        hwcursor.X = 0;
+    if (next_x >= hwcursor.GameW) {
+        next_x = hwcursor.GameW - 1;
+    } else if (next_x < 0) {
+        next_x = 0;
     }
 
-    if (hwcursor.Y >= hwcursor.GameH) {
-        hwcursor.Y = hwcursor.GameH - 1;
-    } else if (hwcursor.Y < 0) {
-        hwcursor.Y = 0;
+    if (next_y >= hwcursor.GameH) {
+        next_y = hwcursor.GameH - 1;
+    } else if (next_y < 0) {
+        next_y = 0;
     }
+
+    if (Get_Current_Resolution_Mode() == MODE_ZOOM && (next_x > 639 || next_y > 399)) {
+        // prevent mouse leaving screen in zoom mode
+        return;
+    }
+
+    hwcursor.X = next_x;
+    hwcursor.Y = next_y;
 }
 
 void Move_Video_Mouse_Absolute(const int x, const int y)

--- a/wiki/4.Planned-Features.md
+++ b/wiki/4.Planned-Features.md
@@ -33,9 +33,13 @@ As I decide what items to work on next, I'll add a feature request to this repo 
 
 ## Tiberian Dawn
 
-- Persist skirmish/lan options in conquer.ini -> `[MultiPlayer]`
-  - 'Remember' last settings basically
-  - Fall back on Game.Multiplayer rules for default values
+- Enhancement to choose the strategy for the AI finding a target
+  - Instead of always defaulting to 'Most north unit'
+  - In the case of superweapons, this is instead of 'Most valuable thing, searching from the north'
+  - Could have more enhancements that remove 'cheese' strats from the game
+- Press `T` to select all instance of the select object type on screen (aircraft/infantry/units)
+- Persist all skirmish/lan options in conquer.ini -> `[MultiPlayer]`
+  - Partially implemented int `TiberianDawnSettings` class
 - Syncing rule ini files
   - Add missing sections/rules, but leave existing values alone
   - Ignore unrecognized sections/rules, just log a warning


### PR DESCRIPTION
## Fixes

common: Ensure mouse is centered on zoom in/out to prevent scrolling on mission start
common: Prevent mouse leaving the screen in zoom mode