### PR TITLE
feat(td): T key selects all of selected type

### DIFF
--- a/tiberiandawn/conquer.cpp
+++ b/tiberiandawn/conquer.cpp
@@ -60,6 +60,7 @@
 
 #include "function.h"
 #include "common/irandom.h"
+#include <algorithm>
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
@@ -395,6 +396,48 @@ void Main_Game(int argc, char* argv[])
 #endif
 }
 
+static signed char Get_Selectable_Object_Instance_Id(ObjectClass* object)
+{
+    if (object->What_Am_I() == RTTI_AIRCRAFT) {
+        return dynamic_cast<AircraftClass*>(object)->Class->Type;
+    }
+
+    if (object->What_Am_I() == RTTI_UNIT) {
+        return dynamic_cast<UnitClass*>(object)->Class->Type;
+    }
+
+    if (object->What_Am_I() == RTTI_INFANTRY) {
+        return dynamic_cast<InfantryClass*>(object)->Class->Type;
+    }
+
+    return -1;
+}
+
+// BUG: Filter out non-player owned selected objects
+static void Select_Objects_Of_Same_Type()
+{
+    const auto first_tech = CurrentObject[0];
+    const auto first_type = first_tech->What_Am_I();
+    const auto first_instance = Get_Selectable_Object_Instance_Id(first_tech);
+
+    // unsupported type
+    if (first_instance == -1) {
+        return;
+    }
+
+    // If more than one object is selected, validate they are all the same type. If not, do nothing.
+    for (auto index = 1; index < CurrentObject.Count(); index++) {
+        const auto tech = CurrentObject[index];
+
+        if (tech->What_Am_I() != first_type || Get_Selectable_Object_Instance_Id(tech) != first_instance) {
+            // mixed types selected, so can't determine type to select
+            return;
+        }
+    }
+
+    OutList.Add(EventClass(EventClass::SELECT_ALL_OF_TYPE, first_type, first_instance));
+}
+
 /***********************************************************************************************
  * Keyboard_Process -- Processes the tactical map input codes.                                 *
  *                                                                                             *
@@ -598,16 +641,15 @@ void Keyboard_Process(KeyNumType& input)
         }
     }
 
-    if (key != 0 && (key == Options.KeyDeploy)) {
-        if (CurrentObject.Count()) {
-            for (index = 0; index < CurrentObject.Count(); index++) {
-                ObjectClass const* tech = CurrentObject[index];
+    if (key != 0 && key == Options.KeyDeploy && CurrentObject.Count()) {
+        for (index = 0; index < CurrentObject.Count(); index++) {
+            const auto tech = CurrentObject[index];
 
-                if (tech != NULL && tech->Can_Player_Move()) {
-                    OutList.Add(EventClass(EventClass::DEPLOY, tech->As_Target()));
-                }
+            if (tech != nullptr && tech->Can_Player_Move()) {
+                OutList.Add(EventClass(EventClass::DEPLOY, tech->As_Target()));
             }
         }
+
         input = KN_NONE;
     }
 
@@ -692,8 +734,11 @@ void Keyboard_Process(KeyNumType& input)
     /*
     **	Toggles the repair state similarly to pressing the repair button.
     */
