### PR TITLE
fix(td): Improve Rally Point Rendering

### DIFF
--- a/tiberiandawn/building.cpp
+++ b/tiberiandawn/building.cpp
@@ -184,7 +184,7 @@ int BuildingClass::Validate(void) const
   *=============================================================================================*/
 bool BuildingClass::Can_Have_Rally_Point() const
 {
-    if (!this->IsOwnedByPlayer || !Class->IsFactory || Class->ToBuild == FACTORY_TYPE_BUILDING) {
+    if (!Is_Owned_By_Player() || !Class->IsFactory || Class->ToBuild == FACTORY_TYPE_BUILDING) {
        return false;
     }
 
@@ -1339,22 +1339,19 @@ void BuildingClass::AI(void)
     }
 
     // rally point logic
-    if (Can_Have_Rally_Point() && Is_Owned_By_Player() && RallyPoint) {
-        if (
-            !Is_Selected_By_Player()
-            || !Target_Legal(RallyPoint)
-            || (!Map.In_View(Coord_Cell(Center_Coord())) && !Map.In_View(Coord_Cell(As_Coord(RallyPoint))))
-        ) {
-            if (Map.VisibleRallyPointSource != nullptr) {
-                //Map.Refresh_RallyLine(); would make the below 'false'
-                Map.Flag_To_Redraw(true);
-            }
+    if (!Can_Have_Rally_Point() || !Target_Legal(RallyPoint)) {
+        return;
+    }
 
-            Map.VisibleRallyPointSource = nullptr;
-            return;
-        }
-
+    if (Is_Selected_By_Player()) {
+        // GScreenClass::Render will use this reference to draw any visible portion of the rally line to screen
         Map.VisibleRallyPointSource = this;
+    } else if (Map.VisibleRallyPointSource == this) {
+        // we are about to remove the rally point source, so ensure Map render routine clears any visible portion of
+        // the rally line from the screen
+        Map.Flag_To_Redraw(true);
+
+        Map.VisibleRallyPointSource = nullptr;
     }
 }
 

--- a/tiberiandawn/building.cpp
+++ b/tiberiandawn/building.cpp
@@ -730,24 +730,6 @@ void BuildingClass::Draw_It(int x, int y, WindowNumberType window)
         }
     }
 
-    if (Can_Have_Rally_Point()
-        && Is_Selected_By_Player()
-        && Is_Owned_By_Player()
-        && RallyPoint
-        && Target_Legal(RallyPoint)) {
-        int startX, startY, endX, endY;
-
-        Map.Coord_To_Pixel(Center_Coord(), startX, startY);
-        Map.Coord_To_Pixel(As_Coord(RallyPoint), endX, endY);
-
-        Map.RallyPointLine = { XY_Coord(startX, startY), XY_Coord(endX, endY) };
-    } else if (Can_Have_Rally_Point()
-        && !Is_Selected_By_Player()
-        && Is_Owned_By_Player()
-        && RallyPoint) {
-        Map.RallyPointLine.reset();
-    }
-
     TechnoClass::Draw_It(x, y, window);
 }
 
@@ -1353,6 +1335,49 @@ void BuildingClass::AI(void)
                     Mark(MARK_CHANGE);
                 }
             }
+        }
+    }
+
+    // BUG: Draws over the sidebar slightly (stops after power bar)
+    if (Can_Have_Rally_Point()
+        && Is_Owned_By_Player()
+        && RallyPoint) {
+        if (!Is_Selected_By_Player()
+            || !Target_Legal(RallyPoint)
+            || !Map.In_View(Coord_Cell(Center_Coord()))
+            || !Map.In_View(Coord_Cell(As_Coord(RallyPoint)))
+            //|| (Map.IsSidebarActive && Coord_X(Center_Coord()) >= Map.SideX)
+            //|| (Map.IsSidebarActive && Coord_X(As_Coord(RallyPoint)) >= Map.SideX)
+            ) {
+            if (Map.RallyPointLine.has_value()) {
+                //Map.Refresh_RallyLine(); would make the below 'false'
+                Map.Flag_To_Redraw(true);
+            }
+
+            Map.RallyPointLine.reset();
+            return;
+        }
+
+        int startX, startY, endX, endY;
+
+        Map.Coord_To_Pixel(Center_Coord(), startX, startY);
+        Map.Coord_To_Pixel(As_Coord(RallyPoint), endX, endY);
+
+        int rallyPointStart = XY_Coord(startX, startY);
+        int rallyPointEnd = XY_Coord(endX, endY);
+
+        if (Map.RallyPointLine.has_value()) {
+            if (Map.RallyPointLine->first != rallyPointStart || Map.RallyPointLine->second != rallyPointEnd) {
+                //Map.Refresh_RallyLine(); would make the below 'false'
+                Map.Flag_To_Redraw(true);
+            } else {
+                Map.Flag_To_Redraw(false);
+            }
+
+            Map.RallyPointLine = { rallyPointStart, rallyPointEnd };
+        } else {
+            Map.RallyPointLine = { rallyPointStart, rallyPointEnd };
+            Map.Flag_To_Redraw(false);
         }
     }
 }

