### PR TITLE
feat(td): Implement Some Missing NCO Rules

### DIFF
--- a/cmake/NcoTypes.cmake
+++ b/cmake/NcoTypes.cmake
@@ -223,7 +223,7 @@ function(Main)
 
       message(STATUS "[NcoTypeRules] Processing property #${PROP_INDEX}: ${PROP_NAME} (type=${PROP_TYPE})")
 
-      if (NOT ${PROP_COMMENT} STREQUAL "-") # ignore placeholder comments
+      if (NOT "${PROP_COMMENT}" STREQUAL "-") # ignore placeholder comments
         string(APPEND LOAD_COMMENTS_CODE "\n        ")
         string(APPEND LOAD_COMMENTS_CODE ".Set_Var_Comment(${PROP_NAME}, \"${PROP_COMMENT}\")")
       endif()

--- a/common/json.cpp
+++ b/common/json.cpp
@@ -2,6 +2,122 @@
 
 #include <format>
 
+#include <magic_enum/magic_enum.hpp>
+
+#include "stringutils.h"
+
+std::string CncJsonUtils::Build_Type_Error(const std::string& expected_type, const nlohmann::json& subject)
+{
+    return std::format("expected {}, actual type: {}", expected_type, subject.type_name());
+}
+
+std::string CncJsonUtils::Build_Parse_Error(
+    const std::string& attempted_parse_type,
+    const std::string& subject,
+    const std::string_view& error
+)
+{
+    return std::format(
+        "unable to parse as {}, json value: {} | error = {}",
+        attempted_parse_type,
+        subject,
+        error
+    );
+}
+
+
+void CncJsonUtils::Assert_Json_Is_Object_With_Keys(
+    const nlohmann::json& subject,
+    const std::string& json_path,
+    const std::vector<std::string>& expected_keys
+)
+{
+    Assert_Json_Is<JsonObject>(subject, json_path);
+
+    std::vector<std::string> missing_keys;
+
+    for (const auto& key : expected_keys) {
+        if (!subject.contains(key)) {
+            missing_keys.push_back(key);
+        }
+    }
+
+    if (missing_keys.empty()) {
+        return;
+    }
+
+    std::vector<std::string> actual_keys;
+
+    for (const auto& [key, _] : subject.items()) {
+        actual_keys.emplace_back(key);
+    }
+
+    Throw_Json_Assert_Failure(
+        json_path,
+        "expected object with keys '{}', actual keys: {}",
+        CncStringUtils::To_Csv(expected_keys),
+        CncStringUtils::To_Csv(actual_keys)
+    );
+}
+
+void CncJsonUtils::Assert_Json_Is_Object_With_Keys_And_Types(
+    const nlohmann::json& subject,
+    const std::string& json_path,
+    const std::vector<std::string>& expected_keys,
+    const std::unordered_map<std::string, nlohmann::json::value_t>& expected_types
+)
+{
+    Assert_Json_Is_Object_With_Keys(subject, json_path, expected_keys);
+
+    std::unordered_map<std::string, nlohmann::json::value_t> invalid_types;
+
+    for (const auto& [ key, expected_type ] : expected_types) {
+        if (expected_type == NotNullJsonType && !subject[key].is_null()) {
+            // custom not null check
+            continue;
+        }
+
+        const auto actual_type = subject[key].type();
+
+        if (actual_type != expected_type) {
+            invalid_types[key] = actual_type;
+        }
+    }
+
+    if (invalid_types.empty()) {
+        return;
+    }
+
+    // use magic_enum to lookup names for json type enum
+    static constexpr auto json_types_enums = magic_enum::enum_entries<nlohmann::json::value_t>();
+    static const auto json_type_names = std::unordered_map(json_types_enums.begin(), json_types_enums.end());
+
+    std::vector<std::string> invalid_keys;
+
+    for (const auto& [ key, invalid_type ] : invalid_types) {
+        const auto& expected_type = expected_types.at(key);
+        const auto expected_type_name = expected_type == NotNullJsonType
+            ? "not null"
+            : json_type_names.at(expected_type);
+        const auto actual_type_name = json_type_names.at(invalid_type);
+
+        invalid_keys.emplace_back(
+            std::format(
+                "expected '.{}' to be of type '{}' - actual type: {}",
+                key,
+                expected_type_name,
+                actual_type_name
+            )
+        );
+    }
+
+    Throw_Json_Assert_Failure(
+        json_path,
+        "expected object with correct key types: {}",
+        CncStringUtils::To_Csv(invalid_keys)
+    );
+}
+
 void CncJsonUtils::Cstr_Field_From_Json(
     const nlohmann::json& j,
     const std::string_view& json_path,
@@ -30,23 +146,4 @@ void CncJsonUtils::Cstr_Field_From_Json(
 
     const auto copied_length = value.copy(field, str_length);
     field[copied_length] = '\0';
-}
-
-std::string CncJsonUtils::Build_Type_Error(const std::string& expected_type, const nlohmann::json& subject)
-{
-    return std::format("expected {}, actual type: {}", expected_type, subject.type_name());
-}
-
-std::string CncJsonUtils::Build_Parse_Error(
-    const std::string& attempted_parse_type,
-    const std::string& subject,
-    const std::string_view& error
-)
-{
-    return std::format(
-        "unable to parse as {}, json value: {} | error = {}",
-        attempted_parse_type,
-        subject,
-        error
-    );
 }

--- a/common/json.cpp
+++ b/common/json.cpp
@@ -11,7 +11,7 @@ void CncJsonUtils::Cstr_Field_From_Json(
 )
 {
     const auto sub_path = std::format("{}{}", json_path, field_name);
-    const auto& field_json = j.at(field_name);
+    const auto& field_json = j[field_name];
 
     Assert_Json_Is<JsonString>(field_json, sub_path);
 

--- a/common/json.h
+++ b/common/json.h
@@ -23,10 +23,10 @@
 #define CONVERT_FIELD_TO_JSON(FIELD, CONVERTER) j.emplace(#FIELD, CONVERTER(p.FIELD))
 
 // from_json macros
-#define FIELD_FROM_JSON_TO_VALUE(FIELD, VALUE) j.at(#FIELD).get_to(VALUE)
-#define FIELD_FROM_JSON(FIELD) j.at(#FIELD).get_to(p.FIELD)
-#define FIELD_FROM_JSON_WITH_TYPE(FIELD, TYPE) p.FIELD = j.at(#FIELD).get<TYPE>()
-#define BITFIELD_FROM_JSON(FIELD) p.FIELD = j.at(#FIELD).get<bool>()
+#define FIELD_FROM_JSON_TO_VALUE(FIELD, VALUE) j[#FIELD].get_to(VALUE)
+#define FIELD_FROM_JSON(FIELD) j[#FIELD].get_to(p.FIELD)
+#define FIELD_FROM_JSON_WITH_TYPE(FIELD, TYPE) p.FIELD = j[#FIELD].get<TYPE>()
+#define BITFIELD_FROM_JSON(FIELD) p.FIELD = j[#FIELD].get<bool>()
 
 // to_json/from_json friend functions shorthand (reference types)
 # define JSON_FUNCTIONS(TYPE) friend void to_json(nlohmann::json& j, const TYPE& p); \
@@ -254,7 +254,7 @@ public:
         const std::string_view& field_name
     )
     {
-        const auto& field = j.at(field_name);
+        const auto& field = j[field_name];
 
         Assert_Json_Is<JsonString>(json_path, field);
 

--- a/common/json.h
+++ b/common/json.h
@@ -7,8 +7,6 @@
 #define JSON_DISABLE_ENUM_SERIALIZATION 1
 #include <nlohmann/json.hpp>
 
-#include "stringutils.h"
-
 // emulate C# style nameof
 #define NAMEOF(SYMBOL) #SYMBOL
 
@@ -87,6 +85,11 @@ concept JsonType = std::is_same_v<T, JsonString>
 class CncJsonUtils final
 {
 public:
+    // custom value_t entry for signalling we want anything that isn't null
+    static constexpr auto NotNullJsonType = static_cast<nlohmann::json::value_t>(
+        static_cast<uint8_t>(nlohmann::json::value_t::discarded) + 1
+    );
+
     static std::string Build_Type_Error(const std::string& expected_type, const nlohmann::json& subject);
 
     static std::string Build_Parse_Error(
@@ -211,33 +214,14 @@ public:
         const nlohmann::json& subject,
         const std::string& json_path,
         const std::vector<std::string>& expected_keys
-    )
-    {
-        Assert_Json_Is<JsonObject>(subject, json_path);
+    );
 
-        std::vector<std::string> missing_keys;
-
-        for (const auto& key : expected_keys) {
-            if (!subject.contains(key)) {
-                missing_keys.push_back(key);
-            }
-        }
-
-        if (!missing_keys.empty()) {
-            std::vector<std::string> actual_keys;
-
-            for (const auto& [key, _] : subject.items()) {
-                actual_keys.emplace_back(key);
-            }
-
-            Throw_Json_Assert_Failure(
-                json_path,
-                "expected object with keys '{}', actual keys: {}",
-                CncStringUtils::To_Csv(expected_keys),
-                CncStringUtils::To_Csv(actual_keys)
-            );
-        }
-    }
+    static void Assert_Json_Is_Object_With_Keys_And_Types(
+        const nlohmann::json& subject,
+        const std::string& json_path,
+        const std::vector<std::string>& expected_keys,
+        const std::unordered_map<std::string, nlohmann::json::value_t>& expected_types
+    );
 
     static void Cstr_Field_From_Json(
         const nlohmann::json& j,

--- a/common/lua/luaapi.cpp
+++ b/common/lua/luaapi.cpp
@@ -9,9 +9,9 @@
 #include "luaarguments.h"
 
 // Method implementations
-void LuaApi::With_Api_Namespace(const LuaEngine& engine, std::function<void(luabridge::Namespace&)> action) const
+void LuaApi::With_Api_Namespace(const LuaEngine& engine, const std::function<void(luabridge::Namespace&)>& action) const
 {
-    engine.With_Api_Namespace(Name, std::move(action));
+    engine.With_Api_Namespace(Name, action);
 }
 
 void LuaApi::Register_Api_Metadata(const LuaEngine& engine) const

--- a/common/lua/luaapi.h
+++ b/common/lua/luaapi.h
@@ -41,7 +41,7 @@ public:
 
     virtual ~LuaApi() = default;
 
-    void With_Api_Namespace(const LuaEngine& engine, std::function<void(luabridge::Namespace&)> action) const;
+    void With_Api_Namespace(const LuaEngine& engine, const std::function<void(luabridge::Namespace&)>& action) const;
 
     void Register_Api_Metadata(const LuaEngine& engine) const;
 

--- a/common/lua/luaarguments.cpp
+++ b/common/lua/luaarguments.cpp
@@ -203,7 +203,7 @@ LuaMapParameter LuaArguments::Read_Next_Map(std::string_view parameter_name)
         Lua.Raise_Error_Format("({}) CFunction attempted to read more arguments than were provided", FunctionSignature);
     }
 
-    std::map<std::string, LuaVariant> table_map;
+    std::unordered_map<std::string, LuaVariant> table_map;
     std::optional<std::string> read_error;
 
     Lua.Push_Nil();

--- a/common/lua/luaarguments.h
+++ b/common/lua/luaarguments.h
@@ -23,7 +23,7 @@ public:
         const LuaEngine& lua,
         const std::string_view function_signature,
         const std::string_view parameter,
-        std::map<std::string, LuaVariant> data
+        std::unordered_map<std::string, LuaVariant> data
     ): Lua(lua), FunctionSignature(function_signature), Parameter(parameter), Data(std::move(data)) {}
 
     template<LuaVariantCompatible T>
@@ -72,7 +72,7 @@ private:
     const LuaEngine& Lua;
     std::string_view FunctionSignature;
     std::string_view Parameter;
-    std::map<std::string, LuaVariant> Data;
+    std::unordered_map<std::string, LuaVariant> Data;
 };
 
 /**

--- a/common/lua/luaengine.cpp
+++ b/common/lua/luaengine.cpp
@@ -152,16 +152,26 @@ LuaResult LuaEngine::Exec_File(const std::filesystem::path& script_path) const
     });
 }
 
-LuaResult LuaEngine::Exec_File_If_Exists(const std::filesystem::path& script_path) const
+LuaResult LuaEngine::Exec_File_If_Exists(const std::filesystem::path& script_path, bool& file_was_found) const
 {
     const auto full_script_path = Resolve_Script_Path(script_path);
 
-    if (!std::filesystem::exists(full_script_path) || std::filesystem::is_directory(full_script_path)) {
+    file_was_found = std::filesystem::exists(full_script_path) && !std::filesystem::is_directory(full_script_path);
+
+    if (!file_was_found) {
         CNC_LOGGER_WARN("Skipping lua file execution as it does not exist: {}", full_script_path.string());
+
         return {LUA_OK};
     }
 
     return Exec_File(full_script_path);
+}
+
+LuaResult LuaEngine::Exec_File_If_Exists(const std::filesystem::path& script_path) const
+{
+    bool temp;
+
+    return Exec_File_If_Exists(script_path, temp);
 }
 
 std::future<LuaResult> LuaEngine::Exec_File_Async(const std::filesystem::path& script_path) const

--- a/common/lua/luaengine.h
+++ b/common/lua/luaengine.h
@@ -158,6 +158,8 @@ public:
 
     LuaResult Exec_File(const std::filesystem::path& script_path) const;
 
+    LuaResult Exec_File_If_Exists(const std::filesystem::path& script_path, bool& file_was_found) const;
+
     LuaResult Exec_File_If_Exists(const std::filesystem::path& script_path) const;
 
     std::future<LuaResult> Exec_File_Async(const std::filesystem::path& script_path) const;

--- a/common/lua/rules_luaapi.h
+++ b/common/lua/rules_luaapi.h
@@ -18,6 +18,7 @@ template <typename T>
 concept RuleSectionsProviderConcept = requires()
 {
     { T::Sections() } -> std::same_as<const RuleSections&>;
+    { T::Editable_Sections() } -> std::same_as<RuleSections&>;
 };
 
 // TODO: Update to support new rule variant types
@@ -114,7 +115,7 @@ public:
                 auto section = arguments.Read_First<std::string>().Unpack();
                 auto key = arguments.Read_Next<std::string>().Unpack();
 
-                RulesLuaAdapter::Set_Rule_Value(engine, arguments, R::Sections(), section, key);
+                RulesLuaAdapter::Set_Rule_Value(engine, arguments, R::Editable_Sections(), section, key);
 
                 return 1;
             });

--- a/common/lua/rulesluaadapter.cpp
+++ b/common/lua/rulesluaadapter.cpp
@@ -72,7 +72,7 @@ void RulesLuaAdapter::Push_Rule_Value(
 void RulesLuaAdapter::Set_Rule_Value(
     const SharedLuaEngine& engine,
     LuaArguments& arguments,
-    const RuleSections& sections,
+    RuleSections& sections,
     const std::string& section,
     const std::string& key
 )

--- a/common/lua/rulesluaadapter.h
+++ b/common/lua/rulesluaadapter.h
@@ -55,7 +55,7 @@ public:
     static void Set_Rule_Value(
         const SharedLuaEngine& engine,
         LuaArguments& arguments,
-        const RuleSections& sections,
+        RuleSections& sections,
         const std::string& section,
         const std::string& key
     );

--- a/common/rulesections.cpp
+++ b/common/rulesections.cpp
@@ -32,9 +32,9 @@ FROM_JSON(RuleValueVariant)
     if (
         !j.is_object() ||
         !j.contains("type") ||
-        !j.at("type").is_string() ||
+        !j["type"].is_string() ||
         !j.contains("value") ||
-        j.at("value").is_null()
+        j["value"].is_null()
     ) {
         throw CncJsonException(
             "Invalid {} JSON value - expected object with keys 'type' (string) and 'value' (non-null value), "
@@ -44,8 +44,8 @@ FROM_JSON(RuleValueVariant)
         );
     }
 
-    const auto variant_type = j.at("type").get<std::string>();
-    auto& variant_value = j.at("value");
+    const auto variant_type = j["type"].get<std::string>();
+    auto& variant_value = j["value"];
 
     if (variant_type == "int") {
         p = variant_value.get<int>();

--- a/common/rulesections.cpp
+++ b/common/rulesections.cpp
@@ -355,10 +355,6 @@ RuleSection& RuleSection::Set(std::string_view name, RuleValueVariant value)
 
     Rules[name.data()] = value;
 
-    if (SectionName == "E2") {
-        CNC_LOGGER_WARN("Running OnRulesChanged() handler for E2: {}", Variant_To_String(value));
-    }
-
     OnRulesChanged(*this, name, value);
 
     return *this;

--- a/common/rulesections.cpp
+++ b/common/rulesections.cpp
@@ -2,6 +2,72 @@
 
 #include "rulesections.h"
 
+TO_JSON(RuleValueVariant)
+{
+    j["type"]= RuleSection::Get_Variant_Type(p);
+
+    if (const auto value = std::get_if<int>(&p)) {
+        j["value"] = *value;
+    } else if (const auto value = std::get_if<bool>(&p)) {
+        j["value"] = *value;
+    } else if (const auto value = std::get_if<float>(&p)) {
+        j["value"] = *value;
+    } else if (const auto value = std::get_if<ushort>(&p)) {
+        j["value"] = *value;
+    } else if (const auto value = std::get_if<std::string>(&p)) {
+        j["value"] = *value;
+    } else if (const auto value = std::get_if<uint>(&p)) {
+        j["value"] = *value;
+    } else if (const auto value = std::get_if<char>(&p)) {
+        j["value"] = *value;
+    } else if (const auto value = std::get_if<uchar>(&p)) {
+        j["value"] = *value;
+    } else {
+        throw std::invalid_argument("Unsupported RuleValueVariant type - this is normally caused by variant type list being updated without updating supporting code");
+    }
+}
+
+FROM_JSON(RuleValueVariant)
+{
+    if (
+        !j.is_object() ||
+        !j.contains("type") ||
+        !j.at("type").is_string() ||
+        !j.contains("value") ||
+        j.at("value").is_null()
+    ) {
+        throw CncJsonException(
+            "Invalid {} JSON value - expected object with keys 'type' (string) and 'value' (non-null value), "
+            "actual JSON: {}",
+            NAMEOF(RuleValueVariant),
+            j.dump()
+        );
+    }
+
+    const auto variant_type = j.at("type").get<std::string>();
+    auto& variant_value = j.at("value");
+
+    if (variant_type == "int") {
+        p = variant_value.get<int>();
+    } else if (variant_type == "bool") {
+        p = variant_value.get<bool>();
+    } else if (variant_type == "float") {
+        p = variant_value.get<float>();
+    } else if (variant_type == "unsigned short") {
+        p = variant_value.get<ushort>();
+    } else if (variant_type == "string") {
+        p = variant_value.get<std::string>();
+    } else if (variant_type == "unsigned int") {
+        p = variant_value.get<uint>();
+    } else if (variant_type == "char") {
+        p = variant_value.get<char>();
+    } else if (variant_type == "unsigned char") {
+        p = variant_value.get<uchar>();
+    } else {
+        throw std::invalid_argument("Unsupported RuleValueVariant type - this is normally caused by variant type list being updated without updating supporting code");
+    }
+}
+
 RuleSection& RuleSection::EnableStringSanitization()
 {
     SanitizeIniStrings = true;
@@ -14,7 +80,7 @@ RuleSection& RuleSection::DisableStringSanitization()
     return *this;
 }
 
-bool RuleSection::Variants_Have_Same_Type(RuleValueVariant value_variant_a, RuleValueVariant value_variant_b)
+bool RuleSection::Variants_Have_Same_Type(const RuleValueVariant& value_variant_a, const RuleValueVariant& value_variant_b)
 {
     if (std::holds_alternative<int>(value_variant_a)) {
         return std::holds_alternative<int>(value_variant_b);
@@ -44,7 +110,7 @@ bool RuleSection::Variants_Have_Same_Type(RuleValueVariant value_variant_a, Rule
     throw std::invalid_argument("Unsupported RuleValueVariant type - this is normally caused by variant type list being updated without updating supporting code");
 }
 
-std::string_view RuleSection::Get_Variant_Type(RuleValueVariant value_variant)
+std::string_view RuleSection::Get_Variant_Type(const RuleValueVariant& value_variant)
 {
     if (std::holds_alternative<int>(value_variant)) {
         return "int";
@@ -74,7 +140,7 @@ std::string_view RuleSection::Get_Variant_Type(RuleValueVariant value_variant)
     throw std::invalid_argument("Unsupported RuleValueVariant type - this is normally caused by variant type list being updated without updating supporting code");
 }
 
-std::string RuleSection::Get_Variant_Values(RuleValueVariant value_variant)
+std::string RuleSection::Get_Variant_Values(const RuleValueVariant& value_variant)
 {
     if (std::holds_alternative<int>(value_variant)) {
         return std::format("{}-{}", std::numeric_limits<int>::min(), std::numeric_limits<int>::max());
@@ -104,7 +170,7 @@ std::string RuleSection::Get_Variant_Values(RuleValueVariant value_variant)
     throw std::invalid_argument("Unsupported RuleValueVariant type - this is normally caused by variant type list being updated without updating supporting code");
 }
 
-std::string RuleSection::Variant_To_String(RuleValueVariant value_variant)
+std::string RuleSection::Variant_To_String(const RuleValueVariant& value_variant)
 {
     if (const auto value = std::get_if<int>(&value_variant)) {
         return std::format("{}", *value);
@@ -273,7 +339,7 @@ RuleSection& RuleSection::Set(std::string_view name, RuleValueVariant value)
         Variant_To_String(value)
     );
 
-    auto existing_rule = Try_Get_Variant(name);
+    const auto existing_rule = Try_Get_Variant(name);
 
     if (existing_rule.has_value()) {
         if (!Variants_Have_Same_Type(existing_rule.value(), value)) {
@@ -289,7 +355,10 @@ RuleSection& RuleSection::Set(std::string_view name, RuleValueVariant value)
 
     Rules[name.data()] = value;
 
-    CNC_LOGGER_DEBUG("Running OnRulesChanged() handler");
+    if (SectionName == "E2") {
+        CNC_LOGGER_WARN("Running OnRulesChanged() handler for E2: {}", Variant_To_String(value));
+    }
+
     OnRulesChanged(*this, name, value);
 
     return *this;
@@ -300,7 +369,7 @@ RuleSection& RuleSection::Set(std::string_view name, const char* value)
     return Set(name, std::string(value));
 }
 
-std::optional<std::string_view>& RuleSection::Get_Converter_Section_Type_Name()
+const std::optional<std::string>& RuleSection::Get_Converter_Section_Type_Name()
 {
     return ConverterSectionTypeName;
 }
@@ -319,6 +388,35 @@ std::optional<std::string> RuleSection::Try_Get_Rule_Comment(const std::string_v
     }
 
     return std::nullopt;
+}
+
+TO_JSON(RuleSection)
+{
+    for (const auto& [ name, value ] : p.Rules) {
+        to_json(j[name], value);
+    }
+}
+
+/**
+ * Update rules from JSON export, values for existing rules not present in the JSON export are preserved.
+ */
+FROM_JSON(RuleSection)
+{
+    if (!j.is_object()) {
+        throw CncJsonException(
+            "Invalid {} JSON - expected type 'object', actual type: {}",
+            NAMEOF(RuleSection),
+            j.type_name()
+        );
+    }
+
+    for (const auto& [ key, value ] : j.items()) {
+        RuleValueVariant variant_value;
+
+        from_json(value, variant_value);
+
+        p.Set(key, std::move(variant_value));
+    }
 }
 
 //IniRuleContext