-    if (key != 0 && key == Options.KeyRepair) {
+    if (key != 0 && key == Options.KeyRepair && CurrentObject.Count() < 1) {
         Map.Repair_Mode_Control(-1);
+        input = KN_NONE;
+    } else if (key != 0 && key == Options.KeySelectAllOfType && CurrentObject.Count() > 0) {
+        Select_Objects_Of_Same_Type();
         input = KN_NONE;
     }
 

--- a/tiberiandawn/conquer.cpp
+++ b/tiberiandawn/conquer.cpp
@@ -399,28 +399,30 @@ void Main_Game(int argc, char* argv[])
 static signed char Get_Selectable_Object_Instance_Id(ObjectClass* object)
 {
     if (object->What_Am_I() == RTTI_AIRCRAFT) {
-        return dynamic_cast<AircraftClass*>(object)->Class->Type;
+        const auto aircraft = dynamic_cast<AircraftClass*>(object);
+        return aircraft->Is_Owned_By_Player() ? aircraft->Class->Type : -1;
     }
 
     if (object->What_Am_I() == RTTI_UNIT) {
-        return dynamic_cast<UnitClass*>(object)->Class->Type;
+        const auto unit = dynamic_cast<UnitClass*>(object);
+        return unit->Is_Owned_By_Player() ? unit->Class->Type : -1;
     }
 
     if (object->What_Am_I() == RTTI_INFANTRY) {
-        return dynamic_cast<InfantryClass*>(object)->Class->Type;
+        const auto infantry = dynamic_cast<InfantryClass*>(object);
+        return infantry->Is_Owned_By_Player() ? infantry->Class->Type : -1;
     }
 
     return -1;
 }
 
-// BUG: Filter out non-player owned selected objects
 static void Select_Objects_Of_Same_Type()
 {
     const auto first_tech = CurrentObject[0];
     const auto first_type = first_tech->What_Am_I();
     const auto first_instance = Get_Selectable_Object_Instance_Id(first_tech);
 
-    // unsupported type
+    // unsupported type (or not owned by player)
     if (first_instance == -1) {
         return;
     }

--- a/tiberiandawn/conquer.cpp
+++ b/tiberiandawn/conquer.cpp
@@ -60,7 +60,6 @@
 
 #include "function.h"
 #include "common/irandom.h"
-#include <algorithm>
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>

--- a/tiberiandawn/event.cpp
+++ b/tiberiandawn/event.cpp
@@ -347,6 +347,27 @@ EventClass::EventClass(EventType type, int id, CELL cell)
     Data.Special.Cell = cell;
 }
 
+template<class T, class U>
+static void Select_Objects_Of_Type(TFixedIHeapClass<T>& object_heap, U instance)
+{
+    Unselect_All();
+
+    for (auto i = 0; i < object_heap.Count(); i++) {
+        auto object = object_heap.Ptr(i);
+        auto location = Coord_Cell(object->Coord);
+
+        if (
+            object->Is_Owned_By_Player() &&
+            object->Class->Type == instance &&
+            !object->IsInLimbo &&
+            Map.In_View(location) // BUG: This doesn't respect the actual resolution (fixed width and height check)
+        ) {
+            object->Select();
+        }
+    }
+}
+
+
 /***********************************************************************************************
  * EventClass::Execute -- Execute a queued command.                                            *
  *                                                                                             *
@@ -769,6 +790,24 @@ void EventClass::Execute(void)
                 Map.Flag_To_Redraw(true);
             }
         }
+        break;
+
+    case SELECT_ALL_OF_TYPE:
+        // collect objects of the same type
+        if (Data.Specific.Type == RTTI_AIRCRAFT) {
+            Select_Objects_Of_Type<AircraftClass, AircraftType>(
+                Aircraft, static_cast<AircraftType>(Data.Specific.ID)
+            );
+        } else if (Data.Specific.Type == RTTI_UNIT) {
+            Select_Objects_Of_Type<UnitClass, UnitType>(
+                Units, static_cast<UnitType>(Data.Specific.ID)
+            );
+        } else if (Data.Specific.Type == RTTI_INFANTRY) {
+            Select_Objects_Of_Type<InfantryClass, InfantryType>(
+                Infantry, static_cast<InfantryType>(Data.Specific.ID)
+            );
+        }
+
         break;
 
     /*

--- a/tiberiandawn/event.cpp
+++ b/tiberiandawn/event.cpp
@@ -369,7 +369,6 @@ static void Select_Objects_Of_Type(TFixedIHeapClass<T>& object_heap, const U ins
     }
 }
 
-
 /***********************************************************************************************
  * EventClass::Execute -- Execute a queued command.                                            *
  *                                                                                             *
@@ -795,8 +794,6 @@ void EventClass::Execute(void)
         break;
 
     case SELECT_ALL_OF_TYPE:
-        ObjectClass* a;
-
         // collect objects of the same type
         if (Data.Specific.Type == RTTI_AIRCRAFT) {
             Select_Objects_Of_Type<AircraftClass, AircraftType>(

--- a/tiberiandawn/event.cpp
+++ b/tiberiandawn/event.cpp
@@ -348,21 +348,23 @@ EventClass::EventClass(EventType type, int id, CELL cell)
 }
 
 template<class T, class U>
-static void Select_Objects_Of_Type(TFixedIHeapClass<T>& object_heap, U instance)
+static void Select_Objects_Of_Type(TFixedIHeapClass<T>& object_heap, const U instance_type)
 {
     Unselect_All();
 
     for (auto i = 0; i < object_heap.Count(); i++) {
         auto object = object_heap.Ptr(i);
-        auto location = Coord_Cell(object->Coord);
 
-        if (
-            object->Is_Owned_By_Player() &&
-            object->Class->Type == instance &&
-            !object->IsInLimbo &&
-            Map.In_View(location) // BUG: This doesn't respect the actual resolution (fixed width and height check)
-        ) {
-            object->Select();
+        // if object matches the instance_type, is owned by the played and is selectable...
+        if (object->Is_Owned_By_Player() && object->Class->Type == instance_type && !object->IsInLimbo) {
+            int x = -1;
+            int y = -1;
+
+            // and object is on visible on the screen...
+            if (Map.Coord_To_Pixel(object->Coord, x, y) && x > -1 && y > -1) {
+                // then select it
+                object->Select();
+            }
         }
     }
 }
@@ -793,6 +795,8 @@ void EventClass::Execute(void)
         break;
 
     case SELECT_ALL_OF_TYPE:
+        ObjectClass* a;
+
         // collect objects of the same type
         if (Data.Specific.Type == RTTI_AIRCRAFT) {
             Select_Objects_Of_Type<AircraftClass, AircraftType>(

--- a/tiberiandawn/event.h
+++ b/tiberiandawn/event.h
@@ -88,6 +88,8 @@ public:
 
         SET_RALLY,     // rally point support
 
+        SELECT_ALL_OF_TYPE, // select objects based on type
+
         LAST_EVENT,    // one past the last event
     } EventType;
 

--- a/tiberiandawn/expand.cpp
+++ b/tiberiandawn/expand.cpp
@@ -122,44 +122,25 @@ bool Expansion_Dialog(void)
     int index;
     INIClass ini;
 
-    // TODO: combine into one loop like mission select
-    for (index = 20; index < 60; index++) {
-        char buffer[128];
-        CCFileClass file;
+    for (const auto& player : { SCEN_PLAYER_GDI, SCEN_PLAYER_NOD }) {
+        for (index = 20; index < 60; index++) {
+            char buffer[128];
+            CCFileClass file;
 
-        Set_Scenario_Name(buffer, index, SCEN_PLAYER_GDI, SCEN_DIR_EAST, SCEN_VAR_A);
-        strcat(buffer, ".INI");
-        file.Set_Name(buffer);
-        if (file.Is_Available()) {
-            ini.Clear();
-            ini.Load(file);
-            ini.Get_String("Basic", "Name", "x", buffer, sizeof(buffer));
+            Set_Scenario_Name(buffer, index, player, SCEN_DIR_EAST, SCEN_VAR_A);
+            strcat(buffer, ".INI");
+            file.Set_Name(buffer);
+            if (file.Is_Available()) {
+                ini.Clear();
+                ini.Load(file);
+                ini.Get_String("Basic", "Name", "x", buffer, sizeof(buffer));
 
-            char* data = new char[strlen(buffer) + 1 + sizeof(int) + 25];
-            *((int*)&data[0]) = index;
-            strcpy(&data[sizeof(int)], "GDI: ");
-            strcat(&data[sizeof(int)], buffer);
-            list.Add_Item(data);
-        }
-    }
-
-    for (index = 20; index < 60; index++) {
-        char buffer[128];
-        CCFileClass file;
-
-        Set_Scenario_Name(buffer, index, SCEN_PLAYER_NOD, SCEN_DIR_EAST, SCEN_VAR_A);
-        strcat(buffer, ".INI");
-        file.Set_Name(buffer);
-        if (file.Is_Available()) {
-
-            ini.Clear();
-            ini.Load(file);
-            ini.Get_String("Basic", "Name", "x", buffer, sizeof(buffer));
-            char* data = new char[strlen(buffer) + 1 + sizeof(int) + 25];
-            *((int*)&data[0]) = index;
-            strcpy(&data[sizeof(int)], "NOD: ");
-            strcat(&data[sizeof(int)], buffer);
-            list.Add_Item(data);
+                char* data = new char[strlen(buffer) + 1 + sizeof(int) + 25];
+                *((int*)&data[0]) = index;
+                strcpy(&data[sizeof(int)], player == SCEN_PLAYER_GDI ? "GDI: " : "NOD: ");
+                strcat(&data[sizeof(int)], buffer);
+                list.Add_Item(data);
+            }
         }
     }
 

--- a/tiberiandawn/options.cpp
+++ b/tiberiandawn/options.cpp
@@ -132,6 +132,7 @@ OptionsClass::OptionsClass(void)
     , KeyTeam9(KN_9)
     , KeyTeam10(KN_0)
     , KeyDeploy(KN_D)
+    , KeySelectAllOfType(KN_T)
 {
     GameSpeed = TIMER_SECOND / TICKS_PER_SECOND;
     ScrollRate = TIMER_SECOND / TICKS_PER_SECOND;
@@ -631,6 +632,7 @@ void OptionsClass::Load_Settings(void)
     KeyTeam8 = (KeyNumType)ini.Get_Int(HotkeyName, "KeyTeam8", KeyTeam8);
     KeyTeam9 = (KeyNumType)ini.Get_Int(HotkeyName, "KeyTeam9", KeyTeam9);
     KeyTeam10 = (KeyNumType)ini.Get_Int(HotkeyName, "KeyTeam10", KeyTeam10);
+    KeyDeploy = (KeyNumType)ini.Get_Int(HotkeyName, "KeyDeploy", KeyDeploy);
 
     KeyForceMove1 = (KeyNumType)(KeyForceMove1 & ~WWKEY_VK_BIT);
     KeyForceMove2 = (KeyNumType)(KeyForceMove2 & ~WWKEY_VK_BIT);
@@ -681,6 +683,7 @@ void OptionsClass::Load_Settings(void)
     KeyTeam8 = (KeyNumType)(KeyTeam8 & ~WWKEY_VK_BIT);
     KeyTeam9 = (KeyNumType)(KeyTeam9 & ~WWKEY_VK_BIT);
     KeyTeam10 = (KeyNumType)(KeyTeam10 & ~WWKEY_VK_BIT);
+    KeyDeploy = (KeyNumType)(KeyDeploy & ~WWKEY_VK_BIT);
 
     char workbuf[128];
 
@@ -877,6 +880,7 @@ void OptionsClass::Save_Settings(INIClass& ini)
     ini.Put_Int(HotkeyName, "KeyTeam8", KeyTeam8);
     ini.Put_Int(HotkeyName, "KeyTeam9", KeyTeam9);
     ini.Put_Int(HotkeyName, "KeyTeam10", KeyTeam10);
+    ini.Put_Int(HotkeyName, "KeyDeploy", KeyDeploy);
 }
 
 void OptionsClass::Save_Settings()

--- a/tiberiandawn/options.h
+++ b/tiberiandawn/options.h
@@ -147,6 +147,7 @@ public:
     KeyNumType KeyTeam9;
     KeyNumType KeyTeam10;
     KeyNumType KeyDeploy;
+    KeyNumType KeySelectAllOfType;
 
 protected:
     void Adjust_Palette(void* oldpal,


### PR DESCRIPTION
Allow selecting all units on screen of the same type as the currently selected unit, in Tiberian Dawn. Similar behavior to later C&C games. Default key binding is the 'T' key (can be adjusted in `CONQUER.INI`).

## Features

- td: Select all units on screen of the same type with the 'T' key
- td: Refactor `New Missions` screen logic to reduce code bloat
 