--- a/tiberiandawn/building.cpp
+++ b/tiberiandawn/building.cpp
@@ -1345,39 +1345,16 @@ void BuildingClass::AI(void)
             || !Target_Legal(RallyPoint)
             || (!Map.In_View(Coord_Cell(Center_Coord())) && !Map.In_View(Coord_Cell(As_Coord(RallyPoint))))
         ) {
-            if (Map.RallyPointLine.has_value()) {
+            if (Map.VisibleRallyPointSource != nullptr) {
                 //Map.Refresh_RallyLine(); would make the below 'false'
                 Map.Flag_To_Redraw(true);
             }
 
-            Map.RallyPointLine.reset();
+            Map.VisibleRallyPointSource = nullptr;
             return;
         }
 
-        int startX, startY, endX, endY;
-
-        Map.Coord_To_Pixel(Center_Coord(), startX, startY);
-        Map.Coord_To_Pixel(As_Coord(RallyPoint), endX, endY);
-
-        auto rallyPointStart = XY_Coord(startX, startY);
-        auto rallyPointEnd = XY_Coord(endX, endY);
-
-        if (Map.RallyPointLine.has_value()) {
-            if (Map.RallyPointLine->first != rallyPointStart || Map.RallyPointLine->second != rallyPointEnd) {
-                //Map.Refresh_RallyLine(); would make the below 'false'
-
-                // rally point already rendered and location has changed, map needs full redraw
-                Map.Flag_To_Redraw(true);
-            } else {
-                // rally point already rendered but location has not changed, no full redraw
-                Map.Flag_To_Redraw(false);
-            }
-        } else {
-            // rally point not currently rendered, no full redraw
-            Map.Flag_To_Redraw(false);
-        }
-
-        Map.RallyPointLine = { rallyPointStart, rallyPointEnd };
+        Map.VisibleRallyPointSource = this;
     }
 }
 

--- a/tiberiandawn/building.cpp
+++ b/tiberiandawn/building.cpp
@@ -184,15 +184,11 @@ int BuildingClass::Validate(void) const
   *=============================================================================================*/
 bool BuildingClass::Can_Have_Rally_Point() const
 {
-    if (!this->IsOwnedByPlayer) {
+    if (!this->IsOwnedByPlayer || !Class->IsFactory || Class->ToBuild == FACTORY_TYPE_BUILDING) {
        return false;
     }
 
-    auto rally_points_enabled = Rule.Get_Rule_Value<bool>(ENHANCEMENTS_SECTION, RALLY_POINTS_RULE);
-
-    return rally_points_enabled
-        && Class->IsFactory
-        && Class->ToBuild != FACTORY_TYPE_BUILDING; // rallying makes no sense for buildings
+    return Rule.Get_Rule_Value<bool>(ENHANCEMENTS_SECTION, RALLY_POINTS_RULE);
 }
 
 void BuildingClass::Set_Unselected_By_Player(HouseClass* player)
@@ -734,19 +730,22 @@ void BuildingClass::Draw_It(int x, int y, WindowNumberType window)
         }
     }
 
-    if (Can_Have_Rally_Point() 
+    if (Can_Have_Rally_Point()
         && Is_Selected_By_Player()
         && Is_Owned_By_Player()
         && RallyPoint
-        && Target_Legal(RallyPoint))
-    {
+        && Target_Legal(RallyPoint)) {
         int startX, startY, endX, endY;
 
         Map.Coord_To_Pixel(Center_Coord(), startX, startY);
         Map.Coord_To_Pixel(As_Coord(RallyPoint), endX, endY);
 
-        // BUG: Line flickers if it intercepts certain objects
-        CC_Draw_Line(startX, startY, endX, endY, LTGREEN, 1, window);
+        Map.RallyPointLine = { XY_Coord(startX, startY), XY_Coord(endX, endY) };
+    } else if (Can_Have_Rally_Point()
+        && !Is_Selected_By_Player()
+        && Is_Owned_By_Player()
+        && RallyPoint) {
+        Map.RallyPointLine.reset();
     }
 
     TechnoClass::Draw_It(x, y, window);

--- a/tiberiandawn/building.cpp
+++ b/tiberiandawn/building.cpp
@@ -1338,17 +1338,13 @@ void BuildingClass::AI(void)
         }
     }
 