@@ -340,7 +438,7 @@ IniRuleContext& IniRuleContext::Load(std::string_view name)
 
 void RuleSections::Default_Rules_Changed_Handler(std::function<void(RuleSection&, std::string_view, const RuleValueVariant&)> on_rules_changed)
 {
-    OnRulesChangedDefault = on_rules_changed;
+    OnRulesChangedDefault = std::move(on_rules_changed);
 }
 
 std::vector<std::string_view> RuleSections::Section_Names() const
@@ -363,7 +461,7 @@ bool RuleSections::Has_Section(std::string_view name) const
 void RuleSections::Save_All_To_Ini(INIClass& ini) const
 {
     for (const auto& section : Sections | std::views::values) {
-        section->Save_All_To_Ini(ini);
+        section.Save_All_To_Ini(ini);
     }
 }
 
@@ -371,12 +469,12 @@ RuleSection& RuleSections::Add_Section(std::string_view name, std::function<void
 {
     CNC_LOGGER_DEBUG("Adding new rules section '{}'", name);
 
-    Sections[name.data()] = std::make_unique<RuleSection>(
+    Sections.emplace(name.data(), RuleSection(
         name.data(),
-        on_rules_changed
-    );
+        std::move(on_rules_changed)
+    ));
 
-    return *Sections[name.data()];
+    return Sections.at(name.data());
 }
 
 RuleSection& RuleSections::Add_Section(std::string_view name)
@@ -390,22 +488,44 @@ RuleSection& RuleSections::Add_Section(std::string_view name)
 
 RuleSection& RuleSections::operator[](std::string_view name)
 {
-    auto it = Sections.find(name.data());
-
-    if (it != Sections.end()) {
-        return *(it->second);
+    if (!Sections.contains(name.data())) {
+        return Add_Section(name.data());
     }
 
-    return Add_Section(name.data());
+    return Sections.at(name.data());
 }
 
-RuleSection& RuleSections::operator[](std::string_view name) const
+const RuleSection& RuleSections::operator[](std::string_view name) const
 {
-    auto it = Sections.find(name.data());
-
-    if (it == Sections.end()) {
+    if (!Sections.contains(name.data())) {
         throw std::out_of_range(std::format("Attempted to access missing rule section: {}'", name));
     }
 
-    return *(it->second);
+    return Sections.at(name.data());
+}
+
+TO_JSON(RuleSections)
+{
+    for (const auto& [ name, section ] : p.Sections) {
+        j[name] = section;
+    }
+}
+
+/**
+ * Read rule sections from JSON, RuleSections::[] only calls Add_Section if the section is not present, so existing
+ * sections will be updated rather than replaced.
+ */
+FROM_JSON(RuleSections)
+{
+    if (!j.is_object()) {
+        throw CncJsonException(
+            "Invalid {} JSON - expected type 'object', actual type: {}",
+            NAMEOF(RuleSections),
+            j.type_name()
+        );
+    }
+
+    for (const auto& [name, section_json ] : j.items()) {
+        from_json(section_json, p[name]);
+    }
 }

--- a/common/rulesections.cpp
+++ b/common/rulesections.cpp
@@ -29,20 +29,15 @@ TO_JSON(RuleValueVariant)
 
 FROM_JSON(RuleValueVariant)
 {
-    if (
-        !j.is_object() ||
-        !j.contains("type") ||
-        !j["type"].is_string() ||
-        !j.contains("value") ||
-        j["value"].is_null()
-    ) {
-        throw CncJsonException(
-            "Invalid {} JSON value - expected object with keys 'type' (string) and 'value' (non-null value), "
-            "actual JSON: {}",
-            NAMEOF(RuleValueVariant),
-            j.dump()
-        );
-    }
+    CncJsonUtils::Assert_Json_Is_Object_With_Keys_And_Types(
+        j,
+        NAMEOF(RuleValueVariant),
+        { "type", "value"},
+        {
+            {"type", nlohmann::json::value_t::string },
+            {"value", CncJsonUtils::NotNullJsonType },
+        }
+    );
 
     const auto variant_type = j["type"].get<std::string>();
     auto& variant_value = j["value"];
@@ -398,13 +393,7 @@ TO_JSON(RuleSection)
  */
 FROM_JSON(RuleSection)
 {
-    if (!j.is_object()) {
-        throw CncJsonException(
-            "Invalid {} JSON - expected type 'object', actual type: {}",
-            NAMEOF(RuleSection),
-            j.type_name()
-        );
-    }
+    CncJsonUtils::Assert_Json_Is<JsonObject>(j, NAMEOF(RuleSection));
 
     for (const auto& [ key, value ] : j.items()) {
         RuleValueVariant variant_value;
@@ -513,13 +502,7 @@ TO_JSON(RuleSections)
  */
 FROM_JSON(RuleSections)
 {
-    if (!j.is_object()) {
-        throw CncJsonException(
-            "Invalid {} JSON - expected type 'object', actual type: {}",
-            NAMEOF(RuleSections),
-            j.type_name()
-        );
-    }
+    CncJsonUtils::Assert_Json_Is<JsonObject>(j, NAMEOF("RuleSections"));
 
     for (const auto& [name, section_json ] : j.items()) {
         from_json(section_json, p[name]);

--- a/common/rulesections.h
+++ b/common/rulesections.h
@@ -40,6 +40,9 @@ typedef unsigned long ulong;
 
 using RuleValueVariant = std::variant<int, bool, float, ushort, std::string, uint, char, uchar>;
 
+TO_JSON(RuleValueVariant);
+FROM_JSON(RuleValueVariant);
+
 template<typename T>
 concept RuleValueVariantCompatible = (
     std::is_same_v<T, int> ||
@@ -77,13 +80,13 @@ class RuleSection
 public:
     const std::string SectionName;
 
-    static bool Variants_Have_Same_Type(RuleValueVariant value_variant_a, RuleValueVariant value_variant_b);
+    static bool Variants_Have_Same_Type(const RuleValueVariant& value_variant_a, const RuleValueVariant& value_variant_b);
 
-    static std::string_view Get_Variant_Type(RuleValueVariant value_variant);
+    static std::string_view Get_Variant_Type(const RuleValueVariant& value_variant);
 
-    static std::string Get_Variant_Values(RuleValueVariant value_variant);
+    static std::string Get_Variant_Values(const RuleValueVariant& value_variant);
 
-    static std::string Variant_To_String(RuleValueVariant value_variant);
+    static std::string Variant_To_String(const RuleValueVariant& value_variant);
 
     RuleSection(
         std::string section_name,
@@ -304,7 +307,7 @@ public:
         return *this;
     }
 
-    std::optional<std::string_view>& Get_Converter_Section_Type_Name();
+    const std::optional<std::string>& Get_Converter_Section_Type_Name();
 
     template<class T, TypeConverter<T> C>
     T Get_With_Converter(std::string_view name) const
@@ -423,7 +426,7 @@ public:
     std::optional<std::string> Try_Get_Rule_Comment(std::string_view name) const;
 
     // TODO: Handle OnRulesChanged, if needed
-    NLOHMANN_DEFINE_TYPE_INTRUSIVE(RuleSection, Rules, ConverterSectionTypeName, SectionName)
+    JSON_FUNCTIONS(RuleSection)
 private:
     static inline const auto& Logger = CncLogger::For(RuleSection);
 
@@ -445,10 +448,10 @@ private:
      */
     bool SanitizeIniStrings;
     std::optional<std::string> Comment;
-    std::map<std::string, RuleValueVariant> Rules;
-    std::map<std::string, std::string> RuleComments;
+    std::unordered_map<std::string, RuleValueVariant> Rules;
+    std::unordered_map<std::string, std::string> RuleComments;
     std::function<void(RuleSection&, std::string_view, const RuleValueVariant&)> OnRulesChanged;
-    std::optional<std::string_view> ConverterSectionTypeName;
+    std::optional<std::string> ConverterSectionTypeName;
 
     template<class T, class U = T, class V = std::string>
     void Safe_Parse(
@@ -731,12 +734,12 @@ public:
 
     RuleSection& operator[](std::string_view name);
 
-    RuleSection& operator[](std::string_view name) const;
+    const RuleSection& operator[](std::string_view name) const;
 
-    NLOHMANN_DEFINE_TYPE_INTRUSIVE(RuleSections, Sections)
+    JSON_FUNCTIONS(RuleSections)
 private:
     static inline const auto& Logger = CncLogger::For(RuleSections);
 
-    std::map<std::string, std::unique_ptr<RuleSection>> Sections;
+    std::unordered_map<std::string, RuleSection> Sections;
     std::optional<std::function<void(RuleSection&, std::string_view, const RuleValueVariant&)>> OnRulesChangedDefault;
 };

--- a/common/twowaymap.h
+++ b/common/twowaymap.h
@@ -25,8 +25,8 @@ template<typename A, typename B>
 class TwoWayMap : private TwoWayMapStatic
 {
 private:
-    std::map<A, B> ForwardMap;
-    std::map<B, A> BackwardMap;
+    std::unordered_map<A, B> ForwardMap;
+    std::unordered_map<B, A> BackwardMap;
 
 public:
     TwoWayMap(std::initializer_list<std::pair<A, B>> pairs)

--- a/common/vector.h
+++ b/common/vector.h
@@ -138,8 +138,8 @@ public:
     {
         CncJsonUtils::Assert_Json_Is_Object_With_Keys(j, ". (VectorClass)", {NAMEOF(_items), NAMEOF(_vector_size)});
 
-        const auto& _vector_size = j.at(NAMEOF(_vector_size));
-        const auto& _items = j.at(NAMEOF(_items));
+        const auto& _vector_size = j[NAMEOF(_vector_size)];
+        const auto& _items = j[NAMEOF(_items)];
 
         CncJsonUtils::Assert_Json_Is<JsonUnsignedInt>(_vector_size, ". (VectorClass)");
         CncJsonUtils::Assert_Json_Is<JsonObject>(_items, NAMEOF(_items));
@@ -428,7 +428,7 @@ public:
     friend FROM_JSON(DynamicVectorArrayClass)
     {
         // Collection field
-        const auto& json_collection = j.at(NAMEOF(Collection));
+        const auto& json_collection = j[NAMEOF(Collection)];
 
         CncJsonUtils::Assert_Json_Is<JsonArray>(json_collection, NAMEOF(Collection));
 

--- a/common/vector.h
+++ b/common/vector.h
@@ -136,7 +136,7 @@ public:
 
     friend FROM_JSON(VectorClass<T>)
     {
-        CncJsonUtils::Assert_Json_Is_Object_With_Keys(j, ". (VectorClass)", {NAMEOF(_items), NAMEOF(_vector_size)});
+        CncJsonUtils::Assert_Json_Is_Object_With_Keys(j, NAMEOF(VectorClass), {NAMEOF(_items), NAMEOF(_vector_size)});
 
         const auto& _vector_size = j[NAMEOF(_vector_size)];
         const auto& _items = j[NAMEOF(_items)];

--- a/docs/saveload/design.md
+++ b/docs/saveload/design.md
@@ -133,7 +133,7 @@ The nlohmann/json library provides excellent support for arbitrary types through
 
 See: https://json.nlohmann.me/features/arbitrary_types/
 
-```cpp
+```c++
 #include <nlohmann/json.hpp>
 using json = nlohmann::json;
 
@@ -172,10 +172,10 @@ public:
     }
 
     friend void from_json(const json& j, AircraftClass& a) {
-        if (j.at("type") != "aircraft")
+        if (j["type"] != "aircraft")
             throw std::runtime_error("Invalid aircraft data");
 
-        a.Class = AircraftTypeClass::As_Reference(static_cast<AircraftType>(j.at("class_id").get<int>()));
+        a.Class = AircraftTypeClass::As_Reference(static_cast<AircraftType>(j["class_id"].get<int>()));
         // ... set other fields ...
     }
 };

--- a/redalert/conquer.cpp
+++ b/redalert/conquer.cpp
@@ -208,11 +208,7 @@ void Main_Game(int argc, char* argv[])
 
         fade = true;
 
-        if (Map.Is_Smaller_Than_Screen()) {
-            Map.Set_View_Dimensions(0, 8 * RESFACTOR);
-            Map.Flag_To_Redraw(true);
-            Map.Render();
-        }
+        Map.Redraw_If_Smaller_Then_Screen();
 
         /*
         ** Initialise the color lookup tables for the chronal vortex
@@ -1910,11 +1906,7 @@ bool Main_Loop()
         Do_Restart();
         Set_Video_Cursor_Clip(true);
 
-        if (Map.Is_Smaller_Than_Screen()) {
-            Map.Set_View_Dimensions(0, 8 * RESFACTOR);
-            Map.Flag_To_Redraw(true);
-            Map.Render();
-        }
+        Map.Redraw_If_Smaller_Then_Screen();
 
         return (!GameActive);
     }

--- a/redalert/map.cpp
+++ b/redalert/map.cpp
@@ -2613,7 +2613,7 @@ bool MapClass::Is_Width_Smaller_Than_Screen() const
     // disable small map detection in remaster
     return false;
 #else
-    constexpr auto sidebar_width = 80 * 2;
+    const auto sidebar_width = 80 * RESFACTOR;
     return (Map.IsSidebarActive ? sidebar_width : 0) + MapCellWidth * CELL_PIXEL_W < SeenBuff.Get_Width();
 #endif
 }
@@ -2624,7 +2624,8 @@ bool MapClass::Is_Height_Smaller_Than_Screen() const
     // disable small map detection in remaster
     return false;
 #else
-    return MapCellHeight * CELL_PIXEL_H < SeenBuff.Get_Height();
+    const auto tab_height = 8 * RESFACTOR;
+    return MapCellHeight * CELL_PIXEL_H < SeenBuff.Get_Height() - tab_height;
 #endif
 }
 
@@ -2636,4 +2637,22 @@ bool MapClass::Is_Smaller_Than_Screen() const
 #else
     return Is_Width_Smaller_Than_Screen() || Is_Height_Smaller_Than_Screen();
 #endif
+}
+
+bool MapClass::Redraw_If_Smaller_Then_Screen()
+{
+    if (!Is_Smaller_Than_Screen()) {
+        return false;
+    }
+
+    const auto sidebar_width = 80 * RESFACTOR;
+    const auto tab_height = 8 * RESFACTOR;
+
+    Map.IsSidebarActive
+        ? Map.Set_View_Dimensions(0, tab_height, SeenBuff.Get_Width() - sidebar_width)
+        : Map.Set_View_Dimensions(0, tab_height);
+    Flag_To_Redraw(true);
+    Render();
+
+    return true;
 }

--- a/redalert/map.h
+++ b/redalert/map.h
@@ -172,6 +172,14 @@ public:
      */
     bool Is_Smaller_Than_Screen() const;
 
+    /**
+     * Based on the current view dimensions, if the map is smaller than the screen resolution, force it to redraw
+     * to ensure cells and sidebar are rendered correctly for the current resolution.
+     *
+     * @return True if the map was redrawn, false otherwise.
+     */
+    bool Redraw_If_Smaller_Then_Screen();
+
 protected:
     /*
     **	This is the array of cell objects.

--- a/redalert/scenario.cpp
+++ b/redalert/scenario.cpp
@@ -1240,11 +1240,7 @@ void Do_Lose(void)
     GamePalette.Set(FADE_PALETTE_FAST, Call_Back);
     Show_Mouse();
 
-    if (Map.Is_Smaller_Than_Screen()) {
-        Map.Set_View_Dimensions(0, 8 *RESFACTOR);
-        Map.Flag_To_Redraw(true);
-        Map.Render();
-    }
+    Map.Redraw_If_Smaller_Then_Screen();
 }
 
 #ifdef FIXIT_VERSION_3 //	Stalemate games.

--- a/tiberiandawn/anim.cpp
+++ b/tiberiandawn/anim.cpp
@@ -1103,11 +1103,11 @@ void AnimClass::Middle(void)
                 building = (BuildingClass*)backup;
         }
 
-        int radius = 3;
-        int rawdamage = 200;
+        int radius = Rule.Get_Rule_Value<int>(GAME_MULTIPLAYER_SECTION, NUCLEAR_STRIKE_DAMAGE_RADIUS_RULE);
+        int rawdamage = Rule.Get_Rule_Value<int>(GAME_MULTIPLAYER_SECTION, NUCLEAR_STRIKE_DAMAGE_RULE);
         if (GameToPlay == GAME_NORMAL) {
-            radius = 4;
-            rawdamage = 1000;
+            radius = Rule.Get_Rule_Value<int>(GAME_SUPERWEAPONS_SECTION, NUCLEAR_STRIKE_DAMAGE_RADIUS_RULE);
+            rawdamage = Rule.Get_Rule_Value<int>(GAME_SUPERWEAPONS_SECTION, NUCLEAR_STRIKE_DAMAGE_RULE);
             Fade_Palette_To(WhitePalette, 30, NULL);
         }
         for (int x = -radius; x <= radius; x++) {
@@ -1221,7 +1221,10 @@ void AnimClass::Middle(void)
             if (!building)
                 building = (BuildingClass*)backup;
         }
-        Explosion_Damage(Center_Coord(), 600, building, WARHEAD_PB);
+
+        const auto ionCannonDamage = Rule.Get_Rule_Value<int>(GAME_SUPERWEAPONS_SECTION, ION_CANNON_DAMAGE_RULE);
+
+        Explosion_Damage(Center_Coord(), ionCannonDamage, building, WARHEAD_PB);
     } break;
 
     case ANIM_NAPALM1:

--- a/tiberiandawn/bdata.cpp
+++ b/tiberiandawn/bdata.cpp
@@ -3343,7 +3343,9 @@ static BuildingTypeClass const Sandbag(STRUCT_SANDBAG_WALL,
                                        BSIZE_11,            // SIZE:			Building size.
                                        NULL,                // Preferred exit cell list.
                                        (short const*)List1, // OCCUPYLIST:	List of active foundation squares.
-                                       (short const*)NULL   // OVERLAPLIST:List of overlap cell offset.
+                                       (short const*)NULL,   // OVERLAPLIST:List of overlap cell offset.
+                                       false,
+                                       OVERLAY_SANDBAG_WALL
 );
 // Cyclone fence
 static BuildingTypeClass const Cyclone(STRUCT_CYCLONE_WALL,
@@ -3394,7 +3396,9 @@ static BuildingTypeClass const Cyclone(STRUCT_CYCLONE_WALL,
                                        BSIZE_11,            // SIZE:			Building size.
                                        NULL,                // Preferred exit cell list.
                                        (short const*)List1, // OCCUPYLIST:	List of active foundation squares.
-                                       (short const*)NULL   // OVERLAPLIST:List of overlap cell offset.
+                                       (short const*)NULL,   // OVERLAPLIST:List of overlap cell offset.
+                                       false,
+                                       OVERLAY_CYCLONE_WALL
 );
 // Brick wall
 static BuildingTypeClass const Brick(STRUCT_BRICK_WALL,
@@ -3445,7 +3449,9 @@ static BuildingTypeClass const Brick(STRUCT_BRICK_WALL,
                                      BSIZE_11,            // SIZE:			Building size.
                                      NULL,                // Preferred exit cell list.
                                      (short const*)List1, // OCCUPYLIST:	List of active foundation squares.
-                                     (short const*)NULL   // OVERLAPLIST:List of overlap cell offset.
+                                     (short const*)NULL,   // OVERLAPLIST:List of overlap cell offset.
+                                     false,
+                                     OVERLAY_BRICK_WALL
 );
 // Barbwire wall
 static BuildingTypeClass const Barbwire(STRUCT_BARBWIRE_WALL,
@@ -3496,7 +3502,9 @@ static BuildingTypeClass const Barbwire(STRUCT_BARBWIRE_WALL,
                                         BSIZE_11,            // SIZE:			Building size.
                                         NULL,                // Preferred exit cell list.
                                         (short const*)List1, // OCCUPYLIST:	List of active foundation squares.
-                                        (short const*)NULL   // OVERLAPLIST:List of overlap cell offset.
+                                        (short const*)NULL,   // OVERLAPLIST:List of overlap cell offset.
+                                        false,
+                                        OVERLAY_BARBWIRE_WALL
 );
 // Wood wall
 static BuildingTypeClass const Wood(STRUCT_WOOD_WALL,
@@ -3547,7 +3555,9 @@ static BuildingTypeClass const Wood(STRUCT_WOOD_WALL,
                                     BSIZE_11,            // SIZE:			Building size.
                                     NULL,                // Preferred exit cell list.
                                     (short const*)List1, // OCCUPYLIST:	List of active foundation squares.
-                                    (short const*)NULL   // OVERLAPLIST:List of overlap cell offset.
+                                    (short const*)NULL,   // OVERLAPLIST:List of overlap cell offset.
+                                    false,
+                                    OVERLAY_WOOD_WALL
 );
 
 BuildingTypeClass const* const BuildingTypeClass::Pointers[STRUCT_COUNT] = {
@@ -3687,7 +3697,8 @@ BuildingTypeClass::BuildingTypeClass(StructType type,
                                      short const* exitlist,
                                      short const* sizelist,
                                      short const* overlap,
-                                     bool is_unsellable)
+                                     bool is_unsellable,
+                                     OverlayType overlay_type)
     : TechnoTypeClass(name,
                       ininame,
                       std::move(cameo_name),
@@ -3764,6 +3775,8 @@ BuildingTypeClass::BuildingTypeClass(StructType type,
     Anims[BSTATE_AUX2].Start = 0;
     Anims[BSTATE_AUX2].Count = 1;
     Anims[BSTATE_AUX2].Rate = 0;
+
+    OverlayToPlace = overlay_type;
 }
 
 /***********************************************************************************************

--- a/tiberiandawn/building.cpp
+++ b/tiberiandawn/building.cpp
@@ -5732,7 +5732,7 @@ FROM_JSON(BuildingClass)
 
     TECHNO_TYPE_TARGET_CONST_PTR_FROM_REF_JSON_WITH_TYPE(BuildingClass, Class, BuildingTypeClass, StructType);
 
-    p.Factory = TARGET_TO_PTR_WITH_TYPE(j.at(NAMEOF(Factory)).get<int>(), FactoryClass);
+    p.Factory = TARGET_TO_PTR_WITH_TYPE(j[NAMEOF(Factory)].get<int>(), FactoryClass);
 
     PARSE_TD_FIELD_FROM_JSON(BuildingClass, ActLike, HousesType);
     BITFIELD_FROM_JSON(IsReadyToCommence);

--- a/tiberiandawn/building.cpp
+++ b/tiberiandawn/building.cpp
@@ -103,6 +103,8 @@
 */
 #include "sidebarglyphx.h"
 
+extern bool DLL_Export_Get_Input_Key_State(KeyNumType key);
+
 enum SAMState
 {
     SAM_NONE = -1,   // Used for non SAM site buildings.

--- a/tiberiandawn/building.cpp
+++ b/tiberiandawn/building.cpp
@@ -1356,6 +1356,91 @@ void BuildingClass::AI(void)
     }
 }
 
+bool BuildingClass::Create_Overlay_At(const OverlayTypeClass& overlay, const CELL cell) const
+{
+    if (const auto o = overlay.Create_One_Of(House))
+    {
+        if (o->Unlimbo(Cell_Coord(cell)))
+        {
+            Map[cell].Owner = House->Class->House;
+            return true;
+        }
+
+        delete o;
+    }
+
+    return false;
+}
+
+bool BuildingClass::Unlimbo_Wall(const COORDINATE coord)
+{
+    const auto placement_cell = Coord_Cell(coord);
+
+    if (Can_Enter_Cell(placement_cell, FACING_NONE) != MOVE_OK) {
+        return false;
+    }
+
+    const auto overlay_type = Class->OverlayToPlace;
+
+    if (overlay_type == OVERLAY_NONE) {
+        return false;
+    }
+
+    // attempt to place the core pillar
+    const auto& overlay = OverlayTypeClass::As_Reference(overlay_type);
+
+    if (!Create_Overlay_At(overlay, placement_cell)) {
+        return false;
+    }
+
+    // wall rules
+    const auto modern_walls = Rule.Get_Rule_Value<bool>(ENHANCEMENTS_SECTION, MODERN_WALL_BUILDING_RULE);
+	const auto wall_length = Rule.Get_Rule_Value<int>(ENHANCEMENTS_SECTION, MODERN_WALL_MAX_LENGTH_RULE);
+    const auto full_cost_walls = Rule.Get_Rule_Value<bool>(ENHANCEMENTS_SECTION, MODERN_WALL_FULL_COST_RULE);
+
+#ifdef REMASTER_BUILD
+    bool ctrldown = DLL_Export_Get_Input_Key_State(KN_LCTRL);
+#else
+    bool ctrldown = (Keyboard->Down(Options.KeyForceAttack1) || Keyboard->Down(Options.KeyForceAttack2));
+#endif
+
+    if (modern_walls && wall_length > 1 && !ctrldown) {
+        /*
+         * Walk through every cardinal direction and run the same scanning logic as the build cursor
+         * Then place new wall overlays and transfer cell ownership up to the scan result distance
+         */
+        for (const auto& dir : FacingCardinals) {
+            const auto scan_dist = Map.Scan_For_Overlay(placement_cell, dir, overlay_type, wall_length);
+            auto adjacent_cell = placement_cell;
+
+            for (auto i = 0; i < scan_dist; ++i) {
+                adjacent_cell = Adjacent_Cell(adjacent_cell, dir);
+
+                if (full_cost_walls && House->Available_Money() < Class->Cost_Of()) {
+                    Speak(VOX_NO_CASH);
+
+                    break;
+                }
+
+                //If we fail to create the overlay here, abort this direction and move on
+                if (!Create_Overlay_At(overlay, adjacent_cell)) {
+                    break;
+                }
+
+                if (full_cost_walls) {
+                    House->Spend_Money(Class->Cost_Of());
+                }
+            }
+        }
+    }
+
+    Transmit_Message(RADIO_OVER_OUT);
+
+    Delete_This();
+
+    return true;
+}
+
 /***********************************************************************************************
  * BuildingClass::Unlimbo -- Removes a building from limbo state.                              *
  *                                                                                             *
@@ -1395,46 +1480,13 @@ bool BuildingClass::Unlimbo(COORDINATE coord, DirType dir)
     }
 #endif
 
-    /*
-    **	If this is a wall type building, then it never gets unlimboed. Instead, it gets
-    **	converted to an overlay type.
-    */
-    if (Class->IsWall) {
-        if (Can_Enter_Cell(Coord_Cell(coord), FACING_NONE) == MOVE_OK) {
-            OverlayType otype = OVERLAY_NONE;
-            switch (Class->Type) {
-            case STRUCT_SANDBAG_WALL:
-                otype = OVERLAY_SANDBAG_WALL;
-                break;
-
-            case STRUCT_CYCLONE_WALL:
-                otype = OVERLAY_CYCLONE_WALL;
-                break;
-
-            case STRUCT_BRICK_WALL:
-                otype = OVERLAY_BRICK_WALL;
-                break;
-
-            case STRUCT_BARBWIRE_WALL:
-                otype = OVERLAY_BARBWIRE_WALL;
-                break;
-
-            case STRUCT_WOOD_WALL:
-                otype = OVERLAY_WOOD_WALL;
-                break;
-            }
-            if (otype != OVERLAY_NONE) {
-                ObjectClass* o = OverlayTypeClass::As_Reference(otype).Create_One_Of(House);
-                if (o && o->Unlimbo(coord)) {
-                    Map[Coord_Cell(coord)].Owner = House->Class->House;
-                    Transmit_Message(RADIO_OVER_OUT);
-                    Delete_This();
-                    return (true);
-                }
-            }
-        }
-        return (false);
-    }
+	/*
+	**	If this is a wall type building, then it never gets unlimboed. Instead, it gets
+	**	converted to an overlay type.
+	*/
+	if (Class->IsWall) {
+		return Unlimbo_Wall(coord);
+	}
 
     /*
     **	Normal building unlimbo process.
@@ -5565,9 +5617,9 @@ bool BuildingClass::Can_Player_Move(void) const
         || (*this == STRUCT_CONST && (Mission == MISSION_GUARD) && Special.IsMCVDeploy);
 }
 
-static bool Scan_For_Proximity_Check(CELL cell, HouseClass* house, bool allowBuildingBesideWalls, int remainingDistance)
+static bool Scan_For_Proximity_Check(CELL cell, HouseClass* house, bool allow_building_beside_walls, int remaining_distance)
 {
-    if (remainingDistance < 1) {
+    if (remaining_distance < 1) {
         return false;
     }
 
@@ -5584,7 +5636,9 @@ static bool Scan_For_Proximity_Check(CELL cell, HouseClass* house, bool allowBui
         **	building located there.
         */
         if (Map[newcell].Owner == house->Class->House) {
-            if (allowBuildingBesideWalls || !OverlayTypeClass::As_Reference(Map[newcell].Overlay).IsWall) {
+            if (allow_building_beside_walls
+                && Map[newcell].Overlay != OVERLAY_NONE
+                && OverlayTypeClass::As_Reference(Map[newcell].Overlay).IsWall) {
                 return true;
             }
         }
@@ -5597,7 +5651,7 @@ static bool Scan_For_Proximity_Check(CELL cell, HouseClass* house, bool allowBui
             return true;
         }
 
-        if (Scan_For_Proximity_Check(newcell, house, allowBuildingBesideWalls, remainingDistance - 1)) {
+        if (Scan_For_Proximity_Check(newcell, house, allow_building_beside_walls, remaining_distance - 1)) {
             return true;
         }
     }
@@ -5639,16 +5693,18 @@ bool BuildingClass::Passes_Proximity_Check(CELL homecell)
     **	cells to these are of friendly persuasion, then consider the proximity check to
     **	have been a success.
     */
-    auto maxPlacementDistance = Rule.Get_Rule_Value<int>(GAME_MAP_SECTION, MAX_BUILD_DISTANCE_RULE);
-    auto preventBuildingInShroud = Rule.Get_Rule_Value<bool>(GAME_MAP_SECTION, PREVENT_BUILDING_IN_SHROUD_RULE);
-    auto allowBuildingBesideWalls = Rule.Get_Rule_Value<bool>(GAME_MAP_SECTION, ALLOW_BUILDING_BESIDE_WALLS_RULE);
+    const auto max_placement_distance = Rule.Get_Rule_Value<int>(ENHANCEMENTS_SECTION, MAX_BUILD_DISTANCE_RULE);
+    const auto prevent_building_in_shroud =
+        Rule.Get_Rule_Value<bool>(GAME_MAP_SECTION, PREVENT_BUILDING_IN_SHROUD_RULE);
+    const auto allow_building_beside_walls =
+        Rule.Get_Rule_Value<bool>(GAME_MAP_SECTION, ALLOW_BUILDING_BESIDE_WALLS_RULE);
 
     auto ptr = Occupy_List(true);
 
     while (*ptr != REFRESH_EOL) {
         CELL cell = homecell + *ptr++;
 
-        if (preventBuildingInShroud && !Map.In_Radar(cell)) {
+        if (prevent_building_in_shroud && !Map.In_Radar(cell)) {
             return false;
         }
     }
@@ -5658,10 +5714,9 @@ bool BuildingClass::Passes_Proximity_Check(CELL homecell)
     while (*ptr != REFRESH_EOL) {
         CELL cell = homecell + *ptr++;
 
-        auto maxDistance = maxPlacementDistance;
-        auto proximityDetected = Scan_For_Proximity_Check(cell, House, allowBuildingBesideWalls, maxDistance);
+        auto proximity_detected = Scan_For_Proximity_Check(cell, House, allow_building_beside_walls, max_placement_distance);
 
-        if (proximityDetected) {
+        if (proximity_detected) {
             return true;
         }
     }

--- a/tiberiandawn/building.h
+++ b/tiberiandawn/building.h
@@ -333,6 +333,9 @@ private:
 
     void Player_Set_Rally_Point(TARGET target);
 
+    bool Create_Overlay_At(const OverlayTypeClass& overlay, const CELL cell) const;
+    virtual bool Unlimbo_Wall(COORDINATE);
+
     /*
     ** Some additional padding in case we need to add data to the class and maintain backwards compatibility for
     *save/load

--- a/tiberiandawn/conquer.cpp
+++ b/tiberiandawn/conquer.cpp
@@ -158,11 +158,7 @@ void Main_Game(int argc, char* argv[])
 
         fade = true;
 
-        if (Map.Is_Smaller_Than_Screen()) {
-            Map.Set_View_Dimensions(0, Map.Get_Tab_Height());
-            Map.Flag_To_Redraw(true);
-            Map.Render();
-        }
+        Map.Redraw_If_Smaller_Then_Screen();
 
         /*
         **	Make the game screen visible, clear the keyboard buffer of spurious
@@ -1839,11 +1835,7 @@ bool Main_Loop()
         Do_Restart();
         Set_Video_Cursor_Clip(true);
 
-        if (Map.Is_Smaller_Than_Screen()) {
-            Map.Set_View_Dimensions(0, Map.Get_Tab_Height());
-            Map.Flag_To_Redraw(true);
-            Map.Render();
-        }
+        Map.Redraw_If_Smaller_Then_Screen();
     }
 
     /*

--- a/tiberiandawn/const.cpp
+++ b/tiberiandawn/const.cpp
@@ -464,3 +464,5 @@ unsigned char const RemapNone[256] = {
     224, 225, 226, 227, 228, 229, 230, 231, 232, 233, 234, 235, 236, 237, 238, 239, // 224..239
     240, 241, 242, 243, 244, 245, 246, 247, 248, 249, 250, 251, 252, 253, 254, 255  // 240..255
 };
+
+const FacingType FacingCardinals[4]{ FACING_N, FACING_E, FACING_S, FACING_W };

--- a/tiberiandawn/display.cpp
+++ b/tiberiandawn/display.cpp
@@ -833,9 +833,9 @@ bool DisplayClass::Passes_Proximity_Check(ObjectTypeClass const* object)
 }
 
 #ifdef USE_RA_AI
-bool DisplayClass::Scan_For_Proximity(CELL cell, HousesType house, bool preventBuildingInShroud, bool allowBuildingBesideWalls, int remainingDistance) const
+bool DisplayClass::Scan_For_Proximity(CELL cell, HousesType house, bool prevent_building_in_shroud, bool allow_building_beside_walls, int remaining_distance) const
 {
-	if (remainingDistance < 1) {
+	if (remaining_distance < 1) {
 		return false;
 	}
 
@@ -846,7 +846,7 @@ bool DisplayClass::Scan_For_Proximity(CELL cell, HousesType house, bool preventB
 			continue;
 		}
 
-		if (preventBuildingInShroud && !In_Radar(cell))
+		if (prevent_building_in_shroud && !In_Radar(cell))
 		{
 			return false;
 		}
@@ -857,7 +857,9 @@ bool DisplayClass::Scan_For_Proximity(CELL cell, HousesType house, bool preventB
 		**	building located there.
 		*/
 		if ((*this)[newcell].Owner == house) {
-			if (allowBuildingBesideWalls || !OverlayTypeClass::As_Reference((*this)[newcell].Overlay).IsWall) {
+			if (allow_building_beside_walls
+			    && (*this)[newcell].Overlay != OVERLAY_NONE
+			    && OverlayTypeClass::As_Reference((*this)[newcell].Overlay).IsWall) {
 				return true;
 			}
 		}
@@ -870,7 +872,7 @@ bool DisplayClass::Scan_For_Proximity(CELL cell, HousesType house, bool preventB
 			return true;
 		}
 
-		if (Scan_For_Proximity(newcell, house, preventBuildingInShroud, allowBuildingBesideWalls, remainingDistance - 1)) {
+		if (Scan_For_Proximity(newcell, house, prevent_building_in_shroud, allow_building_beside_walls, remaining_distance - 1)) {
 			return true;
 		}
 	}
@@ -926,9 +928,11 @@ bool DisplayClass::Passes_Proximity_Check(ObjectTypeClass const * object, Houses
 		return(true);
 	}
 
-	auto maxPlacementDistance = Rule.Get_Rule_Value<int>(GAME_MAP_SECTION, MAX_BUILD_DISTANCE_RULE);
-	auto preventBuildingInShroud = Rule.Get_Rule_Value<bool>(GAME_MAP_SECTION, PREVENT_BUILDING_IN_SHROUD_RULE);
-	auto allowBuildingBesideWalls = Rule.Get_Rule_Value<bool>(GAME_MAP_SECTION, ALLOW_BUILDING_BESIDE_WALLS_RULE);
+	auto max_placement_distance = Rule.Get_Rule_Value<int>(ENHANCEMENTS_SECTION, MAX_BUILD_DISTANCE_RULE);
+	auto prevent_building_in_shroud =
+	    Rule.Get_Rule_Value<bool>(GAME_MAP_SECTION, PREVENT_BUILDING_IN_SHROUD_RULE);
+	auto allow_building_beside_walls =
+	    Rule.Get_Rule_Value<bool>(GAME_MAP_SECTION, ALLOW_BUILDING_BESIDE_WALLS_RULE);
 
 	/*
 	**	Scan through all cells that the building foundation would cover. If any adjacent
@@ -940,7 +944,7 @@ bool DisplayClass::Passes_Proximity_Check(ObjectTypeClass const * object, Houses
 		CELL cell = trycell + *ptr++;
 
         // BUG: Doesn't prevent building in shroud
-		if (preventBuildingInShroud && !Map.In_Radar(cell)) {
+		if (prevent_building_in_shroud && !Map.In_Radar(cell)) {
 			return false;
 		}
 	}
@@ -949,8 +953,14 @@ bool DisplayClass::Passes_Proximity_Check(ObjectTypeClass const * object, Houses
 	while (*ptr != REFRESH_EOL) {
 		CELL cell = trycell + *ptr++;
 
-		auto maximumDistance = maxPlacementDistance;
-		auto proximityDetected = Scan_For_Proximity(cell, house, preventBuildingInShroud, allowBuildingBesideWalls, maximumDistance);
+		auto maximumDistance = max_placement_distance;
+		auto proximityDetected = Scan_For_Proximity(
+		    cell,
+		    house,
+		    prevent_building_in_shroud,
+		    allow_building_beside_walls,
+		    maximumDistance
+		);
 
 		if (proximityDetected)
 		{
@@ -1205,6 +1215,8 @@ void DisplayClass::AI(KeyNumType& input, int x, int y)
             || Get_Mouse_Y() >= (TacPixelY + Lepton_To_Pixel(TacLeptonHeight)))) {
         Mouse_Left_Release(-1, Get_Mouse_X(), Get_Mouse_Y(), NULL, ACTION_NONE);
     }
+
+	Update_Placement_Cursor();
 
     MapClass::AI(input, x, y);
 }
@@ -2470,6 +2482,75 @@ void DisplayClass::Draw_It(bool forced)
     }
 }
 
+/**
+ * This routine will run any updates for the cursor while in placement mode
+ */
+void DisplayClass::Update_Placement_Cursor()
+{
+    const auto modern_walls = Rule.Get_Rule_Value<bool>(ENHANCEMENTS_SECTION, MODERN_WALL_BUILDING_RULE);
+	const auto wall_length = Rule.Get_Rule_Value<int>(ENHANCEMENTS_SECTION, MODERN_WALL_MAX_LENGTH_RULE);
+
+	if (!modern_walls || wall_length < 2 || !In_Radar(ZoneCell))
+	{
+		return;
+	}
+
+	const auto placementBuilding = PendingObject
+		&& PendingObject->What_Am_I() == RTTI_BUILDINGTYPE
+			? static_cast<const BuildingTypeClass*>(PendingObject)
+			: nullptr;
+
+	if (placementBuilding == nullptr || !placementBuilding->IsWall)
+	{
+		return;
+	}
+
+#ifdef REMASTER_BUILD
+    bool ctrldown = DLL_Export_Get_Input_Key_State(KN_LCTRL);
+#else
+    bool ctrldown = (Keyboard->Down(Options.KeyForceAttack1) || Keyboard->Down(Options.KeyForceAttack2));
+#endif
+
+	if (!In_Radar(ZoneCell) || ctrldown) {
+		if (CursorSize[1] != REFRESH_EOL) {
+			Set_Cursor_Shape(placementBuilding->Occupy_List(true));
+		}
+
+		return;
+	}
+
+	short offset_list[50];
+	auto constexpr max_offsets = std::size(offset_list) - 1;
+	const auto wall_overlay = placementBuilding->OverlayToPlace;
+
+	auto offsets_length = 1;
+
+	offset_list[0] = 0;
+
+	for (const auto& dir : FacingCardinals)
+	{
+		const auto scan_distance = Scan_For_Overlay(ZoneCell, dir, wall_overlay, wall_length);
+
+		//Break out if we're going to overflow the buffer
+		if (offsets_length + scan_distance > max_offsets) {
+			break;
+		}
+
+		auto current = ZoneCell;
+
+		for (auto i =  0; i < scan_distance; ++i)
+		{
+			current = Adjacent_Cell(current, dir);
+
+			offset_list[offsets_length++] = current - ZoneCell - ZoneOffset;
+		}
+	}
+
+	offset_list[offsets_length] = REFRESH_EOL;
+
+	Set_Cursor_Shape(offset_list);
+}
+
 /***********************************************************************************************
  * DisplayClass::Redraw_Icons -- Draws all terrain icons necessary.                            *
  *                                                                                             *
@@ -2702,6 +2783,8 @@ void DisplayClass::Redraw_Shadow_Rects(void)
         }
     }
 }
+
+
 
 /***********************************************************************************************
  * DisplayClass::Next_Object -- Searches for next object on display.                           *

--- a/tiberiandawn/display.h
+++ b/tiberiandawn/display.h
@@ -185,7 +185,7 @@ public:
     bool In_View(CELL cell);
     bool Passes_Proximity_Check(ObjectTypeClass const* object);
 #ifdef USE_RA_AI
-    bool Scan_For_Proximity(CELL cell, HousesType house, bool preventBuildingInShroud, bool allowBuildingBesideWalls, int remainingDistance) const;
+    bool Scan_For_Proximity(CELL cell, HousesType house, bool prevent_building_in_shroud, bool allow_building_beside_walls, int remaining_distance) const;
     bool Passes_Proximity_Check(ObjectTypeClass const* object, HousesType house, short const* list, CELL trycell) const;
 #endif
     ObjectClass* Cell_Object(CELL cell, int x = 0, int y = 0);
@@ -330,6 +330,8 @@ private:
     void Redraw_Icons(int draw_flags = 0);
     void Redraw_Shadow(void);
     void Redraw_Shadow_Rects(void);
+
+    void Update_Placement_Cursor();
 
     /*
     **	This bit array is used to flag cells to be redrawn. If the icon needs to

--- a/tiberiandawn/dllinterface.cpp
+++ b/tiberiandawn/dllinterface.cpp
@@ -6029,81 +6029,81 @@ void DLLExportClass::Cell_Class_Draw_It(CNCDynamicMapStruct* dynamic_map,
     }
 
     // render wall placement markers
-	if (cell_ptr->IsCursorHere && Map.PendingObject) {
-		auto isWall = (*Map.PendingObject).What_Am_I() == RTTI_BUILDINGTYPE
+	if (cell_ptr->IsCursorHere && Map.PendingObject != nullptr) {
+		auto is_wall = Map.PendingObject->What_Am_I() == RTTI_BUILDINGTYPE
 			&& static_cast<const BuildingTypeClass&>(*Map.PendingObject).IsWall;
 
-		if (!isWall || Map.ZoneCell == cell_ptr->Cell_Number()) {
+		if (!is_wall || Map.ZoneCell == cell_ptr->Cell_Number()) {
 			return;
 		}
 
-		auto& cursorEntry = dynamic_map->Entries[entry_index++];
+		auto& cursor_entry = dynamic_map->Entries[entry_index++];
 
 		strncpy(
-			cursorEntry.AssetName,
+			cursor_entry.AssetName,
 			cell_ptr->Is_Generally_Clear()
 				? "PLACEMENT_EXTRA"
 				: "PLACEMENT_BAD",
 			CNC_OBJECT_ASSET_NAME_LENGTH
 		);
 
-		cursorEntry.AssetName[CNC_OBJECT_ASSET_NAME_LENGTH - 1] = 0;
-		cursorEntry.Type = -1;
-		cursorEntry.Owner = (char)cell_ptr->Owner;
-		cursorEntry.DrawFlags = SHAPE_CENTER | SHAPE_GHOST | SHAPE_COLOR;
-		cursorEntry.PositionX = xpixel + (ICON_PIXEL_W / 2);
-		cursorEntry.PositionY = ypixel + (ICON_PIXEL_H / 2);
-		cursorEntry.Width = 24;
-		cursorEntry.Height = 24;
-		cursorEntry.CellX = Cell_X(cell);
-		cursorEntry.CellY = Cell_Y(cell);
-		cursorEntry.ShapeIndex = 0;
-		cursorEntry.IsSmudge = true;
-		cursorEntry.IsOverlay = false;
-		cursorEntry.IsResource = false;
-		cursorEntry.IsSellable = false;
-		cursorEntry.IsTheaterShape = false;
-		cursorEntry.IsFlag = false;
+		cursor_entry.AssetName[CNC_OBJECT_ASSET_NAME_LENGTH - 1] = 0;
+		cursor_entry.Type = -1;
+		cursor_entry.Owner = (char)cell_ptr->Owner;
+		cursor_entry.DrawFlags = SHAPE_CENTER | SHAPE_GHOST | SHAPE_COLOR;
+		cursor_entry.PositionX = xpixel + (ICON_PIXEL_W / 2);
+		cursor_entry.PositionY = ypixel + (ICON_PIXEL_H / 2);
+		cursor_entry.Width = 24;
+		cursor_entry.Height = 24;
+		cursor_entry.CellX = Cell_X(cell);
+		cursor_entry.CellY = Cell_Y(cell);
+		cursor_entry.ShapeIndex = 0;
+		cursor_entry.IsSmudge = true;
+		cursor_entry.IsOverlay = false;
+		cursor_entry.IsResource = false;
+		cursor_entry.IsSellable = false;
+		cursor_entry.IsTheaterShape = false;
+		cursor_entry.IsFlag = false;
 	}
 
     /*
     ** Render wall placement markers.
     */
-    if (cell_ptr->IsCursorHere && Map.PendingObject) {
-        auto isWall = (*Map.PendingObject).What_Am_I() == RTTI_BUILDINGTYPE
+    if (cell_ptr->IsCursorHere && Map.PendingObject != nullptr) {
+        auto is_wall = Map.PendingObject->What_Am_I() == RTTI_BUILDINGTYPE
             && static_cast<const BuildingTypeClass&>(*Map.PendingObject).IsWall;
 
-        if (!isWall || Map.ZoneCell == cell_ptr->Cell_Number()) {
+        if (!is_wall || Map.ZoneCell == cell_ptr->Cell_Number()) {
             return;
         }
 
-        auto& cursorEntry = dynamic_map->Entries[entry_index++];
+        auto& cursor_entry = dynamic_map->Entries[entry_index++];
 
         strncpy(
-            cursorEntry.AssetName,
+            cursor_entry.AssetName,
             cell_ptr->Is_Generally_Clear()
                 ? "PLACEMENT_EXTRA"
                 : "PLACEMENT_BAD",
             CNC_OBJECT_ASSET_NAME_LENGTH
         );
 
-        cursorEntry.AssetName[CNC_OBJECT_ASSET_NAME_LENGTH - 1] = 0;
-        cursorEntry.Type = -1;
-        cursorEntry.Owner = (char)cell_ptr->Owner;
-        cursorEntry.DrawFlags = SHAPE_CENTER | SHAPE_GHOST | SHAPE_COLOR;
-        cursorEntry.PositionX = xpixel + (ICON_PIXEL_W / 2);
-        cursorEntry.PositionY = ypixel + (ICON_PIXEL_H / 2);
-        cursorEntry.Width = 24;
-        cursorEntry.Height = 24;
-        cursorEntry.CellX = Cell_X(cell);
-        cursorEntry.CellY = Cell_Y(cell);
-        cursorEntry.ShapeIndex = 0;
-        cursorEntry.IsSmudge = true;
-        cursorEntry.IsOverlay = false;
-        cursorEntry.IsResource = false;
-        cursorEntry.IsSellable = false;
-        cursorEntry.IsTheaterShape = false;
-        cursorEntry.IsFlag = false;
+        cursor_entry.AssetName[CNC_OBJECT_ASSET_NAME_LENGTH - 1] = 0;
+        cursor_entry.Type = -1;
+        cursor_entry.Owner = (char)cell_ptr->Owner;
+        cursor_entry.DrawFlags = SHAPE_CENTER | SHAPE_GHOST | SHAPE_COLOR;
+        cursor_entry.PositionX = xpixel + (ICON_PIXEL_W / 2);
+        cursor_entry.PositionY = ypixel + (ICON_PIXEL_H / 2);
+        cursor_entry.Width = 24;
+        cursor_entry.Height = 24;
+        cursor_entry.CellX = Cell_X(cell);
+        cursor_entry.CellY = Cell_Y(cell);
+        cursor_entry.ShapeIndex = 0;
+        cursor_entry.IsSmudge = true;
+        cursor_entry.IsOverlay = false;
+        cursor_entry.IsResource = false;
+        cursor_entry.IsSellable = false;
+        cursor_entry.IsTheaterShape = false;
+        cursor_entry.IsFlag = false;
     }
 }
 

--- a/tiberiandawn/dllinterface.cpp
+++ b/tiberiandawn/dllinterface.cpp
@@ -3221,7 +3221,7 @@ void DLLExportClass::DLL_Draw_Intercept(int shape_number,
         if (is_infantry) {
             InfantryClass* infantry = static_cast<InfantryClass*>(object);
             new_object.ControlGroup = infantry->Group;
-            new_object.CanPlaceBombs = infantry->Class->Type == INFANTRY_RAMBO;
+            new_object.CanPlaceBombs = infantry->Class->HasC4Charges;
         }
 
         new_object.CanHarvest = false;

--- a/tiberiandawn/dllinterface.cpp
+++ b/tiberiandawn/dllinterface.cpp
@@ -7797,13 +7797,13 @@ bool SaveGameRemasterState_v1::Validate() const
 
     auto result = true;
 
-    std::map<std::string, nlohmann::json> player_fields = {
+    std::unordered_map<std::string, nlohmann::json> player_fields = {
         {NAMEOF(RemasterMultiplayerStartPositions), RemasterMultiplayerStartPositions},
         {NAMEOF(RemasterPlayerIDs), RemasterPlayerIDs},
         {NAMEOF(RemasterMPlayerIsHuman), RemasterMPlayerIsHuman},
         {NAMEOF(RemasterPlacementType), RemasterPlacementType},
         {NAMEOF(RemasterMultiplayerSidebars), RemasterMultiplayerSidebars}
-};
+    };
 
     for (const auto& [field, json_value] : player_fields) {
         if (!json_value.is_array()) {

--- a/tiberiandawn/dllinterface.cpp
+++ b/tiberiandawn/dllinterface.cpp
@@ -6027,10 +6027,8 @@ void DLLExportClass::Cell_Class_Draw_It(CNCDynamicMapStruct* dynamic_map,
             flag_entry.IsFlag = true;
         }
     }
-	*Render wall placement markers.
-	*Special thanks to pchote for this, getting the cursor rendering in classic was easy
-	*getting it to render in glyphX has been difficult
-	*/
+
+    // render wall placement markers
 	if (cell_ptr->IsCursorHere && Map.PendingObject) {
 		auto isWall = (*Map.PendingObject).What_Am_I() == RTTI_BUILDINGTYPE
 			&& static_cast<const BuildingTypeClass&>(*Map.PendingObject).IsWall;

--- a/tiberiandawn/dllinterface.cpp
+++ b/tiberiandawn/dllinterface.cpp
@@ -4434,9 +4434,9 @@ static const int _map_width_shift_bits = 7;
 static const int _map_width_shift_bits = 6;
 #endif
 
-static void Scan_For_Valid_Placement(CELL cell, unsigned char* placement_distance, bool preventBuildingInShroud, bool allowBuildingBesideWalls, int remainingDistance)
+static void Scan_For_Valid_Placement(CELL cell, unsigned char* placement_distance, bool prevent_building_in_shroud, bool allow_building_beside_walls, int remaining_distance)
 {
-	if (remainingDistance < 1)
+	if (remaining_distance < 1)
 	{
 		return;
 	}
@@ -4449,15 +4449,17 @@ static void Scan_For_Valid_Placement(CELL cell, unsigned char* placement_distanc
 			continue;
 		}
 
-		if (!allowBuildingBesideWalls && OverlayTypeClass::As_Reference(Map[adjcell].Overlay).IsWall) {
-			return;
-		}
+	    if (allow_building_beside_walls
+	        && Map[adjcell].Overlay == OVERLAY_NONE
+	        && OverlayTypeClass::As_Reference(Map[adjcell].Overlay).IsWall) {
+	        return;
+	    }
 
-		if (!preventBuildingInShroud || Map.In_Radar(adjcell)) {
+		if (!prevent_building_in_shroud || Map.In_Radar(adjcell)) {
 			placement_distance[adjcell] = min(placement_distance[adjcell], 1U);
 		}
 
-		Scan_For_Valid_Placement(adjcell, placement_distance, preventBuildingInShroud, allowBuildingBesideWalls, remainingDistance - 1);
+		Scan_For_Valid_Placement(adjcell, placement_distance, prevent_building_in_shroud, allow_building_beside_walls, remaining_distance - 1);
 	}
 }
 
@@ -4486,9 +4488,9 @@ void DLLExportClass::Calculate_Placement_Distances(BuildingTypeClass* placement_
         map_cell_height++;
     }
 
-	auto maxPlacementDistance = Rule.Get_Rule_Value<int>(GAME_MAP_SECTION, MAX_BUILD_DISTANCE_RULE);
-	auto preventBuildingInShroud = Rule.Get_Rule_Value<bool>(GAME_MAP_SECTION, PREVENT_BUILDING_IN_SHROUD_RULE);
-	auto allowBuildingBesideWalls = Rule.Get_Rule_Value<bool>(GAME_MAP_SECTION, ALLOW_BUILDING_BESIDE_WALLS_RULE);
+	auto max_placement_distance = Rule.Get_Rule_Value<int>(ENHANCEMENTS_SECTION, MAX_BUILD_DISTANCE_RULE);
+	auto prevent_building_in_shroud = Rule.Get_Rule_Value<bool>(GAME_MAP_SECTION, PREVENT_BUILDING_IN_SHROUD_RULE);
+	auto allow_building_beside_walls = Rule.Get_Rule_Value<bool>(GAME_MAP_SECTION, ALLOW_BUILDING_BESIDE_WALLS_RULE);
 
     memset(placement_distance, 255U, MAP_CELL_TOTAL);
     for (int y = 0; y < map_cell_height; y++) {
@@ -4499,9 +4501,7 @@ void DLLExportClass::Calculate_Placement_Distances(BuildingTypeClass* placement_
                 || (Map[cell].Owner == PlayerPtr->Class->House)) {
 				placement_distance[cell] = 0U;
 
-				auto maxPlacement = maxPlacementDistance;
-
-				Scan_For_Valid_Placement(cell, placement_distance, preventBuildingInShroud, allowBuildingBesideWalls, maxPlacement);
+				Scan_For_Valid_Placement(cell, placement_distance, prevent_building_in_shroud, allow_building_beside_walls, max_placement_distance);
             }
         }
     }
@@ -6026,6 +6026,86 @@ void DLLExportClass::Cell_Class_Draw_It(CNCDynamicMapStruct* dynamic_map,
             flag_entry.IsTheaterShape = false;
             flag_entry.IsFlag = true;
         }
+    }
+	*Render wall placement markers.
+	*Special thanks to pchote for this, getting the cursor rendering in classic was easy
+	*getting it to render in glyphX has been difficult
+	*/
+	if (cell_ptr->IsCursorHere && Map.PendingObject) {
+		auto isWall = (*Map.PendingObject).What_Am_I() == RTTI_BUILDINGTYPE
+			&& static_cast<const BuildingTypeClass&>(*Map.PendingObject).IsWall;
+
+		if (!isWall || Map.ZoneCell == cell_ptr->Cell_Number()) {
+			return;
+		}
+
+		auto& cursorEntry = dynamic_map->Entries[entry_index++];
+
+		strncpy(
+			cursorEntry.AssetName,
+			cell_ptr->Is_Generally_Clear()
+				? "PLACEMENT_EXTRA"
+				: "PLACEMENT_BAD",
+			CNC_OBJECT_ASSET_NAME_LENGTH
+		);
+
+		cursorEntry.AssetName[CNC_OBJECT_ASSET_NAME_LENGTH - 1] = 0;
+		cursorEntry.Type = -1;
+		cursorEntry.Owner = (char)cell_ptr->Owner;
+		cursorEntry.DrawFlags = SHAPE_CENTER | SHAPE_GHOST | SHAPE_COLOR;
+		cursorEntry.PositionX = xpixel + (ICON_PIXEL_W / 2);
+		cursorEntry.PositionY = ypixel + (ICON_PIXEL_H / 2);
+		cursorEntry.Width = 24;
+		cursorEntry.Height = 24;
+		cursorEntry.CellX = Cell_X(cell);
+		cursorEntry.CellY = Cell_Y(cell);
+		cursorEntry.ShapeIndex = 0;
+		cursorEntry.IsSmudge = true;
+		cursorEntry.IsOverlay = false;
+		cursorEntry.IsResource = false;
+		cursorEntry.IsSellable = false;
+		cursorEntry.IsTheaterShape = false;
+		cursorEntry.IsFlag = false;
+	}
+
+    /*
+    ** Render wall placement markers.
+    */
+    if (cell_ptr->IsCursorHere && Map.PendingObject) {
+        auto isWall = (*Map.PendingObject).What_Am_I() == RTTI_BUILDINGTYPE
+            && static_cast<const BuildingTypeClass&>(*Map.PendingObject).IsWall;
+
+        if (!isWall || Map.ZoneCell == cell_ptr->Cell_Number()) {
+            return;
+        }
+
+        auto& cursorEntry = dynamic_map->Entries[entry_index++];
+
+        strncpy(
+            cursorEntry.AssetName,
+            cell_ptr->Is_Generally_Clear()
+                ? "PLACEMENT_EXTRA"
+                : "PLACEMENT_BAD",
+            CNC_OBJECT_ASSET_NAME_LENGTH
+        );
+
+        cursorEntry.AssetName[CNC_OBJECT_ASSET_NAME_LENGTH - 1] = 0;
+        cursorEntry.Type = -1;
+        cursorEntry.Owner = (char)cell_ptr->Owner;
+        cursorEntry.DrawFlags = SHAPE_CENTER | SHAPE_GHOST | SHAPE_COLOR;
+        cursorEntry.PositionX = xpixel + (ICON_PIXEL_W / 2);
+        cursorEntry.PositionY = ypixel + (ICON_PIXEL_H / 2);
+        cursorEntry.Width = 24;
+        cursorEntry.Height = 24;
+        cursorEntry.CellX = Cell_X(cell);
+        cursorEntry.CellY = Cell_Y(cell);
+        cursorEntry.ShapeIndex = 0;
+        cursorEntry.IsSmudge = true;
+        cursorEntry.IsOverlay = false;
+        cursorEntry.IsResource = false;
+        cursorEntry.IsSellable = false;
+        cursorEntry.IsTheaterShape = false;
+        cursorEntry.IsFlag = false;
     }
 }
 

--- a/tiberiandawn/externs.h
+++ b/tiberiandawn/externs.h
@@ -434,4 +434,6 @@ extern bool ShareAllyVisibility;
 // OmniBlade - Moves from tcpip.cpp as part of networking cleanup.
 extern bool Server; // Is this player acting as client or server
 
+extern const FacingType FacingCardinals[4];
+
 #endif

--- a/tiberiandawn/hdata.cpp
+++ b/tiberiandawn/hdata.cpp
@@ -299,7 +299,7 @@ HouseTypeClass& HouseTypeClass::As_Mutable_Reference(HousesType house)
 
 void HouseTypeClass::Set_Remap_Color_Table()
 {
-    static std::map<PlayerColorType, unsigned char const*> color_to_table {
+    static std::unordered_map<PlayerColorType, unsigned char const*> color_to_table {
         { REMAP_GOLD, RemapGold },
         { REMAP_LTBLUE, RemapLtBlue },
         { REMAP_RED, RemapRed },

--- a/tiberiandawn/house.cpp
+++ b/tiberiandawn/house.cpp
@@ -4804,7 +4804,17 @@ void HouseClass::Sell_Wall(CELL cell)
                         Sound_Effect(VOC_CASHTURN);
                     }
 
-                    Refund_Money(btype->Cost_Of() / 2);
+                    const auto modern_walls =
+                        Rule.Get_Rule_Value<bool>(ENHANCEMENTS_SECTION, MODERN_WALL_BUILDING_RULE);
+                    const auto wall_length =
+                        Rule.Get_Rule_Value<int>(ENHANCEMENTS_SECTION, MODERN_WALL_MAX_LENGTH_RULE);
+                    const auto full_cost_walls =
+                        Rule.Get_Rule_Value<bool>(ENHANCEMENTS_SECTION, MODERN_WALL_FULL_COST_RULE);
+
+                    if (!IsHuman || !modern_walls || wall_length < 2 || full_cost_walls) {
+                        Refund_Money(btype->Cost_Of() / 2); // TODO: add modifier rule for wall sell value
+                    }
+
                     Map[cell].Overlay = OVERLAY_NONE;
                     Map[cell].OverlayData = 0;
                     Map[cell].Owner = HOUSE_NONE;

--- a/tiberiandawn/house.cpp
+++ b/tiberiandawn/house.cpp
@@ -6207,7 +6207,7 @@ int HouseClass::AI_Building(void)
         **	will be sufficient money to train troopers.
         */
         current = BQuantity[STRUCT_BARRACKS] + BQuantity[STRUCT_HAND];
-        if (current < Round_Up(Rule.BarracksRatio * fixed(CurBuildings)) && current < (unsigned)Rule.BarracksLimit
+        if (current < Round_Up(Rule.InfantryFactoryRatio * fixed(CurBuildings)) && current < (unsigned)Rule.InfantryFactoryLimit
             && (money > 300 || hasincome)) {
             b = &BuildingTypeClass::As_Reference(STRUCT_BARRACKS);
             if (Can_Build(b, ActLike) && (b->Cost_Of() < money || hasincome)) {
@@ -6233,7 +6233,7 @@ int HouseClass::AI_Building(void)
         **	be sufficient money to build vehicles.
         */
         current = BQuantity[STRUCT_WEAP] + BQuantity[STRUCT_AIRSTRIP];
-        if (current < Round_Up(Rule.WarRatio * fixed(CurBuildings)) && current < (unsigned)Rule.WarLimit
+        if (current < Round_Up(Rule.UnitFactoryRatio * fixed(CurBuildings)) && current < (unsigned)Rule.UnitFactoryLimit
             && (money > 2000 || hasincome)) {
             b = &BuildingTypeClass::As_Reference(STRUCT_WEAP);
 
@@ -6291,7 +6291,7 @@ int HouseClass::AI_Building(void)
     **	Advanced base defense would be good. (TobiasKarnat)
     */
         current = BQuantity[STRUCT_ATOWER] + BQuantity[STRUCT_OBELISK];
-        if (current < Round_Up(Rule.TeslaRatio * fixed(CurBuildings)) && current < (unsigned)Rule.TeslaLimit) {
+        if (current < Round_Up(Rule.AdvancedDefenceRatio * fixed(CurBuildings)) && current < (unsigned)Rule.AdvancedDefenceLimit) {
             b = &BuildingTypeClass::As_Reference(STRUCT_ATOWER);
             if (Can_Build(b, ActLike) && (b->Cost_Of() < money || hasincome) && Power_Fraction() >= 1) {
                 choiceptr = BuildChoice.Alloc();

--- a/tiberiandawn/idata.cpp
+++ b/tiberiandawn/idata.cpp
@@ -406,7 +406,9 @@ static InfantryTypeClass const E5(INFANTRY_E5,           // Infantry type number
                                 { HOUSE_BAD, HOUSE_MULTI1, HOUSE_MULTI2, HOUSE_MULTI3, HOUSE_MULTI4, HOUSE_MULTI5, HOUSE_MULTI6, HOUSE_JP }, // Who can own this infantry unit.
                                   WEAPON_CHEMSPRAY,
                                   WEAPON_NONE,
-                                  MPH_SLOW);
+                                  MPH_SLOW,
+                                  false,
+                                  true);
 
 // Engineer
 
@@ -1495,7 +1497,8 @@ InfantryTypeClass::InfantryTypeClass(InfantryType type,
                                      WeaponType primary,
                                      WeaponType secondary,
                                      MPHType maxspeed,
-                                     bool has_c4_charges)
+                                     bool has_c4_charges,
+                                     bool is_immune_to_tiberium)
     : TechnoTypeClass(name,
                       ininame,
                       std::move(cameo_name),
@@ -1552,6 +1555,7 @@ InfantryTypeClass::InfantryTypeClass(InfantryType type,
         DoControls[i].Jump = *do_table++;
     }
 
+    IsImmuneToTiberium = is_immune_to_tiberium;
     HasC4Charges = has_c4_charges;
 #ifdef cuts // ST - 10/3/95 10:09AM
     DoControls[DO_STAND_READY].Frame = dostandready;

--- a/tiberiandawn/idata.cpp
+++ b/tiberiandawn/idata.cpp
@@ -545,7 +545,8 @@ static InfantryTypeClass const Commando(INFANTRY_RAMBO,     // Infantry type num
                                         { HOUSE_MULTI1, HOUSE_MULTI2, HOUSE_MULTI3, HOUSE_MULTI4, HOUSE_MULTI5, HOUSE_MULTI6, HOUSE_JP, HOUSE_GOOD, HOUSE_BAD }, // Who can own this infantry unit.
                                         WEAPON_RIFLE,
                                         WEAPON_NONE,
-                                        MPH_SLOW_ISH // Maximum speed of infantry.
+                                        MPH_SLOW_ISH, // Maximum speed of infantry.
+                                        true
 );
 
 // Civilians
@@ -1493,7 +1494,8 @@ InfantryTypeClass::InfantryTypeClass(InfantryType type,
                                      std::vector<HousesType> ownableBy,
                                      WeaponType primary,
                                      WeaponType secondary,
-                                     MPHType maxspeed)
+                                     MPHType maxspeed,
+                                     bool has_c4_charges)
     : TechnoTypeClass(name,
                       ininame,
                       std::move(cameo_name),
@@ -1550,6 +1552,7 @@ InfantryTypeClass::InfantryTypeClass(InfantryType type,
         DoControls[i].Jump = *do_table++;
     }
 
+    HasC4Charges = has_c4_charges;
 #ifdef cuts // ST - 10/3/95 10:09AM
     DoControls[DO_STAND_READY].Frame = dostandready;
     DoControls[DO_STAND_READY].Count = dostandreadyframe;

--- a/tiberiandawn/infantry.cpp
+++ b/tiberiandawn/infantry.cpp
@@ -2882,9 +2882,10 @@ ActionType InfantryClass::What_Action(ObjectClass* object) const
     ActionType action = FootClass::What_Action(object);
 
     /*
-    **	First see if it's a commando, and if he's attacking a building, have him return ACTION_SABOTAGE instead
+    **	First see if infantry has C4 charges, and if he's attacking a building, have him return ACTION_SABOTAGE instead
     */
-    if (*this == INFANTRY_RAMBO && action == ACTION_ATTACK && object->What_Am_I() == RTTI_BUILDING) {
+    if (this->Class->HasC4Charges && action == ACTION_ATTACK && object->What_Am_I() == RTTI_BUILDING) {
+        // TODO: investigate doing this to units (like RA2 Tanya)
         return (ACTION_SABOTAGE);
     }
 

--- a/tiberiandawn/infantry.cpp
+++ b/tiberiandawn/infantry.cpp
@@ -2557,7 +2557,9 @@ TARGET InfantryClass::Greatest_Threat(ThreatType threat) const
     **	unless specifically in hunt mode.
     */
     case WEAPON_RIFLE:
-        if (House->IsHuman && (Mission == MISSION_GUARD || Mission == MISSION_GUARD_AREA)) {
+        const auto commando_guard_rule = Rule.Get_Rule_Value<bool>(ENHANCEMENTS_SECTION, COMMANDO_GUARD_RULE);
+
+        if (House->IsHuman && (Mission == MISSION_GUARD || Mission == MISSION_GUARD_AREA) && !commando_guard_rule) {
             return (TARGET_NONE);
         }
         return (TechnoClass::Greatest_Threat(threat | THREAT_INFANTRY | THREAT_BUILDINGS));

--- a/tiberiandawn/infantry.cpp
+++ b/tiberiandawn/infantry.cpp
@@ -775,9 +775,9 @@ void InfantryClass::Per_Cell_Process(bool center)
     FootClass::Per_Cell_Process(center);
 
     /*
-    **	If over Tiberium, then this infantry unit will take damage.
+    **	If over Tiberium, then this infantry unit will take damage (unless they are immune).
     */
-    if (IsActive && !IsInLimbo && center && cellptr->Land_Type() == LAND_TIBERIUM && *this != INFANTRY_E5) {
+    if (IsActive && !IsInLimbo && center && cellptr->Land_Type() == LAND_TIBERIUM && !this->Class->IsImmuneToTiberium) {
         auto damage = Rule.Get_Rule_Value<int>(GAME_MAP_SECTION, TIBERIUM_INFANTRY_DAMAGE_RULE);
 
         Take_Damage(damage, 0, WARHEAD_FIRE);

--- a/tiberiandawn/lua/scenario_luaapi.cpp
+++ b/tiberiandawn/lua/scenario_luaapi.cpp
@@ -11,12 +11,19 @@
 #include "events/modifyhousemoney_luaevent.h"
 #include "scenario_luaapi.h"
 
-ScenarioLuaApi::ScenarioLuaApi(std::string scenario_name, std::string scenario_type, std::string scenario_faction, std::string scenario_house): TiberianDawnLuaApi("Scenario", true)
+ScenarioLuaApi::ScenarioLuaApi(
+    std::string scenario_name,
+    std::string scenario_type,
+    std::string scenario_faction,
+    std::string scenario_house,
+    const bool was_loaded_from_save
+) : TiberianDawnLuaApi("Scenario", true)
 {
     ScenarioName = std::move(scenario_name);
     ScenarioType = std::move(scenario_type);
     ScenarioFaction = std::move(scenario_faction);
     ScenarioHouse = std::move(scenario_house);
+    WasLoadedFromSave = was_loaded_from_save;
 }
 
 void ScenarioLuaApi::Register_Dependencies(LuaEngine& engine) const
@@ -30,7 +37,8 @@ void ScenarioLuaApi::Register_Consts(LuaEngine& engine) const
         n.addConstant("name", ScenarioName)
             .addConstant("type", ScenarioType)
             .addConstant("faction", ScenarioFaction)
-            .addConstant("house", ScenarioHouse);
+            .addConstant("house", ScenarioHouse)
+            .addConstant("wasLoadedFromSave", WasLoadedFromSave);
     });
 }
 

--- a/tiberiandawn/lua/scenario_luaapi.h
+++ b/tiberiandawn/lua/scenario_luaapi.h
@@ -15,7 +15,8 @@ public:
         std::string scenario_name,
         std::string scenario_type,
         std::string scenario_faction,
-        std::string scenario_house
+        std::string scenario_house,
+        bool was_loaded_from_save
     ) ;
 
     void Register_Dependencies(LuaEngine& engine) const override;
@@ -35,4 +36,5 @@ private:
     std::string ScenarioType;
     std::string ScenarioFaction;
     std::string ScenarioHouse;
+    bool WasLoadedFromSave;
 };

--- a/tiberiandawn/lua/scenariolua.cpp
+++ b/tiberiandawn/lua/scenariolua.cpp
@@ -41,7 +41,8 @@ void ScenarioLua::On_Scenario_Load(
     const GameEnum& game_type,
     const ScenarioClass& scenario,
     const HouseClass& player,
-    const std::optional<std::string>& ini_script_path
+    const std::optional<std::string>& ini_script_path,
+    const bool was_loaded_from_save
 )
 {
     Call_Back();
@@ -61,7 +62,8 @@ void ScenarioLua::On_Scenario_Load(
        scenario_name,
        scenario_type_name,
        faction,
-       house_name
+       house_name,
+       was_loaded_from_save
     );
 
     // ensure house_name is lowercase for filename use
@@ -78,7 +80,8 @@ void ScenarioLua::On_Scenario_Load(
     const GameEnum& game_type,
     const ScenarioClass& scenario,
     const HouseClass& player,
-    const CCINIClass& ini
+    const CCINIClass& ini,
+    const bool was_loaded_from_save
 )
 {
     const auto ini_script_path = ini.Get_String(
@@ -87,10 +90,15 @@ void ScenarioLua::On_Scenario_Load(
         NotFoundStr
     );
 
-    On_Scenario_Load(game_type, scenario, player, ini_script_path);
+    On_Scenario_Load(game_type, scenario, player, ini_script_path, was_loaded_from_save);
 }
 
-void ScenarioLua::On_Scenario_Load(const GameEnum& game_type, const ScenarioClass& scenario, const HouseClass& player)
+void ScenarioLua::On_Scenario_Load(
+    const GameEnum& game_type,
+    const ScenarioClass& scenario,
+    const HouseClass& player,
+    const bool was_loaded_from_save
+)
 {    const std::string scenario_ini_file = scenario.FileName;
 
     if (CncStringUtils::Is_Blank(scenario_ini_file)) {
@@ -105,7 +113,7 @@ void ScenarioLua::On_Scenario_Load(const GameEnum& game_type, const ScenarioClas
     if (!ini_file.Is_Available()) {
         CNC_LOGGER_WARN("Not checking scenario INI for lua scripts - file is missing: {}", scenario_ini_file);
 
-        On_Scenario_Load(game_type, scenario, player, std::nullopt);
+        On_Scenario_Load(game_type, scenario, player, std::nullopt, was_loaded_from_save);
         return;
     }
 
@@ -118,7 +126,7 @@ void ScenarioLua::On_Scenario_Load(const GameEnum& game_type, const ScenarioClas
 
     CNC_LOGGER_INFO("Checking scenario INI file for lua scripts: {}", scenario_ini_file);
 
-    On_Scenario_Load(game_type, scenario, player, ini);
+    On_Scenario_Load(game_type, scenario, player, ini, was_loaded_from_save);
 }
 
 LuaResultWithValue<std::string> ScenarioLua::Eval_Lua_Console_Input(std::string input_line)
@@ -212,7 +220,13 @@ void ScenarioLua::Process_Lua_Events(AtomicQueue<LuaEvent>& events)
     });
 }
 
-void ScenarioLua::Init_Tiberian_Dawn_Lua_Engine(std::string& scenario_name, std::string& scenario_type_name, std::string& faction, std::string& house_name)
+void ScenarioLua::Init_Tiberian_Dawn_Lua_Engine(
+    std::string& scenario_name,
+    std::string& scenario_type_name,
+    std::string& faction,
+    std::string& house_name,
+    const bool was_loaded_from_save
+)
 {
     Engine = LuaEngineBuilder<UniqueLuaEngine>()
         .With_Api<SystemLuaApi>()
@@ -223,7 +237,7 @@ void ScenarioLua::Init_Tiberian_Dawn_Lua_Engine(std::string& scenario_name, std:
         .With_Api<GameLuaApi>()
         .With_Api<MessagesLuaApi>()
         .With_Api<UiLuaApi>()
-        .With_Api<ScenarioLuaApi>(scenario_name, scenario_type_name, faction, house_name)
+        .With_Api<ScenarioLuaApi>(scenario_name, scenario_type_name, faction, house_name, was_loaded_from_save)
         .Build();
 }
 

--- a/tiberiandawn/lua/scenariolua.cpp
+++ b/tiberiandawn/lua/scenariolua.cpp
@@ -129,6 +129,11 @@ void ScenarioLua::On_Scenario_Load(
     On_Scenario_Load(game_type, scenario, player, ini, was_loaded_from_save);
 }
 
+const std::vector<std::string>& ScenarioLua::Get_Scenario_Scripts()
+{
+    return ScenarioScripts;
+}
+
 LuaResultWithValue<std::string> ScenarioLua::Eval_Lua_Console_Input(std::string input_line)
 {
     LuaConsoleInputHistory.push_back(input_line);
@@ -270,15 +275,23 @@ void ScenarioLua::Exec_Scenario_Lua_Scripts(
         }
     }
 
+    ScenarioScripts.clear();
+
     for (const auto& script_path : lua_scripts_to_load) {
-      Get_Engine()
-           .Exec_File_If_Exists(script_path)
-           .On_Error([&](auto& r) {
+        bool script_exists;
+
+        Get_Engine()
+            .Exec_File_If_Exists(script_path, script_exists)
+            .On_Error([&](auto& r) {
                 CNC_LOGGER_ERROR(
                      "Failed to load scenario script '{}' due to an error: {}",
                      script_path,
                      r.Error_Message()
                 );
-           });
+            });
+
+        if (script_exists) {
+            ScenarioScripts.emplace_back(script_path);
+        }
     }
 }

--- a/tiberiandawn/lua/scenariolua.cpp
+++ b/tiberiandawn/lua/scenariolua.cpp
@@ -23,6 +23,11 @@ const RuleSections& TdRuleSectionsProvider::Sections()
     return Rule.Get_Rule_Sections();
 }
 
+RuleSections& TdRuleSectionsProvider::Editable_Sections()
+{
+    return Rule.Get_Editable_Rule_Sections();
+}
+
 const LuaEngine& ScenarioLua::Get_Engine()
 {
     if (!Engine.has_value()) {

--- a/tiberiandawn/lua/scenariolua.h
+++ b/tiberiandawn/lua/scenariolua.h
@@ -47,20 +47,23 @@ public:
         const GameEnum& game_type,
         const ScenarioClass& scenario,
         const HouseClass& player,
-        const std::optional<std::string>& ini
+        const std::optional<std::string>& ini,
+        bool was_loaded_from_save = false
     );
 
     static void On_Scenario_Load(
         const GameEnum& game_type,
         const ScenarioClass& scenario,
         const HouseClass& player,
-        const CCINIClass& ini
+        const CCINIClass& ini,
+        bool was_loaded_from_save
     );
 
     static void On_Scenario_Load(
         const GameEnum& game_type,
         const ScenarioClass& scenario,
-        const HouseClass& player
+        const HouseClass& player,
+        bool was_loaded_from_save
     );
 
     static LuaResultWithValue<std::string> Eval_Lua_Console_Input(std::string input_line);
@@ -105,7 +108,8 @@ private:
          std::string& scenario_name,
          std::string& scenario_type_name,
          std::string& faction,
-         std::string& house_name
+         std::string& house_name,
+         bool was_loaded_from_save
     );
 
     /**

--- a/tiberiandawn/lua/scenariolua.h
+++ b/tiberiandawn/lua/scenariolua.h
@@ -18,6 +18,7 @@ class TdRuleSectionsProvider final
 {
 public:
     static const RuleSections& Sections();
+    static RuleSections& Editable_Sections();
 
 private:
     TdRuleSectionsProvider() = delete;

--- a/tiberiandawn/lua/scenariolua.h
+++ b/tiberiandawn/lua/scenariolua.h
@@ -66,6 +66,8 @@ public:
         bool was_loaded_from_save
     );
 
+    static const std::vector<std::string>& Get_Scenario_Scripts();
+
     static LuaResultWithValue<std::string> Eval_Lua_Console_Input(std::string input_line);
 
     static const std::vector<std::string>& Get_Lua_Console_Input_History();
@@ -98,6 +100,7 @@ private:
     static constexpr std::string_view NotFoundStr = "__NOT_FOUND__";
     static inline const auto& Logger = CncLogger::For(ScenarioLua);
     static inline std::optional<UniqueLuaEngine> Engine;
+    static inline std::vector<std::string> ScenarioScripts;
     static inline std::vector<std::string> LuaConsoleInputHistory;
 
     /**

--- a/tiberiandawn/lua/scripts/nco/TiberianDawn/Scenario.lua
+++ b/tiberiandawn/lua/scripts/nco/TiberianDawn/Scenario.lua
@@ -90,6 +90,7 @@ local TdApiModule = require("nco.TiberianDawn.lib.TdApiModule")
 ---@class Scenario : ApiModule
 ---@field name string
 ---@field type "single-player"|"multiplayer"
+---@field wasLoadedFromSave boolean
 ---@field player ScenarioPlayer
 ---@field houses ScenarioHouses | { [string]: House }
 ---@field teams ScenarioTeamTypes | { [string]: string }
@@ -134,6 +135,8 @@ local function builder(cppApi)
   return {
     name = cppApi.name,
     type = cppApi.type,
+
+    wasLoadedFromSave = cppApi.wasLoadedFromSave,
 
     player = {
       faction = cppApi.faction,

--- a/tiberiandawn/lua/tdtypes_luaapi.h
+++ b/tiberiandawn/lua/tdtypes_luaapi.h
@@ -66,13 +66,13 @@ private:
     template<EnumSignedChar T, RulesTypeClass<T> U>
     void Register_Type_Functions(luabridge::Namespace& n) const
     {
-        auto type_name = TdTypeConverter::Get_Type_Name<T>();
-        auto get_instances_function = std::format("get{}InstanceNames", type_name);
-        auto get_properties_function = std::format("get{}PropertyNames", type_name);
-        auto get_property_type_function = std::format("get{}PropertyType", type_name);
-        auto get_display_name_function = std::format("get{}DisplayName", type_name);
-        auto get_property_value_function = std::format("get{}PropertyValue", type_name);
-        auto set_property_value_function = std::format("set{}PropertyValue", type_name);
+        static const auto type_name = TdTypeConverter::Get_Type_Name<T>();
+        static const auto get_instances_function = std::format("get{}InstanceNames", type_name);
+        static const auto get_properties_function = std::format("get{}PropertyNames", type_name);
+        static const auto get_property_type_function = std::format("get{}PropertyType", type_name);
+        static const auto get_display_name_function = std::format("get{}DisplayName", type_name);
+        static const auto get_property_value_function = std::format("get{}PropertyValue", type_name);
+        static const auto set_property_value_function = std::format("set{}PropertyValue", type_name);
 
         n.addCFunction(get_instances_function.c_str(), [](auto L) {
             const auto engine = SharedLuaEngine(L);
@@ -251,7 +251,7 @@ private:
 
                 // get new string value for the rule and rules section for specific type instance
                 auto property_value = arguments.Read_Next<std::string>().Unpack();
-                auto section = sections[section_name];
+                auto& section = sections[section_name];
 
                 // get current rule value and type
                 auto current_value = section.template Get<std::string>(property_name);

--- a/tiberiandawn/lua/tdtypes_luaapi.h
+++ b/tiberiandawn/lua/tdtypes_luaapi.h
@@ -239,7 +239,7 @@ private:
             const auto property_name = arguments.Read_Next<std::string>().Unpack();
 
             // validate arg
-            const auto& sections = Rule.Get_Rule_Sections_For_Type<T>();
+            auto& sections = Rule.Get_Editable_Rule_Sections_For_Type<T>();
             const auto instance = Resolve_Instance_By_Name<T>(engine, sections, type_name, instance_name);
 
             // fetch type rules and instance name

--- a/tiberiandawn/map.cpp
+++ b/tiberiandawn/map.cpp
@@ -2198,7 +2198,7 @@ FROM_JSON(MapClass)
     BITFIELD_FROM_JSON(IsForwardScan);
 
     // Array field - follows MouseClass::Save logic
-    const auto& cells = j.at(NAMEOF(Array));
+    const auto& cells = j[NAMEOF(Array)];
 
     CncJsonUtils::Assert_Json_Is<JsonObject>(cells, NAMEOF(Array));
 

--- a/tiberiandawn/map.cpp
+++ b/tiberiandawn/map.cpp
@@ -2095,7 +2095,7 @@ bool MapClass::Is_Height_Smaller_Than_Screen() const
     // disable small map detection in remaster
     return false;
 #else
-    return MapCellHeight * CELL_PIXEL_H < SeenBuff.Get_Height();
+    return MapCellHeight * CELL_PIXEL_H < SeenBuff.Get_Height() - Map.Get_Tab_Height();
 #endif
 }
 
@@ -2107,6 +2107,21 @@ bool MapClass::Is_Smaller_Than_Screen() const
 #else
     return Is_Width_Smaller_Than_Screen() || Is_Height_Smaller_Than_Screen();
 #endif
+}
+
+bool MapClass::Redraw_If_Smaller_Then_Screen()
+{
+    if (!Is_Smaller_Than_Screen()) {
+        return false;
+    }
+
+    Map.IsSidebarActive
+        ? Map.Set_View_Dimensions(0, Map.Get_Tab_Height(), SeenBuff.Get_Width() - Map.SideBarWidth)
+        : Map.Set_View_Dimensions(0, Map.Get_Tab_Height());
+    Flag_To_Redraw(true);
+    Render();
+
+    return true;
 }
 
 TO_JSON(MapClass)

--- a/tiberiandawn/map.cpp
+++ b/tiberiandawn/map.cpp
@@ -2079,6 +2079,12 @@ CELL MapClass::Nearby_Location(CELL cell) const //, SpeedType speed, int zone, M
 
 #endif // USE_RA_AI
 
+/**
+ * Based on the current view dimensions, is the map width smaller than the screen width?
+ *
+ * If the sidebar is active, this is taken into account as the reduced horizontal resolution
+ * may make the map larger than the screen width.
+ */
 bool MapClass::Is_Width_Smaller_Than_Screen() const
 {
 #ifdef REMASTER_BUILD
@@ -2089,6 +2095,9 @@ bool MapClass::Is_Width_Smaller_Than_Screen() const
 #endif
 }
 
+/**
+ * Based on the current view dimensions, is the map height smaller than the screen height?
+ */
 bool MapClass::Is_Height_Smaller_Than_Screen() const
 {
 #ifdef REMASTER_BUILD
@@ -2099,6 +2108,12 @@ bool MapClass::Is_Height_Smaller_Than_Screen() const
 #endif
 }
 
+/**
+ * Based on the current view dimensions, is the map smaller than the screen resolution?
+ *
+ * If the sidebar is active, this is taken into account as the reduced horizontal resolution
+ * may make the map larger than the screen.
+ */
 bool MapClass::Is_Smaller_Than_Screen() const
 {
 #ifdef REMASTER_BUILD
@@ -2109,6 +2124,12 @@ bool MapClass::Is_Smaller_Than_Screen() const
 #endif
 }
 
+/**
+ * Based on the current view dimensions, if the map is smaller than the screen resolution, force it to redraw
+ * to ensure cells and sidebar are rendered correctly for the current resolution.
+ *
+ * @return True if the map was redrawn, false otherwise.
+ */
 bool MapClass::Redraw_If_Smaller_Then_Screen()
 {
     if (!Is_Smaller_Than_Screen()) {
@@ -2123,6 +2144,50 @@ bool MapClass::Redraw_If_Smaller_Then_Screen()
 
     return true;
 }
+
+/**
+ * This routine will find the nearest instance of the overlay in the given direction from the origin. It will abort if
+ * it comes across any obstacle.
+ */
+int MapClass::Scan_For_Overlay(
+    const CELL origin,
+    const FacingType dir,
+    const OverlayType overlay,
+    const int maxLength
+) const
+{
+	if (!In_Radar(origin))
+	{
+		return -1;
+	}
+
+	auto current = origin;
+
+	for (auto i = 0; i < maxLength; ++i)
+	{
+		current = Adjacent_Cell(current, dir);
+
+		if (!In_Radar(current))
+		{
+			break;
+		}
+
+		const auto& map_cell = Map[current];
+
+		if (map_cell.Overlay == overlay) {
+			//Found a match
+			return i;
+		}
+
+	    if (!Map[current].Is_Generally_Clear()) {
+			//Blocked by an object
+			break;
+		}
+	}
+
+	return -1;
+}
+
 
 TO_JSON(MapClass)
 {

--- a/tiberiandawn/map.h
+++ b/tiberiandawn/map.h
@@ -184,6 +184,14 @@ public:
      */
     bool Is_Smaller_Than_Screen() const;
 
+    /**
+     * Based on the current view dimensions, if the map is smaller than the screen resolution, force it to redraw
+     * to ensure cells and sidebar are rendered correctly for the current resolution.
+     *
+     * @return True if the map was redrawn, false otherwise.
+     */
+    bool Redraw_If_Smaller_Then_Screen();
+
 protected:
     /*
     **	This is the array of cell objects.

--- a/tiberiandawn/map.h
+++ b/tiberiandawn/map.h
@@ -163,35 +163,12 @@ public:
         return (Array.ID(ptr));
     };
 
-    /**
-     * Based on the current view dimensions, is the map width smaller than the screen width?
-     *
-     * If the sidebar is active, this is taken into account as the reduced horizontal resolution
-     * may make the map larger than the screen width.
-     */
     bool Is_Width_Smaller_Than_Screen() const;
-
-    /**
-     * Based on the current view dimensions, is the map height smaller than the screen height?
-     */
     bool Is_Height_Smaller_Than_Screen() const;
-
-    /**
-     * Based on the current view dimensions, is the map smaller than the screen resolution?
-     *
-     * If the sidebar is active, this is taken into account as the reduced horizontal resolution
-     * may make the map larger than the screen.
-     */
     bool Is_Smaller_Than_Screen() const;
-
-    /**
-     * Based on the current view dimensions, if the map is smaller than the screen resolution, force it to redraw
-     * to ensure cells and sidebar are rendered correctly for the current resolution.
-     *
-     * @return True if the map was redrawn, false otherwise.
-     */
     bool Redraw_If_Smaller_Then_Screen();
 
+    int Scan_For_Overlay(CELL origin, FacingType dir, OverlayType overlay, int maxLength) const;
 protected:
     /*
     **	This is the array of cell objects.

--- a/tiberiandawn/rules-nco.cpp.in
+++ b/tiberiandawn/rules-nco.cpp.in
@@ -92,7 +92,6 @@ void RulesClass::Apply_Static_And_Global_Values() const {
 
     Special.Read_Rules(Sections);
 
-    // TODO: consider save/load implications
     for (auto i = 0; i < Houses.Count(); i++) {
         const auto house = Houses.Ptr(i);
 

--- a/tiberiandawn/rules-nco.cpp.in
+++ b/tiberiandawn/rules-nco.cpp.in
@@ -55,7 +55,7 @@ const RuleSections& SpecialClass::Read_Rules(const RuleSections& rules)
     return rules;
 }
 
-const RuleSections& SpecialClass::Write_Rules(const RuleSections& rules) const
+RuleSections& SpecialClass::Write_Rules(RuleSections& rules) const
 {
     // map
     rules[GAME_MAP_SECTION]

--- a/tiberiandawn/rules-nco.cpp.in
+++ b/tiberiandawn/rules-nco.cpp.in
@@ -85,10 +85,29 @@ const RuleSections& SpecialClass::Write_Rules(const RuleSections& rules) const
 }
 
 void RulesClass::Apply_Static_And_Global_Values() const {
+    FactoryClass::STEP_COUNT = Get_Rule_Value<int>(GAME_FACTORIES_SECTION, TOTAL_PRODUCTION_STEPS_RULE);
+
+    MPlayerCountMax[0] = Get_Rule_Value<int>(GAME_MULTIPLAYER_SECTION, START_UNITS_WITHOUT_BASE_MAX_RULE);
+    MPlayerCountMax[1] = Get_Rule_Value<int>(GAME_MULTIPLAYER_SECTION, START_UNITS_WITH_BASE_MAX_RULE);
+
     Special.Read_Rules(Sections);
 
-    FactoryClass::STEP_COUNT = Rule.Get_Rule_Value<int>(GAME_FACTORIES_SECTION, TOTAL_PRODUCTION_STEPS_RULE);
+    // TODO: consider save/load implications
+    for (auto i = 0; i < Houses.Count(); i++) {
+        const auto house = Houses.Ptr(i);
 
-    MPlayerCountMax[0] = Rule.Get_Rule_Value<int>(GAME_MULTIPLAYER_SECTION, START_UNITS_WITHOUT_BASE_MAX_RULE);
-    MPlayerCountMax[1] = Rule.Get_Rule_Value<int>(GAME_MULTIPLAYER_SECTION, START_UNITS_WITH_BASE_MAX_RULE);
+        if (house == nullptr) {
+            continue;
+        }
+
+        house->AirStrike.Set_Recharge_Time(
+            Get_Rule_Value<int>(GAME_SUPERWEAPONS_SECTION, AIR_STRIKE_RECHARGE_TIME_IN_MINS_RULE) * TICKS_PER_MINUTE
+        );
+        house->IonCannon.Set_Recharge_Time(
+            Get_Rule_Value<int>(GAME_SUPERWEAPONS_SECTION, ION_CANNON_RECHARGE_TIME_IN_MINS_RULE) * TICKS_PER_MINUTE
+        );
+        house->NukeStrike.Set_Recharge_Time(
+            Get_Rule_Value<int>(GAME_SUPERWEAPONS_SECTION, NUCLEAR_STRIKE_RECHARGE_TIME_IN_MINS_RULE) * TICKS_PER_MINUTE
+        );
+    }
 }

--- a/tiberiandawn/rules.cpp
+++ b/tiberiandawn/rules.cpp
@@ -795,9 +795,7 @@ TO_JSON(RulesClass)
 
 FROM_JSON(RulesClass)
 {
-    if (!j.is_object()) {
-        throw CncJsonException("Invalid {} JSON - expected object, actual type: {}", NAMEOF(RulesClass), j.type_name());
-    }
+    CncJsonUtils::Assert_Json_Is<JsonObject>(j, NAMEOF(RulesClass));
 
     p.AttackInterval = j["AttackInterval"];
     p.AttackDelay = j["AttackDelay"];

--- a/tiberiandawn/rules.cpp
+++ b/tiberiandawn/rules.cpp
@@ -319,7 +319,7 @@ void RulesClass::Init_For_Scenario(
     for (const auto& [type_name, sections] : TypeRules) {
         CNC_LOG_DEBUG("Type section: {}", type_name);
 
-        for (const auto& section : sections->Section_Names()) {
+        for (const auto& section : sections.Section_Names()) {
             CNC_LOG_DEBUG("  Instance section: {}", section);
         }
     }
@@ -668,15 +668,11 @@ static void Init_Type(RuleSections& sections, U first, U count, const CncLogger&
  * type.
  */
 template <EnumSignedChar T>
-RuleSections& Sections_For(std::map<std::string_view, std::unique_ptr<RuleSections>>& type_rules)
+RuleSections& Sections_For(std::map<std::string_view, RuleSections>& type_rules)
 {
     static const auto type_name = TdTypeConverter::Get_Type_Name<T>();
 
-    if (!type_rules.contains(type_name)) {
-        type_rules[type_name] = std::make_unique<RuleSections>();
-    }
-
-    return *type_rules[type_name];
+    return type_rules[type_name];
 }
 
 void RulesClass::Init_Types()
@@ -734,7 +730,7 @@ void RulesClass::Assert_Section_Not_Present(const std::string_view name) const
 {
     if (
         Sections.Has_Section(name) ||
-        std::ranges::any_of(TypeRules, [&](const auto& s) { return s.second->Has_Section(name); })
+        std::ranges::any_of(TypeRules, [&](const auto& s) { return s.second.Has_Section(name); })
     ) {
         CNC_LOGGER_FATAL(
             "An attempt was made to init a rules section twice, this is likely due to using a INI Name "

--- a/tiberiandawn/rules.cpp
+++ b/tiberiandawn/rules.cpp
@@ -747,6 +747,10 @@ void RulesClass::Assert_Section_Not_Present(const std::string_view name) const
     }
 }
 
+/**
+ * Note: Diff array is not serialized to JSON as these values are loaded into HouseClass instances when scenario is
+ * loaded from INI, so save games already have the appropriate values set elsewhere.
+ */
 TO_JSON(RulesClass)
 {
     j["AttackInterval"] = p.AttackInterval;

--- a/tiberiandawn/rules.cpp
+++ b/tiberiandawn/rules.cpp
@@ -746,3 +746,102 @@ void RulesClass::Assert_Section_Not_Present(const std::string_view name) const
         );
     }
 }
+
+TO_JSON(RulesClass)
+{
+    j["AttackInterval"] = p.AttackInterval;
+    j["AttackDelay"] = p.AttackDelay;
+    j["PowerEmergencyFraction"] = p.PowerEmergencyFraction;
+    j["HelipadRatio"] = p.HelipadRatio;
+    j["AdvancedDefenceRatio"] = p.AdvancedDefenceRatio;
+    j["AdvancedDefenceLimit"] = p.AdvancedDefenceLimit;
+    j["AARatio"] = p.AARatio;
+    j["AALimit"] = p.AALimit;
+    j["DefenseRatio"] = p.DefenseRatio;
+    j["DefenseLimit"] = p.DefenseLimit;
+    j["UnitFactoryRatio"] = p.UnitFactoryRatio;
+    j["UnitFactoryLimit"] = p.UnitFactoryLimit;
+    j["InfantryFactoryRatio"] = p.InfantryFactoryRatio;
+    j["InfantryFactoryLimit"] = p.InfantryFactoryLimit;
+    j["RefineryLimit"] = p.RefineryLimit;
+    j["RefineryRatio"] = p.RefineryRatio;
+    j["BaseSizeAdd"] = p.BaseSizeAdd;
+    j["PowerSurplus"] = p.PowerSurplus;
+    j["MaxIQ"] = p.MaxIQ;
+    j["IQSuperWeapons"] = p.IQSuperWeapons;
+    j["IQProduction"] = p.IQProduction;
+    j["IQGuardArea"] = p.IQGuardArea;
+    j["IQRepairSell"] = p.IQRepairSell;
+    j["IQCrush"] = p.IQCrush;
+    j["IQScatter"] = p.IQScatter;
+    j["IQContentScan"] = p.IQContentScan;
+    j["IQAircraft"] = p.IQAircraft;
+    j["IQHarvester"] = p.IQHarvester;
+    j["IQSellBack"] = p.IQSellBack;
+    j["InfantryReserve"] = p.InfantryReserve;
+    j["InfantryBaseMult"] = p.InfantryBaseMult;
+    j["IsComputerParanoid"] = p.IsComputerParanoid;
+    j["IsCompEasyBonus"] = p.IsCompEasyBonus;
+    j["IsFineDifficulty"] = p.IsFineDifficulty;
+    j["AllowSuperWeapons"] = p.AllowSuperWeapons;
+
+    j["Sections"] = p.Sections;
+    j["TypeRules"] = p.TypeRules;
+}
+
+FROM_JSON(RulesClass)
+{
+    if (!j.is_object()) {
+        throw CncJsonException("Invalid {} JSON - expected object, actual type: {}", NAMEOF(RulesClass), j.type_name());
+    }
+
+    p.AttackInterval = j["AttackInterval"];
+    p.AttackDelay = j["AttackDelay"];
+    p.PowerEmergencyFraction = j["PowerEmergencyFraction"];
+    p.HelipadRatio = j["HelipadRatio"];
+    p.AdvancedDefenceRatio = j["AdvancedDefenceRatio"];
+    p.AdvancedDefenceLimit = j["AdvancedDefenceLimit"];
+    p.AARatio = j["AARatio"];
+    p.AALimit = j["AALimit"];
+    p.DefenseRatio = j["DefenseRatio"];
+    p.DefenseLimit = j["DefenseLimit"];
+    p.UnitFactoryRatio = j["UnitFactoryRatio"];
+    p.UnitFactoryLimit = j["UnitFactoryLimit"];
+    p.InfantryFactoryRatio = j["InfantryFactoryRatio"];
+    p.InfantryFactoryLimit = j["InfantryFactoryLimit"];
+    p.RefineryLimit = j["RefineryLimit"];
+    p.RefineryRatio = j["RefineryRatio"];
+    p.BaseSizeAdd = j["BaseSizeAdd"];
+    p.PowerSurplus = j["PowerSurplus"];
+    p.MaxIQ = j["MaxIQ"];
+    p.IQSuperWeapons = j["IQSuperWeapons"];
+    p.IQProduction = j["IQProduction"];
+    p.IQGuardArea = j["IQGuardArea"];
+    p.IQRepairSell = j["IQRepairSell"];
+    p.IQCrush = j["IQCrush"];
+    p.IQScatter = j["IQScatter"];
+    p.IQContentScan = j["IQContentScan"];
+    p.IQAircraft = j["IQAircraft"];
+    p.IQHarvester = j["IQHarvester"];
+    p.IQSellBack = j["IQSellBack"];
+    p.InfantryReserve = j["InfantryReserve"];
+    p.InfantryBaseMult = j["InfantryBaseMult"];
+    p.IsComputerParanoid = j["IsComputerParanoid"];
+    p.IsCompEasyBonus = j["IsCompEasyBonus"];
+    p.IsFineDifficulty = j["IsFineDifficulty"];
+    p.AllowSuperWeapons = j["AllowSuperWeapons"];
+
+    /**
+     * Apply JSON to RuleSections references to preserve on rules changed handlers and
+     * RuleSection::ConverterSectionTypeName properties (these are not serialized to JSON).
+     *
+     * Additionally, rules not found in JSON are preserved, which effectively merges the current rules with those in
+     * JSON (with the JSON rule values having precendence over existing rule values).
+     */
+
+    from_json(j["Sections"], p.Sections);
+
+    for (const auto& [ type, sections_json ] : j["TypeRules"].items()) {
+        from_json(sections_json, p.TypeRules[type]);
+    }
+}

--- a/tiberiandawn/rules.cpp
+++ b/tiberiandawn/rules.cpp
@@ -97,16 +97,16 @@ RulesClass::RulesClass(void)
     , PowerEmergencyFraction(3, 4)
     , HelipadRatio(".12")
     , HelipadLimit(6)
-    , TeslaRatio(".8")
-    , TeslaLimit(5)
+    , AdvancedDefenceRatio(".8")
+    , AdvancedDefenceLimit(5)
     , AARatio(".14")
     , AALimit(10)
     , DefenseRatio(".5")
     , DefenseLimit(25)
-    , WarRatio(".1")
-    , WarLimit(3)
-    , BarracksRatio(".16")
-    , BarracksLimit(2)
+    , UnitFactoryRatio(".1")
+    , UnitFactoryLimit(3)
+    , InfantryFactoryRatio(".16")
+    , InfantryFactoryLimit(2)
     , RefineryLimit(7)
     , RefineryRatio(".18")
     , BaseSizeAdd(3)
@@ -330,6 +330,11 @@ const RuleSections& RulesClass::Get_Rule_Sections() const
     return Sections;
 }
 
+RuleSections& RulesClass::Get_Editable_Rule_Sections()
+{
+    return Sections;
+}
+
 /**
  * Purge all existing rule definitions, leaving the rule sections
  * and type rules blank.
@@ -431,16 +436,16 @@ void RulesClass::AI(CCINIClass& ini)
     BaseSizeAdd = ini.Get_Int(AI, "BaseSizeAdd", BaseSizeAdd);
     RefineryRatio = ini.Get_Fixed(AI, "RefineryRatio", RefineryRatio);
     RefineryLimit = ini.Get_Int(AI, "RefineryLimit", RefineryLimit);
-    BarracksRatio = ini.Get_Fixed(AI, "BarracksRatio", BarracksRatio);
-    BarracksLimit = ini.Get_Int(AI, "BarracksLimit", BarracksLimit);
-    WarRatio = ini.Get_Fixed(AI, "WarRatio", WarRatio);
-    WarLimit = ini.Get_Int(AI, "WarLimit", WarLimit);
+    InfantryFactoryRatio = ini.Get_Fixed(AI, "BarracksRatio", InfantryFactoryRatio);
+    InfantryFactoryLimit = ini.Get_Int(AI, "BarracksLimit", InfantryFactoryLimit);
+    UnitFactoryRatio = ini.Get_Fixed(AI, "WarRatio", UnitFactoryRatio);
+    UnitFactoryLimit = ini.Get_Int(AI, "WarLimit", UnitFactoryLimit);
     DefenseRatio = ini.Get_Fixed(AI, "DefenseRatio", DefenseRatio);
     DefenseLimit = ini.Get_Int(AI, "DefenseLimit", DefenseLimit);
     AARatio = ini.Get_Fixed(AI, "AARatio", AARatio);
     AALimit = ini.Get_Int(AI, "AALimit", AALimit);
-    TeslaRatio = ini.Get_Fixed(AI, "ObeliskRatio", TeslaRatio);
-    TeslaLimit = ini.Get_Int(AI, "ObeliskLimit", TeslaLimit);
+    AdvancedDefenceRatio = ini.Get_Fixed(AI, "ObeliskRatio", AdvancedDefenceRatio);
+    AdvancedDefenceLimit = ini.Get_Int(AI, "ObeliskLimit", AdvancedDefenceLimit);
     HelipadRatio = ini.Get_Fixed(AI, "HelipadRatio", HelipadRatio);
     HelipadLimit = ini.Get_Int(AI, "HelipadLimit", HelipadLimit);
     IsCompEasyBonus = ini.Get_Bool(AI, "CompEasyBonus", IsCompEasyBonus);
@@ -474,16 +479,16 @@ void RulesClass::Export_AI(CCINIClass& ini) const
     ini.Put_Int(AI, "BaseSizeAdd", BaseSizeAdd);
     ini.Put_Fixed(AI, "RefineryRatio", RefineryRatio);
     ini.Put_Int(AI, "RefineryLimit", RefineryLimit);
-    ini.Put_Fixed(AI, "BarracksRatio", BarracksRatio);
-    ini.Put_Int(AI, "BarracksLimit", BarracksLimit);
-    ini.Put_Fixed(AI, "WarRatio", WarRatio);
-    ini.Put_Int(AI, "WarLimit", WarLimit);
+    ini.Put_Fixed(AI, "BarracksRatio", InfantryFactoryRatio);
+    ini.Put_Int(AI, "BarracksLimit", InfantryFactoryLimit);
+    ini.Put_Fixed(AI, "WarRatio", UnitFactoryRatio);
+    ini.Put_Int(AI, "WarLimit", UnitFactoryLimit);
     ini.Put_Fixed(AI, "DefenseRatio", DefenseRatio);
     ini.Put_Int(AI, "DefenseLimit", DefenseLimit);
     ini.Put_Fixed(AI, "AARatio", AARatio);
     ini.Put_Int(AI, "AALimit", AALimit);
-    ini.Put_Fixed(AI, "ObeliskRatio", TeslaRatio);
-    ini.Put_Int(AI, "ObeliskLimit", TeslaLimit);
+    ini.Put_Fixed(AI, "ObeliskRatio", AdvancedDefenceRatio);
+    ini.Put_Int(AI, "ObeliskLimit", AdvancedDefenceLimit);
     ini.Put_Fixed(AI, "HelipadRatio", HelipadRatio);
     ini.Put_Int(AI, "HelipadLimit", HelipadLimit);
     ini.Put_Bool(AI, "CompEasyBonus", IsCompEasyBonus);
@@ -668,7 +673,7 @@ static void Init_Type(RuleSections& sections, U first, U count, const CncLogger&
  * type.
  */
 template <EnumSignedChar T>
-RuleSections& Sections_For(std::map<std::string_view, RuleSections>& type_rules)
+RuleSections& Sections_For(std::unordered_map<std::string_view, RuleSections>& type_rules)
 {
     static const auto type_name = TdTypeConverter::Get_Type_Name<T>();
 

--- a/tiberiandawn/rules.h
+++ b/tiberiandawn/rules.h
@@ -74,9 +74,25 @@ public:
     fixed RepairDelay;
     fixed BuildDelay;
 
-    unsigned IsBuildSlowdown : 1;
-    unsigned IsWallDestroyer : 1;
-    unsigned IsContentScan : 1;
+    bool IsBuildSlowdown;
+    bool IsWallDestroyer;
+    bool IsContentScan;
+
+    NLOHMANN_DEFINE_TYPE_INTRUSIVE(
+        DifficultyClass,
+        FirepowerBias,
+        GroundspeedBias,
+        AirspeedBias,
+        ArmorBias,
+        ROFBias,
+        CostBias,
+        BuildSpeedBias,
+        RepairDelay,
+        BuildDelay,
+        IsBuildSlowdown,
+        IsWallDestroyer,
+        IsContentScan
+    )
 };
 
 class RuleSections;
@@ -119,14 +135,14 @@ public:
 
     /*
     **	This specifies the percentage of the base (by building quantity) that should
-    **	be composed of Tesla Coils.
+    **	be composed of Advanced Guard Towers / Obelisks.
     */
-    fixed TeslaRatio;
+    fixed AdvancedDefenceRatio;
 
     /*
-    **	Limit tesla coil production to this maximum.
+    **	Limit Advanced Guard Tower / Obelisk production to this maximum.
     */
-    int TeslaLimit;
+    int AdvancedDefenceLimit;
 
     /*
     **	This specifies the percentage of the base (by building quantity) that should
@@ -152,25 +168,25 @@ public:
 
     /*
     **	This specifies the percentage of the base (by building quantity) that should
-    **	be composed of war factories.
+    **	be composed of unit factories.
     */
-    fixed WarRatio;
+    fixed UnitFactoryRatio;
 
     /*
-    **	War factories are limited to this quantity for the computer controlled player.
+    **	Unit factories are limited to this quantity for the computer controlled player.
     */
-    int WarLimit;
+    int UnitFactoryLimit;
 
     /*
     **	This specifies the percentage of the base (by building quantity) that should
-    **	be composed of infantry producing structures.
+    **	be composed of infantry factories.
     */
-    fixed BarracksRatio;
+    fixed InfantryFactoryRatio;
 
     /*
-    **	No more than this many barracks can be built.
+    **	No more than this many infantry factories can be built.
     */
-    int BarracksLimit;
+    int InfantryFactoryLimit;
 
     /*
     **	Refinery building is limited to this many refineries.
@@ -313,6 +329,7 @@ public:
     );
 
     const RuleSections& Get_Rule_Sections() const;
+    RuleSections& Get_Editable_Rule_Sections();
 
     template<EnumSignedChar T>
     const RuleSections& Get_Rule_Sections_For_Type() const
@@ -325,7 +342,21 @@ public:
             );
         }
 
-        return TypeRules.at(type_name);;
+        return TypeRules.at(type_name);
+    }
+
+    template<EnumSignedChar T>
+    RuleSections& Get_Editable_Rule_Sections_For_Type()
+    {
+        static const auto type_name = TdTypeConverter::Get_Type_Name<T>();
+
+        if (!TypeRules.contains(type_name)) {
+            throw std::out_of_range(
+                std::format("Attempted to get rule sections for unsupported type: {}", type_name)
+            );
+        }
+
+        return TypeRules.at(type_name);
     }
 
     void Assert_Section_Not_Present(std::string_view name) const;
@@ -336,11 +367,53 @@ public:
         return Sections[section].Get<T>(rule);
     }
 
+    NLOHMANN_DEFINE_TYPE_INTRUSIVE(
+        RulesClass,
+        AttackInterval,
+        AttackDelay,
+        PowerEmergencyFraction,
+        HelipadRatio,
+        AdvancedDefenceRatio,
+        AdvancedDefenceLimit,
+        AARatio,
+        AALimit,
+        DefenseRatio,
+        DefenseLimit,
+        UnitFactoryRatio,
+        UnitFactoryLimit,
+        InfantryFactoryRatio,
+        InfantryFactoryLimit,
+        RefineryLimit,
+        RefineryRatio,
+        BaseSizeAdd,
+        PowerSurplus,
+        MaxIQ,
+        IQSuperWeapons,
+        IQProduction,
+        IQGuardArea,
+        IQRepairSell,
+        IQCrush,
+        IQScatter,
+        IQContentScan,
+        IQAircraft,
+        IQHarvester,
+        IQSellBack,
+        InfantryReserve,
+        InfantryBaseMult,
+        IsComputerParanoid,
+        IsCompEasyBonus,
+        IsFineDifficulty,
+        AllowSuperWeapons,
+        Diff,
+        Sections,
+        TypeRules
+    )
+
 private:
     // TODO: Roll other sections into this and centrally manage RULES.INI (will benefit loading rules overloads for scenarios)
     RuleSections Sections;
     // TODO: Add existing subclasses of ObjectTypeClass Overlay, Smudge, Template and Terrain
-    std::map<std::string_view, RuleSections> TypeRules;
+    std::unordered_map<std::string_view, RuleSections> TypeRules;
 
     void AI(CCINIClass& ini);
     void IQ(CCINIClass& ini);

--- a/tiberiandawn/rules.h
+++ b/tiberiandawn/rules.h
@@ -325,7 +325,7 @@ public:
             );
         }
 
-        return *TypeRules.at(type_name);;
+        return TypeRules.at(type_name);;
     }
 
     void Assert_Section_Not_Present(std::string_view name) const;
@@ -340,7 +340,7 @@ private:
     // TODO: Roll other sections into this and centrally manage RULES.INI (will benefit loading rules overloads for scenarios)
     RuleSections Sections;
     // TODO: Add existing subclasses of ObjectTypeClass Overlay, Smudge, Template and Terrain
-    std::map<std::string_view, std::unique_ptr<RuleSections>> TypeRules;
+    std::map<std::string_view, RuleSections> TypeRules;
 
     void AI(CCINIClass& ini);
     void IQ(CCINIClass& ini);

--- a/tiberiandawn/rules.h
+++ b/tiberiandawn/rules.h
@@ -367,47 +367,7 @@ public:
         return Sections[section].Get<T>(rule);
     }
 
-    NLOHMANN_DEFINE_TYPE_INTRUSIVE(
-        RulesClass,
-        AttackInterval,
-        AttackDelay,
-        PowerEmergencyFraction,
-        HelipadRatio,
-        AdvancedDefenceRatio,
-        AdvancedDefenceLimit,
-        AARatio,
-        AALimit,
-        DefenseRatio,
-        DefenseLimit,
-        UnitFactoryRatio,
-        UnitFactoryLimit,
-        InfantryFactoryRatio,
-        InfantryFactoryLimit,
-        RefineryLimit,
-        RefineryRatio,
-        BaseSizeAdd,
-        PowerSurplus,
-        MaxIQ,
-        IQSuperWeapons,
-        IQProduction,
-        IQGuardArea,
-        IQRepairSell,
-        IQCrush,
-        IQScatter,
-        IQContentScan,
-        IQAircraft,
-        IQHarvester,
-        IQSellBack,
-        InfantryReserve,
-        InfantryBaseMult,
-        IsComputerParanoid,
-        IsCompEasyBonus,
-        IsFineDifficulty,
-        AllowSuperWeapons,
-        Diff,
-        Sections,
-        TypeRules
-    )
+    JSON_FUNCTIONS(RulesClass)
 
 private:
     // TODO: Roll other sections into this and centrally manage RULES.INI (will benefit loading rules overloads for scenarios)

--- a/tiberiandawn/rules/00.Enhancements.json
+++ b/tiberiandawn/rules/00.Enhancements.json
@@ -23,6 +23,36 @@
       "comment": "Allow the commandos to guard an area (applies to any infantry equipped with a RIFLE weapon)"
     },
     {
+      "name": "MaxBuildDistance",
+      "type": "int",
+      "default": 1,
+      "comment": "This controls how far away from an existing structure a player can place a building. _Note: values higher than 6 may cause performance problems._"
+    },
+    {
+      "name": "ModernWallBuilding",
+      "type": "bool",
+      "default": true,
+      "comment": "Two wall pieces are connected automatically when placed in line of sight of each-other. See ModernWallMaxLength and ModernWallFullCost."
+    },
+    {
+      "name": "ModernWallMaxLength",
+      "type": "int",
+      "default": 4,
+      "comment": "How far apart are two wall pieces allowed to be to allow them to be connected? Respects MaxBuildDistance and [Game.Map]->AllowBuildingBesideWalls"
+    },
+    {
+      "name": "ModernWallFullCost",
+      "type": "bool",
+      "default": true,
+      "comment": "When connecting two wall pieces, should the player pay for each piece of connecting wall? Requires ModernWallBuilding to be on"
+    },
+    {
+      "name": "CommandoGuard",
+      "type": "bool",
+      "default": true,
+      "comment": "Allow the commandos to guard an area (applies to any infantry equipped with a RIFLE weapon)"
+    },
+    {
       "name": "NewSaveGameFormat",
       "type": "bool",
       "default": true,

--- a/tiberiandawn/rules/00.Enhancements.json
+++ b/tiberiandawn/rules/00.Enhancements.json
@@ -17,6 +17,12 @@
       "comment": "Barracks, Hand of Nod, Weapons Factory etc. support setting rally points for produced units TS/RA2 style. Ported from the CFEPatch - see: https://bitbucket.org/cfehunter/cncremastered/src/cfepatch/"
     },
     {
+      "name": "CommandoGuard",
+      "type": "bool",
+      "default": true,
+      "comment": "Allow the commandos to guard an area (applies to any infantry equipped with a RIFLE weapon)"
+    },
+    {
       "name": "NewSaveGameFormat",
       "type": "bool",
       "default": true,

--- a/tiberiandawn/rules/02.Game.Map.json
+++ b/tiberiandawn/rules/02.Game.Map.json
@@ -5,12 +5,6 @@
   "comment": "Building placement rules and tiberium behavior.",
   "rules": [
     {
-      "name": "MaxBuildDistance",
-      "type": "int",
-      "default": 1,
-      "comment": "This controls how far away from an existing structure a player can place a building. _Note: values higher than 6 may cause performance problems._ (Candidate for moving to enhancements)"
-    },
-    {
       "name": "PreventBuildingInShroud",
       "type": "bool",
       "default": true,

--- a/tiberiandawn/rules/07.Game.Multiplayer.json
+++ b/tiberiandawn/rules/07.Game.Multiplayer.json
@@ -27,6 +27,18 @@
       "type": "int",
       "default": 10000,
       "comment": "Maximum number of starting credits for each player"
+    },
+    {
+      "name": "NuclearStrikeDamage",
+      "type": "int",
+      "default": 200,
+      "comment": "Modified direct hit damage for Nuclear Strike in Multiplayer games"
+    },
+    {
+      "name": "NuclearStrikeDamageRadius",
+      "type": "int",
+      "default": 3,
+      "comment": "Modified blast radius for Nuclear Strike in Multiplayer games"
     }
   ]
 }

--- a/tiberiandawn/rules/11.Game.Superweapons.json
+++ b/tiberiandawn/rules/11.Game.Superweapons.json
@@ -1,0 +1,44 @@
+{
+  "$schema": "../../cmake/nco-rules-json-schema.json",
+  "section": "Game.Superweapons",
+  "ini_comment": "Rules for superweapons in the game",
+  "comment": "Change superweapon damage and recharge times.",
+  "rules": [
+    {
+      "name": "AirStrikeRechargeTimeInMins",
+      "type": "int",
+      "default": 8,
+      "comment": "How long an Air Strike takes to recharge, in minutes"
+    },
+    {
+      "name": "IonCannonRechargeTimeInMins",
+      "type": "int",
+      "default": 10,
+      "comment": "How long the Ion Cannon takes to recharge, in minutes"
+    },
+    {
+      "name": "IonCannonDamage",
+      "type": "int",
+      "default": 600,
+      "comment": "Ion Cannon direct hit damage"
+    },
+    {
+      "name": "NuclearStrikeRechargeTimeInMins",
+      "type": "int",
+      "default": 14,
+      "comment": "How long a Nuclear Strike takes to recharge, in minutes"
+    },
+    {
+      "name": "NuclearStrikeDamage",
+      "type": "int",
+      "default": 1000,
+      "comment": "Nuclear Strike direct hit damage"
+    },
+    {
+      "name": "NuclearStrikeDamageRadius",
+      "type": "int",
+      "default": 4,
+      "comment": "How big is the blast radius of a Nuclear Strike"
+    }
+  ]
+}

--- a/tiberiandawn/savegame_v1.cpp
+++ b/tiberiandawn/savegame_v1.cpp
@@ -70,7 +70,7 @@ bool SaveGameScenarioState_v1::Validate(const GameType scenario_game_type) const
         result = false;
     }
 
-    const std::map<std::string, std::string> stringFields = {
+    const std::unordered_map<std::string, std::string> stringFields = {
         { NAMEOF(ScenarioFileName), ScenarioFileName },
         { NAMEOF(BriefText), BriefText },
         { NAMEOF(BriefMovieName), BriefMovieName },
@@ -143,7 +143,7 @@ bool SaveGameScenarioState_v1::Validate(const GameType scenario_game_type) const
     }
 
     // skirmish state
-    std::map<std::string, nlohmann::json> player_fields = {
+    std::unordered_map<std::string, nlohmann::json> player_fields = {
         {NAMEOF(MultiPlayerIds), MultiPlayerIds},
         {NAMEOF(MultiPlayerNames), MultiPlayerNames},
         {NAMEOF(MultiPlayerHouses), MultiPlayerHouses},
@@ -358,7 +358,7 @@ bool SaveGameObjectHeaps_v1::Validate() const
 {
     auto result = true;
 
-    std::map<std::string_view, const nlohmann::json*> heaps = {
+    std::unordered_map<std::string_view, const nlohmann::json*> heaps = {
         { NAMEOF(AnimsHeap), &AnimsHeap },
         { NAMEOF(AircraftHeap), &AircraftHeap },
         { NAMEOF(BulletsHeap), &BulletsHeap },
@@ -498,6 +498,8 @@ void SaveGame_v1::Read_Globals()
 #ifdef REMASTER_BUILD
     RemasterState.Read_Dll_State();
 #endif
+
+    Rules = Rule;
 }
 
 bool SaveGame_v1::Validate(const GameType scenario_game_type) const
@@ -599,6 +601,15 @@ bool SaveGame_v1::Validate(const GameType scenario_game_type) const
     result = RemasterState.Validate() && result;
 #endif
 
+    if (!Rules.is_object()) {
+        result = false;
+        CNC_LOGGER_ERROR(
+            "Invalid {} save game value - json object expected, actual type: {}",
+            NAMEOF(Rules),
+            Rules.type_name()
+        );
+    }
+
     return result;
 }
 
@@ -630,6 +641,21 @@ bool SaveGame_v1::Write_Globals() const
 #endif
 
     return true;
+}
+
+SaveGameData SaveGame_v1::Export_SaveGameData() const
+{
+    if (!Validate(GameToPlay)) {
+        throw std::runtime_error("Refusing to export data from invalid save game");
+    }
+
+    return std::move(
+        SaveGameData(
+            ScenarioState.Parse_MultiPlayer_Special(),
+            ScenarioState.MultiSuperweaponsEnabled,
+            Rules
+        )
+    );
 }
 
 void SaveGame_v1::Dump_Json(std::string& output) const

--- a/tiberiandawn/savegame_v1.cpp
+++ b/tiberiandawn/savegame_v1.cpp
@@ -3,6 +3,7 @@
 
 #include "tiberiandawnsettings.h"
 #include "typeconverter.h"
+#include "lua/scenariolua.h"
 
 #pragma region SaveGameScenarioState_v1
 void SaveGameScenarioState_v1::Read_Globals()
@@ -53,6 +54,8 @@ void SaveGameScenarioState_v1::Read_Globals()
     SelectedObjects = CurrentObject;
     Waypoints = Scen.Waypoint;
     Views = Scen.Views;
+
+    ScenarioScripts = ScenarioLua::Get_Scenario_Scripts();
 }
 
 bool SaveGameScenarioState_v1::Validate(const GameType scenario_game_type) const
@@ -653,6 +656,7 @@ SaveGameData SaveGame_v1::Export_SaveGameData() const
         SaveGameData(
             ScenarioState.Parse_MultiPlayer_Special(),
             ScenarioState.MultiSuperweaponsEnabled,
+            ScenarioState.ScenarioScripts,
             Rules
         )
     );

--- a/tiberiandawn/savegame_v1.h
+++ b/tiberiandawn/savegame_v1.h
@@ -122,7 +122,7 @@ public:
 
 private:
     static inline const auto& Logger = CncLogger::For(SaveGameScenarioState_v1);
-    static inline const std::map<std::string, int> GlobalBufferSizes = {
+    static inline const std::unordered_map<std::string, int> GlobalBufferSizes = {
         { NAMEOF(ScenarioFileName), std::size(Scen.FileName) },
         { NAMEOF(BriefText), std::size(Scen.BriefingText) },
         { NAMEOF(BriefMovieName), std::size(BriefMovie) },
@@ -249,10 +249,13 @@ public:
     SaveGameRemasterState_v1 RemasterState;
 #endif
 
+    nlohmann::json Rules;
+
     bool Load_From_File(const std::string& path);
     void Read_Globals();
     bool Validate(GameType scenario_game_type) const;
     bool Write_Globals() const;
+    SaveGameData Export_SaveGameData() const;
     void Dump_Json(std::string& output) const;
     bool To_File(CDFileClass& save_file, const SaveGameHeader& header) const;
 
@@ -272,7 +275,8 @@ public:
         GameLogic,
         Layers,
         AiBase,
-        GameScore
+        GameScore,
+        Rules
     )
 #else
     NLOHMANN_DEFINE_TYPE_INTRUSIVE(
@@ -287,7 +291,8 @@ public:
         Layers,
         AiBase,
         GameScore,
-        RemasterState
+        RemasterState,
+        Rules
     )
 #endif
 

--- a/tiberiandawn/savegame_v1.h
+++ b/tiberiandawn/savegame_v1.h
@@ -71,6 +71,8 @@ public:
     nlohmann::json Waypoints;
     nlohmann::json Views;
 
+    std::vector<std::string> ScenarioScripts;
+
     void Read_Globals();
     bool Validate(GameType scenario_game_type) const;
     ScenarioDirType Parse_Scenario_Direction() const;
@@ -117,7 +119,8 @@ public:
         MultiSuperweaponsEnabled,
         SelectedObjects,
         Waypoints,
-        Views
+        Views,
+        ScenarioScripts
     )
 
 private:

--- a/tiberiandawn/savegameheader.cpp
+++ b/tiberiandawn/savegameheader.cpp
@@ -4,6 +4,13 @@
 #include "savegameheader.h"
 #include "typeconverter.h"
 
+void SaveGameData::Apply_Rules(RulesClass& rules) const
+{
+    CNC_LOGGER_INFO("Applying scenario rules from save game data");
+
+    from_json(ScenarioRules, rules);
+}
+
 bool SaveGameHeader::From_Stream(std::ifstream& stream, SaveGameHeader& output)
 {
     // read SaveGameHeader JSON
@@ -113,6 +120,20 @@ bool SaveGameHeader::Write_Globals() const
     Whom = Parse_Player_House_Type();
 
     return true;
+}
+
+void SaveGameHeader::Set_SaveGameData(SaveGameData data)
+{
+    SaveData = std::move(data);
+}
+
+const SaveGameData& SaveGameHeader::Get_SaveGameData() const
+{
+    if (!SaveData.has_value()) {
+        throw std::runtime_error("Attempt was made to access save game header with empty save data export");
+    }
+
+    return SaveData.value();
 }
 
 GameType SaveGameHeader::Parse_Game_Type() const

--- a/tiberiandawn/savegameheader.cpp
+++ b/tiberiandawn/savegameheader.cpp
@@ -4,11 +4,23 @@
 #include "savegameheader.h"
 #include "typeconverter.h"
 
-void SaveGameData::Apply_Rules(RulesClass& rules) const
+bool SaveGameData::Apply_Rules(RulesClass& rules) const
 {
     CNC_LOGGER_INFO("Applying scenario rules from save game data");
 
-    from_json(ScenarioRules, rules);
+    std::string error_message;
+
+    try {
+        from_json(ScenarioRules, rules);
+        return true;
+    } catch (const CncJsonException& e) {
+        error_message = e.what();
+    } catch (const nlohmann::json::exception& e) {
+        error_message = e.what();
+    }
+
+    CNC_LOG_ERROR("Error applying rules from save game data: {}", error_message);
+    return false;
 }
 
 bool SaveGameHeader::From_Stream(std::ifstream& stream, SaveGameHeader& output)

--- a/tiberiandawn/savegameheader.h
+++ b/tiberiandawn/savegameheader.h
@@ -8,6 +8,28 @@
 
 #include "defines.h"
 
+class SaveGameData final
+{
+public:
+    SpecialClass SkirmishSpecial;
+    bool SkirmishSuperweaponsEnabled;
+    nlohmann::json ScenarioRules;
+
+    SaveGameData(SpecialClass skirmish_special,
+                 bool skirmish_superweapons_enabled,
+                 nlohmann::json scenario_rules)
+        : SkirmishSpecial(std::move(skirmish_special))
+        , SkirmishSuperweaponsEnabled(skirmish_superweapons_enabled)
+        , ScenarioRules(std::move(scenario_rules))
+    {
+    }
+
+    void Apply_Rules(RulesClass& rules) const;
+
+private:
+    static inline const auto& Logger = CncLogger::For(SaveGameData);
+};
+
 class SaveGameHeader final
 {
 public:
@@ -28,6 +50,8 @@ public:
     void Read_Globals();
     bool Validate() const;
     bool Write_Globals() const;
+    void Set_SaveGameData(SaveGameData data);
+    const SaveGameData& Get_SaveGameData() const;
 
     GameType Parse_Game_Type() const;
     HousesType Parse_Player_House_Type() const;
@@ -47,4 +71,5 @@ public:
 
 private:
     static inline const auto& Logger = CncLogger::For(SaveGameHeader);
+    std::optional<SaveGameData> SaveData;
 };

--- a/tiberiandawn/savegameheader.h
+++ b/tiberiandawn/savegameheader.h
@@ -27,7 +27,7 @@ public:
     {
     }
 
-    void Apply_Rules(RulesClass& rules) const;
+     bool Apply_Rules(RulesClass& rules) const;
 
 private:
     static inline const auto& Logger = CncLogger::For(SaveGameData);

--- a/tiberiandawn/savegameheader.h
+++ b/tiberiandawn/savegameheader.h
@@ -13,13 +13,16 @@ class SaveGameData final
 public:
     SpecialClass SkirmishSpecial;
     bool SkirmishSuperweaponsEnabled;
+    std::vector<std::string> ScenarioScripts;
     nlohmann::json ScenarioRules;
 
     SaveGameData(SpecialClass skirmish_special,
                  bool skirmish_superweapons_enabled,
+                 std::vector<std::string> scenario_scripts,
                  nlohmann::json scenario_rules)
         : SkirmishSpecial(std::move(skirmish_special))
         , SkirmishSuperweaponsEnabled(skirmish_superweapons_enabled)
+        , ScenarioScripts(std::move(scenario_scripts))
         , ScenarioRules(std::move(scenario_rules))
     {
     }

--- a/tiberiandawn/savegameresolver.cpp
+++ b/tiberiandawn/savegameresolver.cpp
@@ -60,11 +60,7 @@ std::optional<SaveGameHeader> SaveGameResolver::Load_Header(const std::string& p
     return header;
 }
 
-std::optional<SaveGameHeader> SaveGameResolver::Load(
-    const std::string& path,
-    SpecialClass& skirmish_special,
-    bool& skirmish_superweapons_enabled
-)
+std::optional<SaveGameHeader> SaveGameResolver::Load(const std::string& path)
 {
     SaveGameHeader header;
 
@@ -79,13 +75,12 @@ std::optional<SaveGameHeader> SaveGameResolver::Load(
                 std::string error_message;
 
                 try {
-                    const auto header_globals_written = header.Write_Globals();
+                    if (header.Write_Globals() && save.Write_Globals()) {
+                        header.Set_SaveGameData(
+                            std::move(save.Export_SaveGameData())
+                        );
 
-                    if (header_globals_written && save.Write_Globals()) {
-                        skirmish_special = save.ScenarioState.Parse_MultiPlayer_Special();
-                        skirmish_superweapons_enabled = save.ScenarioState.MultiSuperweaponsEnabled;
-
-                        return header;
+                        return std::move(header);
                     }
                 } catch (const CncJsonException& e) {
                     error_message = e.what();

--- a/tiberiandawn/savegameresolver.h
+++ b/tiberiandawn/savegameresolver.h
@@ -49,11 +49,7 @@ public:
      * will determine load behavior. References for skirmish options will be assigned values
      * from save data.
      */
-    static std::optional<SaveGameHeader> Load(
-        const std::string& path,
-        SpecialClass& skirmish_special,
-        bool& skirmish_superweapons_enabled
-    );
+    static std::optional<SaveGameHeader> Load(const std::string& path);
 
 private:
     static inline const CncLogger Logger = CncLogger::For(SaveGameResolver);

--- a/tiberiandawn/saveload.cpp
+++ b/tiberiandawn/saveload.cpp
@@ -402,7 +402,7 @@ bool Load_Game(const char* file_name)
 #ifndef REMASTER_BUILD
         PathsClass::Concatenate_Paths(Paths.User_Save_Path(), file_name)
 #else
-        ,file_name
+        file_name
 #endif
     );
 

--- a/tiberiandawn/saveload.cpp
+++ b/tiberiandawn/saveload.cpp
@@ -352,20 +352,37 @@ bool Load_Game(int id)
  * we also apply the game options using Rules API.
  *
  * Rules values stored in save game directly are applied last, ensuring if INI file is not available we still get the
- * correct scenario behaviour; this also restores any rules changed dynamically at runtime by Lua etc.
+ * correct scenario behavior; this also restores any rules changed dynamically at runtime by Lua etc.
  *
- * Scenarios with Lua scripts that have event handlers require the INI file and associated lua scripts to be
- * available or else the scenario may be broken; player may be soft locked due to a event handler not firing.
- *
- * TODO: Flag if Lua scripts have run when saving so ScenarioLua can error if those scripts are not found on load
- *       (missing event handlers could break a scenario)
+ * Save games with Lua scripts are validated to ensure all required scripts are present - if a script is missing, a
+ * required event handler might not be loaded. This could lead to a soft lock state where expected triggers are never
+ * able to fire.
  */
-static void Load_INI_Rules_And_Lua(const SaveGameData& data)
+static bool Load_INI_Rules_And_Lua(const SaveGameData& data)
 {
     Rule.Init_For_Scenario(Scen, GameToPlay, data.SkirmishSpecial, data.SkirmishSuperweaponsEnabled);
     ScenarioLua::On_Scenario_Load(GameToPlay, Scen, *PlayerPtr, true);
 
+    const auto& loaded_scripts = ScenarioLua::Get_Scenario_Scripts();
+    std::vector<std::string> missing_scripts;
+
+    for (const auto& script : data.ScenarioScripts) {
+        if (!std::ranges::contains(loaded_scripts, script)) {
+            missing_scripts.push_back(script);
+        }
+    }
+
+    if (!missing_scripts.empty()) {
+        // missing Lua script(s) might contain event handlers, so we need to abort the load process
+        CNC_LOG_ERROR(
+            "Lua script(s) required to load save game were not found: {}",
+            CncStringUtils::To_Csv(missing_scripts)
+        );
+        return false;
+    }
+
     data.Apply_Rules(Rule);
+    return true;
 }
 
 /*
@@ -462,7 +479,10 @@ bool Load_Game(const char* file_name)
 
     Fixup_Scenario();
 
-    Load_INI_Rules_And_Lua(save_header->Get_SaveGameData());
+    if (!Load_INI_Rules_And_Lua(save_header->Get_SaveGameData())) {
+        Set_Current_Resolution_Mode(resolution_mode);
+        return false;
+    }
 
     ScenarioInit = 0;
 

--- a/tiberiandawn/saveload.cpp
+++ b/tiberiandawn/saveload.cpp
@@ -381,8 +381,7 @@ static bool Load_INI_Rules_And_Lua(const SaveGameData& data)
         return false;
     }
 
-    data.Apply_Rules(Rule);
-    return true;
+    return data.Apply_Rules(Rule);
 }
 
 /*

--- a/tiberiandawn/saveload.cpp
+++ b/tiberiandawn/saveload.cpp
@@ -357,14 +357,13 @@ bool Load_Game(int id)
  * Scenarios with Lua scripts that have event handlers require the INI file and associated lua scripts to be
  * available or else the scenario may be broken; player may be soft locked due to a event handler not firing.
  *
- * TODO: Pass flag to lua script so they know they are being called on save load (not fresh scenario)
  * TODO: Flag if Lua scripts have run when saving so ScenarioLua can error if those scripts are not found on load
  *       (missing event handlers could break a scenario)
  */
 static void Load_INI_Rules_And_Lua(const SaveGameData& data)
 {
     Rule.Init_For_Scenario(Scen, GameToPlay, data.SkirmishSpecial, data.SkirmishSuperweaponsEnabled);
-    ScenarioLua::On_Scenario_Load(GameToPlay, Scen, *PlayerPtr);
+    ScenarioLua::On_Scenario_Load(GameToPlay, Scen, *PlayerPtr, true);
 
     data.Apply_Rules(Rule);
 }

--- a/tiberiandawn/saveload.cpp
+++ b/tiberiandawn/saveload.cpp
@@ -347,13 +347,19 @@ bool Load_Game(int id)
 }
 
 /**
- * Ensure Rules from the scenario INI file recorded in the save game
- * are loaded and init Lua runtime so all scripts are re-ran in prep
- * for continuing the scenario. If the save is from a Skirmish game
+ * Ensure Rules from the scenario INI file recorded in the save game are loaded (if INI file is available) and init
+ * Lua runtime so all scripts are re-ran in prep for continuing the scenario. If the save is from a Skirmish game
  * we also apply the game options using Rules API.
  *
+ * Rules values stored in save game directly are applied last, ensuring if INI file is not available we still get the
+ * correct scenario behaviour; this also restores any rules changed dynamically at runtime by Lua etc.
+ *
+ * Scenarios with Lua scripts that have event handlers require the INI file and associated lua scripts to be
+ * available or else the scenario may be broken; player may be soft locked due to a event handler not firing.
+ *
  * TODO: Pass flag to lua script so they know they are being called on save load (not fresh scenario)
- * TODO: Store RuleSections as map in save game, refactor RulesClass to accept this instead of INI file for scenario rules
+ * TODO: Flag if Lua scripts have run when saving so ScenarioLua can error if those scripts are not found on load
+ *       (missing event handlers could break a scenario)
  */
 static void Load_INI_Rules_And_Lua(const SaveGameData& data)
 {

--- a/tiberiandawn/saveload.cpp
+++ b/tiberiandawn/saveload.cpp
@@ -355,10 +355,12 @@ bool Load_Game(int id)
  * TODO: Pass flag to lua script so they know they are being called on save load (not fresh scenario)
  * TODO: Store RuleSections as map in save game, refactor RulesClass to accept this instead of INI file for scenario rules
  */
-static void Load_INI_Rules_And_Lua(const SpecialClass& skirmish_special, const bool& skirmish_superweapons_enabled)
+static void Load_INI_Rules_And_Lua(const SaveGameData& data)
 {
-    Rule.Init_For_Scenario(Scen, GameToPlay, skirmish_special, skirmish_superweapons_enabled);
+    Rule.Init_For_Scenario(Scen, GameToPlay, data.SkirmishSpecial, data.SkirmishSuperweaponsEnabled);
     ScenarioLua::On_Scenario_Load(GameToPlay, Scen, *PlayerPtr);
+
+    data.Apply_Rules(Rule);
 }
 
 /*
@@ -375,17 +377,12 @@ bool Load_Game(const char* file_name)
     Leave_Zoomed_Resolution_Mode();
     Call_Back();
 
-    SpecialClass skirmish_special;
-    bool skirmish_superweapons_enabled;
-
     const auto save_header = SaveGameResolver::Load(
 #ifndef REMASTER_BUILD
-        PathsClass::Concatenate_Paths(Paths.User_Save_Path(), file_name),
+        PathsClass::Concatenate_Paths(Paths.User_Save_Path(), file_name)
 #else
-        file_name,
+        ,file_name
 #endif
-        skirmish_special,
-        skirmish_superweapons_enabled
     );
 
     if (!save_header.has_value()) {
@@ -460,7 +457,7 @@ bool Load_Game(const char* file_name)
 
     Fixup_Scenario();
 
-    Load_INI_Rules_And_Lua(skirmish_special, skirmish_superweapons_enabled);
+    Load_INI_Rules_And_Lua(save_header->Get_SaveGameData());
 
     ScenarioInit = 0;
 

--- a/tiberiandawn/scenario.cpp
+++ b/tiberiandawn/scenario.cpp
@@ -728,11 +728,7 @@ void Do_Lose(void)
     Fade_Palette_To(GamePalette, FADE_PALETTE_FAST, Call_Back);
     Show_Mouse();
 
-    if (Map.Is_Smaller_Than_Screen()) {
-        Map.Set_View_Dimensions(0, Map.Get_Tab_Height());
-        Map.Flag_To_Redraw(true);
-        Map.Render();
-    }
+    Map.Redraw_If_Smaller_Then_Screen();
 }
 
 /***********************************************************************************************

--- a/tiberiandawn/scenarioini.cpp
+++ b/tiberiandawn/scenarioini.cpp
@@ -660,7 +660,7 @@ bool Read_Scenario_Ini(char* root, SpecialClass special_options, bool allow_supe
      * Lua rabbit hole (if not in scenario editor mode)
      */
     if (!Debug_Map) {
-        ScenarioLua::On_Scenario_Load(GameToPlay, Scen, *PlayerPtr, ini);
+        ScenarioLua::On_Scenario_Load(GameToPlay, Scen, *PlayerPtr, ini, false);
     }
 
     /*

--- a/tiberiandawn/sidebar.cpp
+++ b/tiberiandawn/sidebar.cpp
@@ -2714,7 +2714,7 @@ FROM_JSON(SidebarClass::StripClass::BuildType)
     FIELD_FROM_JSON(BuildableViaCapture);
 
     // BuildableID field
-    const auto& buildable_id_json = j.at(NAMEOF(BuildableID));
+    const auto& buildable_id_json = j[NAMEOF(BuildableID)];
 
     CncJsonUtils::Assert_Json_Is<JsonString>(buildable_id_json, NAMEOF(BuildableID));
 

--- a/tiberiandawn/sidebarglyphx.cpp
+++ b/tiberiandawn/sidebarglyphx.cpp
@@ -811,7 +811,7 @@ FROM_JSON(SidebarGlyphxClass::StripClass::BuildType)
     FIELD_FROM_JSON(BuildableViaCapture);
 
     // BuildableID field
-    const auto& buildable_id_json = j.at(NAMEOF(BuildableID));
+    const auto& buildable_id_json = j[NAMEOF(BuildableID)];
 
     CncJsonUtils::Assert_Json_Is<JsonString>(buildable_id_json, NAMEOF(BuildableID));
 

--- a/tiberiandawn/special.h
+++ b/tiberiandawn/special.h
@@ -282,7 +282,7 @@ public:
     /**
      * Set rule section values based on values in this instance.
      */
-    const RuleSections& Write_Rules(RuleSections& rules) const;
+    RuleSections& Write_Rules(RuleSections& rules) const;
 
     JSON_FUNCTIONS(SpecialClass)
 };

--- a/tiberiandawn/special.h
+++ b/tiberiandawn/special.h
@@ -282,7 +282,7 @@ public:
     /**
      * Set rule section values based on values in this instance.
      */
-    const RuleSections& Write_Rules(const RuleSections& rules) const;
+    const RuleSections& Write_Rules(RuleSections& rules) const;
 
     JSON_FUNCTIONS(SpecialClass)
 };

--- a/tiberiandawn/super.h
+++ b/tiberiandawn/super.h
@@ -79,6 +79,11 @@ public:
         return (RechargeTime);
     };
 
+    void Set_Recharge_Time(const int recharge)
+    {
+        RechargeTime = recharge;
+    }
+
     JSON_FUNCTIONS(SuperClass)
 private:
     bool Recharge(bool player = false);

--- a/tiberiandawn/teamtype.cpp
+++ b/tiberiandawn/teamtype.cpp
@@ -989,7 +989,7 @@ FROM_JSON(TeamTypeClass)
     FIELD_FROM_JSON(ClassCount);
 
     // Class array
-    const auto& class_array = j.at(NAMEOF(Class));
+    const auto& class_array = j[NAMEOF(Class)];
 
     CncJsonUtils::Assert_Json_Is_Array_Of_Exact_Size<JsonUnsignedInt>(
         class_array,

--- a/tiberiandawn/techno.cpp
+++ b/tiberiandawn/techno.cpp
@@ -4476,6 +4476,7 @@ void TechnoClass::Draw_Pips(int x, int y, WindowNumberType window)
 
             if (object) {
                 pip = PIP_FULL;
+                // TODO: rules around this so you can set per infantry type
                 if (object->What_Am_I() == RTTI_INFANTRY) {
                     if (*((InfantryClass*)object) == INFANTRY_RAMBO) {
                         pip = PIP_COMMANDO;

--- a/tiberiandawn/tiberiandawnsettings.cpp
+++ b/tiberiandawn/tiberiandawnsettings.cpp
@@ -52,11 +52,11 @@ void TiberianDawnSettings::Load(std::string ini_file_name, INIClass& ini)
     Load_MultiPlayer(ini);
 }
 
-void TiberianDawnSettings::Update_MultiPlayer() const
+void TiberianDawnSettings::Update_MultiPlayer()
 {
     CNC_LOGGER_DEBUG("Updating Tiberian Dawn multiplayer settings from globals variables");
 
-    MultiPlayer().Set("Handle", MPlayerName)
+    Editable_MultiPlayer().Set("Handle", MPlayerName)
         .Set("ScenarioNumber", MPlayerScenarioNumber)
         .Set("BasesOn", MPlayerBases)
         .Set("TiberiumRegrows", static_cast<bool>(MPlayerTiberium))
@@ -66,7 +66,7 @@ void TiberianDawnSettings::Update_MultiPlayer() const
         .Set_With_Converter<HousesType, TdTypeConverter>("Side", MPlayerHouse);
 }
 
-void TiberianDawnSettings::Update() const
+void TiberianDawnSettings::Update()
 {
     Update_MultiPlayer();
 }
@@ -78,7 +78,7 @@ void TiberianDawnSettings::Save(INIClass& ini) const
     Settings.Save_All_To_Ini(ini);
 }
 
-RuleSection& TiberianDawnSettings::MultiPlayer() const
+const RuleSection& TiberianDawnSettings::MultiPlayer() const
 {
     if (!Settings.Has_Section(MultiPlayerSection)) {
         throw std::runtime_error("Attempted to get multiplayer settings before TdSettings.Load(...) was called");
@@ -87,7 +87,21 @@ RuleSection& TiberianDawnSettings::MultiPlayer() const
     return Settings[MultiPlayerSection];
 }
 
-RuleSection& TiberianDawnSettings::operator[](std::string_view section) const
+RuleSection& TiberianDawnSettings::Editable_MultiPlayer()
+{
+    if (!Settings.Has_Section(MultiPlayerSection)) {
+        throw std::runtime_error("Attempted to get multiplayer settings before TdSettings.Load(...) was called");
+    }
+
+    return Settings[MultiPlayerSection];
+}
+
+const RuleSection& TiberianDawnSettings::operator[](const std::string_view section) const
+{
+    return Settings[section];
+}
+
+RuleSection& TiberianDawnSettings::operator[](const std::string_view section)
 {
     return Settings[section];
 }

--- a/tiberiandawn/tiberiandawnsettings.h
+++ b/tiberiandawn/tiberiandawnsettings.h
@@ -19,13 +19,15 @@ public:
 
     void Load(std::string ini_file_name, INIClass& ini);
 
-    RuleSection& MultiPlayer() const;
+    const RuleSection& MultiPlayer() const;
+    RuleSection& Editable_MultiPlayer();
 
-    void Update_MultiPlayer() const;
-    void Update() const;
+    void Update_MultiPlayer();
+    void Update();
     void Save(INIClass& ini) const;
 
-    RuleSection& operator[](std::string_view section) const;
+    const RuleSection& operator[](std::string_view section) const;
+    RuleSection& operator[](std::string_view section);
 
 private:
     static inline const auto& Logger = CncLogger::For(TiberianDawnSettings);

--- a/tiberiandawn/type.h
+++ b/tiberiandawn/type.h
@@ -1300,9 +1300,8 @@ public:
     char FireLaunch;
     char ProneLaunch;
 
-    // TODO: Implement NCO logic and new fields
-    //bool IsImmuneToTiberium;
-
+    // NCO original rules
+    bool IsImmuneToTiberium;
     bool HasC4Charges;
 
     /*
@@ -1341,7 +1340,8 @@ public:
                       WeaponType primary,
                       WeaponType secondary,
                       MPHType maxspeed,
-                      bool has_c4_charges = false);
+                      bool has_c4_charges = false,
+                      bool is_immune_to_tiberium = false);
     virtual RTTIType What_Am_I(void) const
     {
         return RTTI_INFANTRYTYPE;

--- a/tiberiandawn/type.h
+++ b/tiberiandawn/type.h
@@ -1302,7 +1302,8 @@ public:
 
     // TODO: Implement NCO logic and new fields
     //bool IsImmuneToTiberium;
-    //bool HasC4Charges;
+
+    bool HasC4Charges;
 
     /*
     **	This is the explicit unit class constructor.
@@ -1339,7 +1340,8 @@ public:
                       std::vector<HousesType> ownableBy,
                       WeaponType primary,
                       WeaponType secondary,
-                      MPHType maxspeed);
+                      MPHType maxspeed,
+                      bool has_c4_charges = false);
     virtual RTTIType What_Am_I(void) const
     {
         return RTTI_INFANTRYTYPE;

--- a/tiberiandawn/type.h
+++ b/tiberiandawn/type.h
@@ -854,6 +854,9 @@ public:
     } AnimControlType;
     AnimControlType Anims[BSTATE_COUNT];
 
+    // when this building is placed, this is the overlay that gets placed on the map instead
+    OverlayType OverlayToPlace;
+
     /*
     **	This is a mask flag used to determine if all the necessary prerequisite
     **	buildings have been built.
@@ -916,7 +919,8 @@ public:
                       short const* exitlist,
                       short const* sizelist,
                       short const* overlap,
-                      bool is_unsellable = false);
+                      bool is_unsellable = false,
+                      OverlayType overlay_type = OVERLAY_NONE);
     virtual RTTIType What_Am_I(void) const
     {
         return RTTI_BUILDINGTYPE;

--- a/tiberiandawn/typeconverter.cpp
+++ b/tiberiandawn/typeconverter.cpp
@@ -4,7 +4,7 @@
 /**
  * Make some type names more human-readable or less confusing.
  */
-const std::map<std::string, std::string_view> TdTypeConverter::TypeNamePatchTable = {
+const std::unordered_map<std::string, std::string_view> TdTypeConverter::TypeNamePatchTable = {
     { NAMEOF(AnimType), "Animation" },
     { NAMEOF(StructType), "Building" },
     { NAMEOF(HousesType), "House" }
@@ -36,7 +36,7 @@ static const std::vector TemplateExcludes = {TEMPLATE_COUNT};
 #define ENUM_TYPE_PAIR(TYPE, ...) { Get_Type_Name<TYPE>(), EnumTypeInfo<TYPE>(__VA_ARGS__) }
 
 // Info about each enum supported type, indexed against it's typename
-const std::map<std::string_view, EnumTypeInfoVariant> TdTypeConverter::EnumTypes = {
+const std::unordered_map<std::string_view, EnumTypeInfoVariant> TdTypeConverter::EnumTypes = {
     //            [Typename]                     [Prefix]        [Min Valid Val]                         [Max Valid Val]                           [INI Patch Table]    [Excluded Vals]      [Allow non-enum values?]
     ENUM_TYPE_PAIR(ArmorType,                    "ARMOR_",       ARMOR_NONE,                             ARMOR_LAST,                               {},                  {},                  false),
     ENUM_TYPE_PAIR(MPHType,                      "MPH_",         MPH_IMMOBILE,                           MPH_LIGHT_SPEED,                          {},                  {},                  true),

--- a/tiberiandawn/typeconverter.h
+++ b/tiberiandawn/typeconverter.h
@@ -47,8 +47,8 @@ class TdTypeConverter final
 {
 public:
     static constexpr std::string_view EnumPostfix = "Type";
-    static const std::map<std::string, std::string_view> TypeNamePatchTable;
-    static const std::map<std::string_view, EnumTypeInfoVariant> EnumTypes;
+    static const std::unordered_map<std::string, std::string_view> TypeNamePatchTable;
+    static const std::unordered_map<std::string_view, EnumTypeInfoVariant> EnumTypes;
 
     template<class T>
     requires SupportedByTdTypeConverter<T>
@@ -557,8 +557,8 @@ public:
 
 private:
     static inline const auto& Logger = CncLogger::For(TdTypeConverter);
-    static inline std::map<std::string_view, std::map<std::string_view, ConverterTypeVariant>> RegisteredRuleTypes;
-    static inline std::map<std::string_view, std::map<std::string_view, ConverterTypeVariant>> RegisteredCsvRuleTypes;
+    static inline std::unordered_map<std::string_view, std::unordered_map<std::string_view, ConverterTypeVariant>> RegisteredRuleTypes;
+    static inline std::unordered_map<std::string_view, std::unordered_map<std::string_view, ConverterTypeVariant>> RegisteredCsvRuleTypes;
 
     TdTypeConverter() = delete;
 };

--- a/tiberiandawn/typeconvertermacros.h
+++ b/tiberiandawn/typeconvertermacros.h
@@ -67,27 +67,27 @@
 #pragma region From JSON Macros
 
 // Load target value from JSON into pointer memory address
-#define TARGET_PTR_FROM_JSON_WITH_TYPE(FIELD, TYPE) p.FIELD = TARGET_TO_PTR_WITH_TYPE(j.at(#FIELD).get<TARGET>(), TYPE)
+#define TARGET_PTR_FROM_JSON_WITH_TYPE(FIELD, TYPE) p.FIELD = TARGET_TO_PTR_WITH_TYPE(j[#FIELD].get<TARGET>(), TYPE)
 
 // Load target value from JSON into pointer memory address
 #define TARGET_CONST_PTR_FROM_JSON_WITH_TYPE(FIELD, TYPE) \
-    ((TYPE const*&)p.FIELD) = TARGET_TO_PTR_WITH_TYPE(j.at(#FIELD).get<TARGET>(), TYPE)
+    ((TYPE const*&)p.FIELD) = TARGET_TO_PTR_WITH_TYPE(j[#FIELD].get<TARGET>(), TYPE)
 
 // Load target value for ObjectTypeClass into pointer memory address
 #define OBJECT_TARGET_PTR_FROM_JSON(FIELD) TARGET_PTR_FROM_JSON_WITH_TYPE(FIELD, ObjectClass)
 
 // Load target value for ref to TechnoTypeClass of TYPE into pointer memory address
 #define TECHNO_TYPE_TARGET_PTR_FROM_REF_JSON_WITH_TYPE(CLASS, FIELD, TYPE, ENUM) \
-    TdTypeConverter::Techno_Type_Target_From_Json<TYPE, ENUM>(j.at(#FIELD), #CLASS, #FIELD, p.FIELD)
+    TdTypeConverter::Techno_Type_Target_From_Json<TYPE, ENUM>(j[#FIELD], #CLASS, #FIELD, p.FIELD)
 
 // Load target value for ref to TechnoTypeClass of TYPE into const pointer memory address
 #define TECHNO_TYPE_TARGET_CONST_PTR_FROM_REF_JSON_WITH_TYPE(CLASS, FIELD, TYPE, ENUM) \
-    TdTypeConverter::Techno_Type_Target_From_Json<TYPE, ENUM>(j.at(#FIELD), #CLASS, #FIELD, const_cast<TYPE*&>(p.FIELD))
+    TdTypeConverter::Techno_Type_Target_From_Json<TYPE, ENUM>(j[#FIELD], #CLASS, #FIELD, const_cast<TYPE*&>(p.FIELD))
 
 // Load target values for array (with length SIZE) of ObjectTypeClass pointer memory addresses
 #define OBJECT_TARGET_PTR_ARRAY_FROM_JSON_WITH_SIZE(CLASS, FIELD, TYPE, SIZE) \
     TdTypeConverter::Object_Target_Array_From_Json<TYPE>( \
-        j.at(#FIELD), #CLASS, #FIELD, p.FIELD, SIZE \
+        j[#FIELD], #CLASS, #FIELD, p.FIELD, SIZE \
     )
 
 // Load target values for array of ObjectTypeClass pointer memory addresses

--- a/tiberiandawn/types-nco.cpp.in
+++ b/tiberiandawn/types-nco.cpp.in
@@ -79,6 +79,10 @@ const IniRuleContext& InfantryTypeClass::Read_INI(const IniRuleContext& ini)
 
 const RuleSection& InfantryTypeClass::Read_Rules(const RuleSection& rules)
 {
+    if (rules.SectionName == "E2") {
+      CNC_LOG_WARN("Running Read_Rules() handler for E2");
+    }
+
     return TechnoTypeClass::Read_Rules(rules)
         @READ_INFANTRY_RULES_CODE@;
 }

--- a/tiberiandawn/types-nco.cpp.in
+++ b/tiberiandawn/types-nco.cpp.in
@@ -79,10 +79,6 @@ const IniRuleContext& InfantryTypeClass::Read_INI(const IniRuleContext& ini)
 
 const RuleSection& InfantryTypeClass::Read_Rules(const RuleSection& rules)
 {
-    if (rules.SectionName == "E2") {
-      CNC_LOG_WARN("Running Read_Rules() handler for E2");
-    }
-
     return TechnoTypeClass::Read_Rules(rules)
         @READ_INFANTRY_RULES_CODE@;
 }

--- a/tiberiandawn/types/03.Infantry.json
+++ b/tiberiandawn/types/03.Infantry.json
@@ -39,6 +39,11 @@
       "comment": "For 'fraidycat' infantry types that will run away from any damage causing events, this controls whether they avoid wandering into Tiberium."
     },
     {
+      "name": "HasC4Charges",
+      "type": "Bool",
+      "comment": "Does this infantry type carry C4 charges, and therefore can blow up buildings."
+    },
+    {
       "name": "Type",
       "type": "InfantryType",
       "requires_converter": true,

--- a/tiberiandawn/types/03.Infantry.json
+++ b/tiberiandawn/types/03.Infantry.json
@@ -44,6 +44,11 @@
       "comment": "Does this infantry type carry C4 charges, and therefore can blow up buildings."
     },
     {
+      "name": "IsImmuneToTiberium",
+      "type": "Bool",
+      "comment": "Is this infantry type immune to tiberium damage."
+    },
+    {
       "name": "Type",
       "type": "InfantryType",
       "requires_converter": true,

--- a/tiberiandawn/types/06.Buildings.json
+++ b/tiberiandawn/types/06.Buildings.json
@@ -90,6 +90,13 @@
       "requires_converter": true,
       "valid_values": "NONE, 11, 21, 12, 22, 23, 32, 33, 42, 55",
       "comment": "This is the size of the building. This size value is a rough indication of the building's 'footprint'."
+    },
+    {
+      "name": "OverlayToPlace",
+      "type": "OverlayType",
+      "requires_converter": true,
+      "valid_values": "NONE, CONCRETE, SANDBAG_WALL, CYCLONE_WALL, BRICK_WALL, BARBWIRE_WALL, WOOD_WALL, TIBERIUM1, TIBERIUM2, TIBERIUM3, TIBERIUM4, TIBERIUM5, TIBERIUM6, TIBERIUM7, TIBERIUM8, TIBERIUM9, TIBERIUM10, TIBERIUM11, TIBERIUM12, ROAD, SQUISH, V12, V13, V14, V15, V16, V17, V18, FLAG_SPOT, WOOD_CRATE, STEEL_CRATE",
+      "comment": "Walls are placed as overlay on the map, this determines which overlay to use; non-wall buildings are always NONE."
     }
   ]
 }

--- a/wiki/4.Planned-Features.md
+++ b/wiki/4.Planned-Features.md
@@ -41,9 +41,8 @@ As I decide what items to work on next, I'll add a feature request to this repo 
   - Instead of always defaulting to 'Most north unit'
   - In the case of superweapons, this is instead of 'Most valuable thing, searching from the north'
   - Could have more enhancements that remove 'cheese' strats from the game
-- Press `T` to select all instance of the select object type on screen (aircraft/infantry/units)
 - Persist all skirmish/lan options in conquer.ini -> `[MultiPlayer]`
-  - Partially implemented int `TiberianDawnSettings` class
+  - Partially implemented in `TiberianDawnSettings` class
 - Syncing rule ini files
   - Add missing sections/rules, but leave existing values alone
   - Ignore unrecognized sections/rules, just log a warning

--- a/wiki/4.Planned-Features.md
+++ b/wiki/4.Planned-Features.md
@@ -33,6 +33,9 @@ As I decide what items to work on next, I'll add a feature request to this repo 
 
 ## Tiberian Dawn
 
+- Test INI based terrain and templates (was scrapped for BIN files so performance was better, but code still exists)
+  - Fix any issues as this is far easier from a map editor/external tools POV
+- Allow setting Map cell ownership in Scenario INI so that player walls are sellable on scenario start
 - Blue tiberium
 - Mission selection screen enhancements
   - Add countries and point of conflict


### PR DESCRIPTION
Brings in more NCO rules from the old remastered mod:

- Superweapon rules
- Infantry rules to make Commando C4 ability generic and Chemwarrior tiberium immunity generic
- Command Guard ability
- Modern wall building to allow connecting two wall pieces together in  a straight line (with config options for behavior)

Due to superweapon rules affecting gameplay if changed, storing the current game rules in saves has been implemented. The new order for loading games is:

- Load rules from INI (if present)
- Run Lua scripts
- Apply rules from save game data

This way the scenario is setup in the way the original game was, with changes layered correctly (INI data -> Lua changes -> Runtime changes to rules). All rules are applied on-top of a fresh init of the current rules, which means any new rules the game logic depends on will be present.

**This does mean we cannot change rule names or paths without making a new save game version with migration patches for loading older save game versions**

## Features

- **td**: Implement missing NCO rules (Superweapons, Infantry [IsImmuneToTiberium, HasC4Charges], Commando Guard and ModernWallBuilding)
- **td**:  JSON save games now record rules and apply them on save load
- **td**:  JSON save games assert that Lua Scripts that were executed for scenario are present on load

## Fixes

- **td/ra**: Fixed small map redrawing on high resolution modes when loading from saves and ensuring sidebar taken into account when checking map size (affects `ra` and `td`).
- **td**: Make build beside walls rule logic more robust (actually verifies the object under test is actually a overlay of a wall type)

## Refactors

- **common**: Standardize JSON field handling
- **common**: Migrate from `std::map` to `std::unordered_map` for improved performance.