-    // BUG: Draws over the sidebar slightly (stops after power bar)
-    if (Can_Have_Rally_Point()
-        && Is_Owned_By_Player()
-        && RallyPoint) {
-        if (!Is_Selected_By_Player()
+    // rally point logic
+    if (Can_Have_Rally_Point() && Is_Owned_By_Player() && RallyPoint) {
+        if (
+            !Is_Selected_By_Player()
             || !Target_Legal(RallyPoint)
-            || !Map.In_View(Coord_Cell(Center_Coord()))
-            || !Map.In_View(Coord_Cell(As_Coord(RallyPoint)))
-            //|| (Map.IsSidebarActive && Coord_X(Center_Coord()) >= Map.SideX)
-            //|| (Map.IsSidebarActive && Coord_X(As_Coord(RallyPoint)) >= Map.SideX)
-            ) {
+            || (!Map.In_View(Coord_Cell(Center_Coord())) && !Map.In_View(Coord_Cell(As_Coord(RallyPoint))))
+        ) {
             if (Map.RallyPointLine.has_value()) {
                 //Map.Refresh_RallyLine(); would make the below 'false'
                 Map.Flag_To_Redraw(true);
@@ -1363,22 +1359,25 @@ void BuildingClass::AI(void)
         Map.Coord_To_Pixel(Center_Coord(), startX, startY);
         Map.Coord_To_Pixel(As_Coord(RallyPoint), endX, endY);
 
-        int rallyPointStart = XY_Coord(startX, startY);
-        int rallyPointEnd = XY_Coord(endX, endY);
+        auto rallyPointStart = XY_Coord(startX, startY);
+        auto rallyPointEnd = XY_Coord(endX, endY);
 
         if (Map.RallyPointLine.has_value()) {
             if (Map.RallyPointLine->first != rallyPointStart || Map.RallyPointLine->second != rallyPointEnd) {
                 //Map.Refresh_RallyLine(); would make the below 'false'
+
+                // rally point already rendered and location has changed, map needs full redraw
                 Map.Flag_To_Redraw(true);
             } else {
+                // rally point already rendered but location has not changed, no full redraw
                 Map.Flag_To_Redraw(false);
             }
-
-            Map.RallyPointLine = { rallyPointStart, rallyPointEnd };
         } else {
-            Map.RallyPointLine = { rallyPointStart, rallyPointEnd };
+            // rally point not currently rendered, no full redraw
             Map.Flag_To_Redraw(false);
         }
+
+        Map.RallyPointLine = { rallyPointStart, rallyPointEnd };
     }
 }
 
@@ -2304,6 +2303,7 @@ void BuildingClass::Assign_Target(TARGET target)
 
     if (Can_Have_Rally_Point() && Target_Legal(target)) {
         RallyPoint = target;
+
         return;
     }
 

--- a/tiberiandawn/building.cpp
+++ b/tiberiandawn/building.cpp
@@ -2277,7 +2277,6 @@ void BuildingClass::Assign_Target(TARGET target)
 
     if (Can_Have_Rally_Point() && Target_Legal(target)) {
         RallyPoint = target;
-
         return;
     }
 

--- a/tiberiandawn/event.cpp
+++ b/tiberiandawn/event.cpp
@@ -785,10 +785,8 @@ void EventClass::Execute(void)
     case SET_RALLY:
         if (const auto building = As_Building(Data.NavCom.Whom))
         {
-            if (building->RallyPoint != Data.NavCom.Where)
-            {
+            if (building->Can_Have_Rally_Point() && Target_Legal(Data.NavCom.Where)) {
                 building->RallyPoint = Data.NavCom.Where;
-                Map.Flag_To_Redraw(true);
             }
         }
         break;

--- a/tiberiandawn/gscreen.cpp
+++ b/tiberiandawn/gscreen.cpp
@@ -372,7 +372,43 @@ void GScreenClass::Render(void)
         if (Map.RallyPointLine.has_value() && LogicPage->Lock()) {
             const auto& [ startCoord, endCoord ] = Map.RallyPointLine.value();
 
-            LogicPage->Draw_Line(Coord_X(startCoord), Coord_Y(startCoord), Coord_X(endCoord), Coord_Y(endCoord), LTGREEN);
+            int pixels[4] { Coord_X(startCoord), Coord_Y(startCoord), Coord_X(endCoord), Coord_Y(endCoord) };
+            auto [ start_x, start_y, end_x, end_y ] = pixels;
+
+            CNC_LOG_WARN("Before: {},{} -> {},{}", start_x, start_y, end_x, end_y);
+
+            if (start_x > 32500) {
+                start_x = 0;
+            }
+            if (end_x > 32500) {
+                end_x = 0;
+            }
+
+            if (start_y > 20000) {
+                start_y = 0;
+            }
+            if (end_y > 20000) {
+                end_y = 0;
+            }
+
+            if (Map.IsSidebarActive && start_x >= Map.SideX) {
+                start_x = Map.SideX - 1;
+            }
+            if (start_y <= Map.Get_Tab_Height()) {
+                start_y = Map.Get_Tab_Height() - 1;
+            }
+
+            // enure end point is in bounds of the map area
+            if (Map.IsSidebarActive && end_x >= Map.SideX) {
+                end_x = Map.SideX - 1;
+            }
+            if (end_y <= Map.Get_Tab_Height()) {
+                end_y = Map.Get_Tab_Height() - 1;
+            }
+            CNC_LOG_WARN("After: {},{} -> {},{}", start_x, start_y, end_x, end_y);
+
+            LogicPage->Draw_Line(start_x, start_y, end_x, end_y, LTGREEN);
+
             LogicPage->Unlock();
         }
 

--- a/tiberiandawn/gscreen.cpp
+++ b/tiberiandawn/gscreen.cpp
@@ -45,6 +45,9 @@
  * - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - */
 
 #include "function.h"
+#include <cmath>
+#include <algorithm>
+
 
 #include "common/filepcx.h"
 
@@ -384,27 +387,43 @@ void GScreenClass::Render(void)
             if (start_ok || end_ok) {
                 CNC_LOG_WARN("XY: {},{} -> {},{}", start_x, start_y, end_x, end_y);
 
+                // one of the rally lines points is out of view
                 if (start_ok && !end_ok) {
-                    // draw from start to edge of screen
+                    double dx = (double)end_x - start_x;
+                    double dy = (double)end_y - start_y;
+                    double mag = std::sqrt(dx * dx + dy * dy);
+                    if (mag > 0) {
+                        dx /= mag; dy /= mag;
+                        double limitW = Map.IsSidebarActive ? Map.SideX : SeenBuff.Get_Width();
+                        double limitH = SeenBuff.Get_Height();
+                        double limitYMin = Map.Get_Tab_Height();
+                        double tx = (dx > 0) ? (limitW - start_pixel_x) / dx : (dx < 0) ? (0 - start_pixel_x) / dx : 1e18;
+                        double ty = (dy > 0) ? (limitH - start_pixel_y) / dy : (dy < 0) ? (limitYMin - start_pixel_y) / dy : 1e18;
+                        double t = std::min(tx, ty);
+                        end_pixel_x = (int)(start_pixel_x + t * dx);
+                        end_pixel_y = (int)(start_pixel_y + t * dy);
+
+                        // BUG: spills over sidebar and tabs
+                    }
                 } else if (end_ok && !start_ok) {
-                    // draw from end to edge of screen
+                    double dx = (double)start_x - end_x;
+                    double dy = (double)start_y - end_y;
+                    double mag = std::sqrt(dx * dx + dy * dy);
+                    if (mag > 0) {
+                        dx /= mag; dy /= mag;
+                        double limitW = Map.IsSidebarActive ? Map.SideX : SeenBuff.Get_Width();
+                        double limitH = SeenBuff.Get_Height();
+                        double limitYMin = Map.Get_Tab_Height();
+                        double tx = (dx > 0) ? (limitW - end_pixel_x) / dx : (dx < 0) ? (0 - end_pixel_x) / dx : 1e18;
+                        double ty = (dy > 0) ? (limitH - end_pixel_y) / dy : (dy < 0) ? (limitYMin - end_pixel_y) / dy : 1e18;
+                        double t = std::min(tx, ty);
+                        start_pixel_x = (int)(end_pixel_x + t * dx);
+                        start_pixel_y = (int)(end_pixel_y + t * dy);
+
+                        // BUG: spills over sidebar and tabs
+                    }
                 }
 
-                if (Map.IsSidebarActive && start_pixel_x >= Map.SideX) {
-                    start_pixel_x = Map.SideX - 1;
-                }
-
-                if (Map.IsSidebarActive && end_pixel_x >= Map.SideX) {
-                    end_pixel_x = Map.SideX - 1;
-                }
-
-                if (start_pixel_y <= Map.Get_Tab_Height()) {
-                    start_pixel_y = Map.Get_Tab_Height() - 1;
-                }
-
-                if (end_pixel_y <= Map.Get_Tab_Height()) {
-                    end_pixel_y = Map.Get_Tab_Height() - 1;
-                }
 
                 LogicPage->Draw_Line(start_pixel_x, start_pixel_y, end_pixel_x, end_pixel_y, LTGREEN);
                 CNC_LOG_WARN("Render: {},{} -> {},{}", start_pixel_x, start_pixel_y, end_pixel_x, end_pixel_y);

--- a/tiberiandawn/gscreen.cpp
+++ b/tiberiandawn/gscreen.cpp
@@ -44,10 +44,9 @@
  *   GScreenClass::Remove_A_Button -- Removes a gadget from the game input system.             *
  * - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - */
 
-#include "function.h"
 #include <cmath>
-#include <algorithm>
 
+#include "function.h"
 
 #include "common/filepcx.h"
 

--- a/tiberiandawn/gscreen.cpp
+++ b/tiberiandawn/gscreen.cpp
@@ -72,6 +72,7 @@ GScreenClass::GScreenClass(void)
 {
     IsToUpdate = true;
     IsToRedraw = true;
+    VisibleRallyPointSource = nullptr;
 }
 
 /***********************************************************************************************
@@ -156,6 +157,7 @@ void GScreenClass::Init_Clear(void)
     */
     HiddenPage.Clear();
     IsToRedraw = true;
+    VisibleRallyPointSource = nullptr;
 }
 
 /***********************************************************************************************
@@ -366,7 +368,8 @@ void GScreenClass::Render(void)
     //	IsToRedraw = true;
     //}
 
-    if (Map.VisibleRallyPointSource != nullptr) {
+    if (Rally_Point_Visible()) {
+        // TODO: inefficient, would be better to replicate the rubber band logic to refresh only the cells below rally point line
         Map.Flag_To_Redraw(true);
     }
 
@@ -376,60 +379,8 @@ void GScreenClass::Render(void)
         GraphicViewPortClass* oldpage = Set_Logic_Page(HidPage);
         Draw_It(IsToRedraw);
 
-        if (Map.VisibleRallyPointSource != nullptr) {
-            int coords[4] { Coord_X(VisibleRallyPointSource->Center_Coord()), Coord_Y(VisibleRallyPointSource->Center_Coord()), Coord_X(As_Coord(VisibleRallyPointSource->RallyPoint)), Coord_Y(As_Coord(VisibleRallyPointSource->RallyPoint))};
-            const auto& [ start_x, start_y, end_x, end_y ] = coords;
-
-            int start_pixel_x, start_pixel_y, end_pixel_x, end_pixel_y;
-            const auto start_ok = Map.Coord_To_Pixel(VisibleRallyPointSource->Center_Coord(), start_pixel_x, start_pixel_y);
-            const auto end_ok = Map.Coord_To_Pixel(As_Coord(VisibleRallyPointSource->RallyPoint), end_pixel_x, end_pixel_y);
-
-            if (start_ok || end_ok) {
-                // one of the rally lines points is out of view
-                if (start_ok && !end_ok) {
-                    // calculate the line from start point to the edge of the screen, in the direction of the end point
-                    auto dx = static_cast<double>(end_x) - start_x;
-                    auto dy = static_cast<double>(end_y) - start_y;
-                    auto mag = std::sqrt(dx * dx + dy * dy);
-                    if (mag > 0) {
-                        dx /= mag; dy /= mag;
-                        double limitW = Map.IsSidebarActive ? Map.SideX - 1 : SeenBuff.Get_Width() - 1;
-                        double limitH = SeenBuff.Get_Height() - 1;
-                        double limitYMin = Map.Get_Tab_Height();
-                        double tx = (dx > 0) ? (limitW - start_pixel_x) / dx : (dx < 0) ? (0 - start_pixel_x) / dx : 1e18;
-                        double ty = (dy > 0) ? (limitH - start_pixel_y) / dy : (dy < 0) ? (limitYMin - start_pixel_y) / dy : 1e18;
-                        double t = std::min(tx, ty);
-                        end_pixel_x = (int)(start_pixel_x + t * dx);
-                        end_pixel_y = (int)(start_pixel_y + t * dy);
-                    }
-                } else if (end_ok && !start_ok) {
-                    // calculate the line from end point to the edge of the screen, in the direction of the start point
-                    double dx = (double)start_x - end_x;
-                    double dy = (double)start_y - end_y;
-                    double mag = std::sqrt(dx * dx + dy * dy);
-                    if (mag > 0) {
-                        dx /= mag; dy /= mag;
-                        double limitW = Map.IsSidebarActive ? Map.SideX - 1 : SeenBuff.Get_Width() - 1;
-                        double limitH = SeenBuff.Get_Height() - 1;
-                        double limitYMin = Map.Get_Tab_Height();
-                        double tx = (dx > 0) ? (limitW - end_pixel_x) / dx : (dx < 0) ? (0 - end_pixel_x) / dx : 1e18;
-                        double ty = (dy > 0) ? (limitH - end_pixel_y) / dy : (dy < 0) ? (limitYMin - end_pixel_y) / dy : 1e18;
-                        double t = std::min(tx, ty);
-                        start_pixel_x = (int)(end_pixel_x + t * dx);
-                        start_pixel_y = (int)(end_pixel_y + t * dy);
-                    }
-                }
-
-                // BUG: correctly prevents line drawing over tabs or sidebar but can cause pitch/angle of the line to be slightly off
-                if (Map.IsSidebarActive && start_pixel_x >= Map.SideX) start_pixel_x = Map.SideX - 1;
-                if (Map.IsSidebarActive && end_pixel_x >= Map.SideX) end_pixel_x = Map.SideX - 1;
-                if (start_pixel_y < Map.Get_Tab_Height()) start_pixel_y = Map.Get_Tab_Height();
-                if (end_pixel_y < Map.Get_Tab_Height()) end_pixel_y = Map.Get_Tab_Height();
-
-                LogicPage->Draw_Line(start_pixel_x, start_pixel_y, end_pixel_x, end_pixel_y, LTGREEN);
-            }
-
-            LogicPage->Unlock();
+        if (Rally_Point_Visible()) {
+            Render_Rally_Point_Line();
         }
 
         if (Buttons)
@@ -544,14 +495,145 @@ void GScreenClass::Blit_Display(void)
 #endif //(0)
 }
 
+bool GScreenClass::Rally_Point_Visible() const
+{
+    return Map.VisibleRallyPointSource != nullptr
+        && Map.VisibleRallyPointSource->Can_Have_Rally_Point()
+        && Target_Legal(Map.VisibleRallyPointSource->RallyPoint);
+}
+
+/**
+ * Given a path between two co-ords (where the end point is a co-ord that is not currently
+ * visible to the player) determine the last visible pixel of the path (at the screen edge).
+ *
+ * Used to partially draw a line which is cut off by the edge of these screen.
+ */
+static bool Get_Screen_Edge_Pixel_For_Path(
+    const int& path_start_coord_x,
+    const int& path_start_coord_y,
+    const int& path_end_coord_x,
+    const int& path_end_coord_y,
+    const int& path_start_pixel_x,
+    const int& path_start_pixel_y,
+    int& path_end_pixel_x,
+    int& path_end_pixel_y
+)
+{
+    // calculate the line from lhs point to the edge of the screen, in the direction of the rhs point
+    auto dirX = static_cast<double>(path_end_coord_x) - path_start_coord_x;
+    auto dirY = static_cast<double>(path_end_coord_y) - path_start_coord_y;
+
+    const auto length = std::sqrt(dirX * dirX + dirY * dirY);
+
+    if (length < 1) {
+        return false;
+    }
+
+    dirX /= length;
+    dirY /= length;
+
+    const auto rightEdge = static_cast<double>(Map.IsSidebarActive ? Map.SideX - 1 : SeenBuff.Get_Width() - 1);
+    const auto bottomEdge = static_cast<double>(SeenBuff.Get_Height()) - 1;
+    const auto topEdge = static_cast<double>(Map.Get_Tab_Height());
+
+    // Calculate the distance to the closest screen edge to clip the line
+    const auto tToXEdge = (dirX > 0)
+        ? (rightEdge - path_start_pixel_x) / dirX
+        : (dirX < 0) ? (0 - path_start_pixel_x) / dirX : 1e18;
+    const auto tToYEdge = (dirY > 0)
+        ? (bottomEdge - path_start_pixel_y) / dirY
+        : (dirY < 0) ? (topEdge - path_start_pixel_y) / dirY : 1e18;
+
+    const auto tToEdge = std::min(tToXEdge, tToYEdge);
+
+    path_end_pixel_x = static_cast<int>(path_start_pixel_x + tToEdge * dirX);
+    path_end_pixel_y = static_cast<int>(path_start_pixel_y + tToEdge * dirY);
+
+    return true;
+}
+
+void GScreenClass::Render_Rally_Point_Line() const
+{
+    if (!LogicPage->Lock()) {
+        return;
+    }
+
+    // unpack rally start and end point co-ords
+    int coords[4] {
+        Coord_X(VisibleRallyPointSource->Center_Coord()),
+        Coord_Y(VisibleRallyPointSource->Center_Coord()),
+        Coord_X(As_Coord(VisibleRallyPointSource->RallyPoint)),
+        Coord_Y(As_Coord(VisibleRallyPointSource->RallyPoint))
+    };
+    const auto& [ start_x, start_y, end_x, end_y ] = coords;
+
+    // attempt to convert co-ords to pixel values
+    int start_pixel_x, start_pixel_y, end_pixel_x, end_pixel_y;
+    const auto start_ok = Map.Coord_To_Pixel(VisibleRallyPointSource->Center_Coord(), start_pixel_x, start_pixel_y);
+    const auto end_ok = Map.Coord_To_Pixel(As_Coord(VisibleRallyPointSource->RallyPoint), end_pixel_x, end_pixel_y);
+
+    if (!start_ok && ! end_ok) {
+        // neither rally point is in a viewable section of the map, abort
+        LogicPage->Unlock();
+        return;
+    }
+
+    // one of the rally lines points is out of view
+    if (start_ok && !end_ok) {
+        // calculate the last visible pixel of the line from start point to the end point
+        Get_Screen_Edge_Pixel_For_Path(
+            start_x,
+            start_y,
+            end_x,
+            end_y,
+            start_pixel_x,
+            start_pixel_y,
+            end_pixel_x,
+            end_pixel_y
+        );
+    } else if (end_ok && !start_ok) {
+        // calculate the last visible pixel of the line from end point to the start point
+        Get_Screen_Edge_Pixel_For_Path(
+            end_x,
+            end_y,
+            start_x,
+            start_y,
+            end_pixel_x,
+            end_pixel_y,
+            start_pixel_x,
+            start_pixel_y
+        );
+    }
+
+    // BUG: checks prevent line drawing over sidebar or tabs but can cause pitch/angle of the line to be slightly off
+    if (Map.IsSidebarActive && start_pixel_x >= Map.SideX) {
+        start_pixel_x = Map.SideX - 1;
+    }
+    if (start_pixel_y < Map.Get_Tab_Height()) {
+        start_pixel_y = Map.Get_Tab_Height() + 1;
+    }
+
+    if (Map.IsSidebarActive && end_pixel_x >= Map.SideX) {
+        end_pixel_x = Map.SideX - 1;
+    }
+    if (end_pixel_y < Map.Get_Tab_Height()) {
+        end_pixel_y = Map.Get_Tab_Height() + 1;
+    }
+
+    LogicPage->Draw_Line(start_pixel_x, start_pixel_y, end_pixel_x, end_pixel_y, LTGREEN);
+    LogicPage->Unlock();
+}
+
 TO_JSON(GScreenClass)
 {
     BITFIELD_TO_JSON(IsToRedraw);
     BITFIELD_TO_JSON(IsToUpdate);
+    OBJECT_TARGET_PTR_TO_JSON(VisibleRallyPointSource);
 }
 
 FROM_JSON(GScreenClass)
 {
     BITFIELD_FROM_JSON(IsToRedraw);
     BITFIELD_FROM_JSON(IsToUpdate);
+    TARGET_CONST_PTR_FROM_JSON_WITH_TYPE(VisibleRallyPointSource, BuildingClass);
 }

--- a/tiberiandawn/gscreen.cpp
+++ b/tiberiandawn/gscreen.cpp
@@ -385,13 +385,12 @@ void GScreenClass::Render(void)
             const auto end_ok = Map.Coord_To_Pixel(As_Coord(VisibleRallyPointSource->RallyPoint), end_pixel_x, end_pixel_y);
 
             if (start_ok || end_ok) {
-                CNC_LOG_WARN("XY: {},{} -> {},{}", start_x, start_y, end_x, end_y);
-
                 // one of the rally lines points is out of view
                 if (start_ok && !end_ok) {
-                    double dx = (double)end_x - start_x;
-                    double dy = (double)end_y - start_y;
-                    double mag = std::sqrt(dx * dx + dy * dy);
+                    // calculate the line from start point to the edge of the screen, in the direction of the end point
+                    auto dx = static_cast<double>(end_x) - start_x;
+                    auto dy = static_cast<double>(end_y) - start_y;
+                    auto mag = std::sqrt(dx * dx + dy * dy);
                     if (mag > 0) {
                         dx /= mag; dy /= mag;
                         double limitW = Map.IsSidebarActive ? Map.SideX - 1 : SeenBuff.Get_Width() - 1;
@@ -404,6 +403,7 @@ void GScreenClass::Render(void)
                         end_pixel_y = (int)(start_pixel_y + t * dy);
                     }
                 } else if (end_ok && !start_ok) {
+                    // calculate the line from end point to the edge of the screen, in the direction of the start point
                     double dx = (double)start_x - end_x;
                     double dy = (double)start_y - end_y;
                     double mag = std::sqrt(dx * dx + dy * dy);
@@ -420,13 +420,13 @@ void GScreenClass::Render(void)
                     }
                 }
 
+                // BUG: correctly prevents line drawing over tabs or sidebar but can cause pitch/angle of the line to be slightly off
                 if (Map.IsSidebarActive && start_pixel_x >= Map.SideX) start_pixel_x = Map.SideX - 1;
                 if (Map.IsSidebarActive && end_pixel_x >= Map.SideX) end_pixel_x = Map.SideX - 1;
                 if (start_pixel_y < Map.Get_Tab_Height()) start_pixel_y = Map.Get_Tab_Height();
                 if (end_pixel_y < Map.Get_Tab_Height()) end_pixel_y = Map.Get_Tab_Height();
 
                 LogicPage->Draw_Line(start_pixel_x, start_pixel_y, end_pixel_x, end_pixel_y, LTGREEN);
-                CNC_LOG_WARN("Render: {},{} -> {},{}", start_pixel_x, start_pixel_y, end_pixel_x, end_pixel_y);
             }
 
             LogicPage->Unlock();

--- a/tiberiandawn/gscreen.cpp
+++ b/tiberiandawn/gscreen.cpp
@@ -363,51 +363,52 @@ void GScreenClass::Render(void)
     //	IsToRedraw = true;
     //}
 
+    if (Map.VisibleRallyPointSource != nullptr) {
+        Map.Flag_To_Redraw(true);
+    }
+
     if (IsToUpdate || IsToRedraw) {
 
         // WWMouse->Erase_Mouse(&HidPage, TRUE);
         GraphicViewPortClass* oldpage = Set_Logic_Page(HidPage);
         Draw_It(IsToRedraw);
 
-        if (Map.RallyPointLine.has_value() && LogicPage->Lock()) {
-            const auto& [ startCoord, endCoord ] = Map.RallyPointLine.value();
+        if (Map.VisibleRallyPointSource != nullptr) {
+            int coords[4] { Coord_X(VisibleRallyPointSource->Center_Coord()), Coord_Y(VisibleRallyPointSource->Center_Coord()), Coord_X(As_Coord(VisibleRallyPointSource->RallyPoint)), Coord_Y(As_Coord(VisibleRallyPointSource->RallyPoint))};
+            const auto& [ start_x, start_y, end_x, end_y ] = coords;
 
-            int pixels[4] { Coord_X(startCoord), Coord_Y(startCoord), Coord_X(endCoord), Coord_Y(endCoord) };
-            auto [ start_x, start_y, end_x, end_y ] = pixels;
+            int start_pixel_x, start_pixel_y, end_pixel_x, end_pixel_y;
+            const auto start_ok = Map.Coord_To_Pixel(VisibleRallyPointSource->Center_Coord(), start_pixel_x, start_pixel_y);
+            const auto end_ok = Map.Coord_To_Pixel(As_Coord(VisibleRallyPointSource->RallyPoint), end_pixel_x, end_pixel_y);
 
-            CNC_LOG_WARN("Before: {},{} -> {},{}", start_x, start_y, end_x, end_y);
+            if (start_ok || end_ok) {
+                CNC_LOG_WARN("XY: {},{} -> {},{}", start_x, start_y, end_x, end_y);
 
-            if (start_x > 32500) {
-                start_x = 0;
-            }
-            if (end_x > 32500) {
-                end_x = 0;
-            }
+                if (start_ok && !end_ok) {
+                    // draw from start to edge of screen
+                } else if (end_ok && !start_ok) {
+                    // draw from end to edge of screen
+                }
 
-            if (start_y > 20000) {
-                start_y = 0;
-            }
-            if (end_y > 20000) {
-                end_y = 0;
-            }
+                if (Map.IsSidebarActive && start_pixel_x >= Map.SideX) {
+                    start_pixel_x = Map.SideX - 1;
+                }
 
-            if (Map.IsSidebarActive && start_x >= Map.SideX) {
-                start_x = Map.SideX - 1;
-            }
-            if (start_y <= Map.Get_Tab_Height()) {
-                start_y = Map.Get_Tab_Height() - 1;
-            }
+                if (Map.IsSidebarActive && end_pixel_x >= Map.SideX) {
+                    end_pixel_x = Map.SideX - 1;
+                }
 
-            // enure end point is in bounds of the map area
-            if (Map.IsSidebarActive && end_x >= Map.SideX) {
-                end_x = Map.SideX - 1;
-            }
-            if (end_y <= Map.Get_Tab_Height()) {
-                end_y = Map.Get_Tab_Height() - 1;
-            }
-            CNC_LOG_WARN("After: {},{} -> {},{}", start_x, start_y, end_x, end_y);
+                if (start_pixel_y <= Map.Get_Tab_Height()) {
+                    start_pixel_y = Map.Get_Tab_Height() - 1;
+                }
 
-            LogicPage->Draw_Line(start_x, start_y, end_x, end_y, LTGREEN);
+                if (end_pixel_y <= Map.Get_Tab_Height()) {
+                    end_pixel_y = Map.Get_Tab_Height() - 1;
+                }
+
+                LogicPage->Draw_Line(start_pixel_x, start_pixel_y, end_pixel_x, end_pixel_y, LTGREEN);
+                CNC_LOG_WARN("Render: {},{} -> {},{}", start_pixel_x, start_pixel_y, end_pixel_x, end_pixel_y);
+            }
 
             LogicPage->Unlock();
         }

--- a/tiberiandawn/gscreen.cpp
+++ b/tiberiandawn/gscreen.cpp
@@ -394,16 +394,14 @@ void GScreenClass::Render(void)
                     double mag = std::sqrt(dx * dx + dy * dy);
                     if (mag > 0) {
                         dx /= mag; dy /= mag;
-                        double limitW = Map.IsSidebarActive ? Map.SideX : SeenBuff.Get_Width();
-                        double limitH = SeenBuff.Get_Height();
+                        double limitW = Map.IsSidebarActive ? Map.SideX - 1 : SeenBuff.Get_Width() - 1;
+                        double limitH = SeenBuff.Get_Height() - 1;
                         double limitYMin = Map.Get_Tab_Height();
                         double tx = (dx > 0) ? (limitW - start_pixel_x) / dx : (dx < 0) ? (0 - start_pixel_x) / dx : 1e18;
                         double ty = (dy > 0) ? (limitH - start_pixel_y) / dy : (dy < 0) ? (limitYMin - start_pixel_y) / dy : 1e18;
                         double t = std::min(tx, ty);
                         end_pixel_x = (int)(start_pixel_x + t * dx);
                         end_pixel_y = (int)(start_pixel_y + t * dy);
-
-                        // BUG: spills over sidebar and tabs
                     }
                 } else if (end_ok && !start_ok) {
                     double dx = (double)start_x - end_x;
@@ -411,19 +409,21 @@ void GScreenClass::Render(void)
                     double mag = std::sqrt(dx * dx + dy * dy);
                     if (mag > 0) {
                         dx /= mag; dy /= mag;
-                        double limitW = Map.IsSidebarActive ? Map.SideX : SeenBuff.Get_Width();
-                        double limitH = SeenBuff.Get_Height();
+                        double limitW = Map.IsSidebarActive ? Map.SideX - 1 : SeenBuff.Get_Width() - 1;
+                        double limitH = SeenBuff.Get_Height() - 1;
                         double limitYMin = Map.Get_Tab_Height();
                         double tx = (dx > 0) ? (limitW - end_pixel_x) / dx : (dx < 0) ? (0 - end_pixel_x) / dx : 1e18;
                         double ty = (dy > 0) ? (limitH - end_pixel_y) / dy : (dy < 0) ? (limitYMin - end_pixel_y) / dy : 1e18;
                         double t = std::min(tx, ty);
                         start_pixel_x = (int)(end_pixel_x + t * dx);
                         start_pixel_y = (int)(end_pixel_y + t * dy);
-
-                        // BUG: spills over sidebar and tabs
                     }
                 }
 
+                if (Map.IsSidebarActive && start_pixel_x >= Map.SideX) start_pixel_x = Map.SideX - 1;
+                if (Map.IsSidebarActive && end_pixel_x >= Map.SideX) end_pixel_x = Map.SideX - 1;
+                if (start_pixel_y < Map.Get_Tab_Height()) start_pixel_y = Map.Get_Tab_Height();
+                if (end_pixel_y < Map.Get_Tab_Height()) end_pixel_y = Map.Get_Tab_Height();
 
                 LogicPage->Draw_Line(start_pixel_x, start_pixel_y, end_pixel_x, end_pixel_y, LTGREEN);
                 CNC_LOG_WARN("Render: {},{} -> {},{}", start_pixel_x, start_pixel_y, end_pixel_x, end_pixel_y);

--- a/tiberiandawn/gscreen.cpp
+++ b/tiberiandawn/gscreen.cpp
@@ -369,6 +369,13 @@ void GScreenClass::Render(void)
         GraphicViewPortClass* oldpage = Set_Logic_Page(HidPage);
         Draw_It(IsToRedraw);
 
+        if (Map.RallyPointLine.has_value() && LogicPage->Lock()) {
+            const auto& [ startCoord, endCoord ] = Map.RallyPointLine.value();
+
+            LogicPage->Draw_Line(Coord_X(startCoord), Coord_Y(startCoord), Coord_X(endCoord), Coord_Y(endCoord), LTGREEN);
+            LogicPage->Unlock();
+        }
+
         if (Buttons)
             Buttons->Draw_All(false);
 

--- a/tiberiandawn/gscreen.h
+++ b/tiberiandawn/gscreen.h
@@ -102,11 +102,14 @@ public:
     virtual void Code_Pointers(void);
     virtual void Decode_Pointers(void);
 
+    bool Rally_Point_Visible() const;
+
     /*
     ** When the building currently selected by the player has a rally point set, the line from the
-    ** structure to the rally point will be stored here for use in the
+    ** structure to the rally point should be rendered. This pointer is set by BuildingClass::AI so
+    ** ::Render can use it's center point and rally point target to draw a line between them.
     */
-    BuildingClass* VisibleRallyPointSource;
+    BuildingClass const* VisibleRallyPointSource;
 
     /*
     **	This points to the buttons that are used for input. All of the derived classes will
@@ -130,6 +133,8 @@ private:
     **	class can perform it's rendering.
     */
     unsigned IsToUpdate : 1;
+
+    void Render_Rally_Point_Line() const;
 
     JSON_FUNCTIONS(GScreenClass)
 private:

--- a/tiberiandawn/gscreen.h
+++ b/tiberiandawn/gscreen.h
@@ -106,7 +106,7 @@ public:
     ** When the building currently selected by the player has a rally point set, the line from the
     ** structure to the rally point will be stored here for use in the
     */
-    std::optional<std::pair<COORDINATE, COORDINATE>> RallyPointLine;
+    BuildingClass* VisibleRallyPointSource;
 
     /*
     **	This points to the buttons that are used for input. All of the derived classes will

--- a/tiberiandawn/gscreen.h
+++ b/tiberiandawn/gscreen.h
@@ -103,6 +103,12 @@ public:
     virtual void Decode_Pointers(void);
 
     /*
+    ** When the building currently selected by the player has a rally point set, the line from the
+    ** structure to the rally point will be stored here for use in the
+    */
+    std::optional<std::pair<COORDINATE, COORDINATE>> RallyPointLine;
+
+    /*
     **	This points to the buttons that are used for input. All of the derived classes will
     **	attached their specific buttons to this list.
     */

--- a/tiberiandawn/help.cpp
+++ b/tiberiandawn/help.cpp
@@ -263,7 +263,6 @@ void HelpClass::Draw_It(bool forced)
     TabClass::Draw_It(forced);
 
     if (Text != TXT_NONE && (forced || !CountDownTimer.Time())) {
-
         if (LogicPage->Lock()) {
             //		Fancy_Text_Print(Text, DrawX, DrawY, Color, BLACK, TPF_6POINT|TPF_NOSHADOW);
             Fancy_Text_Print(Text, DrawX, DrawY, Color, BLACK, TPF_MAP | TPF_NOSHADOW);

--- a/tiberiandawn/help.cpp
+++ b/tiberiandawn/help.cpp
@@ -265,7 +265,6 @@ void HelpClass::Draw_It(bool forced)
     if (Text != TXT_NONE && (forced || !CountDownTimer.Time())) {
 
         if (LogicPage->Lock()) {
-
             //		Fancy_Text_Print(Text, DrawX, DrawY, Color, BLACK, TPF_6POINT|TPF_NOSHADOW);
             Fancy_Text_Print(Text, DrawX, DrawY, Color, BLACK, TPF_MAP | TPF_NOSHADOW);
             LogicPage->Draw_Rect(DrawX - 1, DrawY - 1, DrawX + Width + 1, DrawY + FontHeight, Color);

--- a/tiberiandawn/iomap.cpp
+++ b/tiberiandawn/iomap.cpp
@@ -1062,4 +1062,8 @@ void GScreenClass::Code_Pointers(void)
  *=============================================================================================*/
 void GScreenClass::Decode_Pointers(void)
 {
+    if (VisibleRallyPointSource != NULL) {
+        static_cast<BuildingClass const*&>(VisibleRallyPointSource) = static_cast<BuildingClass*>(As_Object(TARGET_SAFE_CAST(VisibleRallyPointSource), false));
+        Check_Ptr((void*)VisibleRallyPointSource, __FILE__, __LINE__);
+    }
 }

--- a/tiberiandawn/iomap.cpp
+++ b/tiberiandawn/iomap.cpp
@@ -1062,7 +1062,7 @@ void GScreenClass::Code_Pointers(void)
  *=============================================================================================*/
 void GScreenClass::Decode_Pointers(void)
 {
-    if (VisibleRallyPointSource != NULL) {
+    if (VisibleRallyPointSource != nullptr) {
         static_cast<BuildingClass const*&>(VisibleRallyPointSource) = static_cast<BuildingClass*>(As_Object(TARGET_SAFE_CAST(VisibleRallyPointSource), false));
         Check_Ptr((void*)VisibleRallyPointSource, __FILE__, __LINE__);
     }


### PR DESCRIPTION
Overhaul the rendering of rally points:

- Move `BuildingClass` rally point logic to `::AI`
- Ensure lines are drawn over all game objects to prevent glitching using `GScreenClass::Render`
- Partially draw line if one end of the rally point is off the screen
- Update save/load to preserve currently visible rally point