### PR TITLE
fix(td): JSON save games not restoring color remap table reference on load

### DIFF
--- a/common/region.h
+++ b/common/region.h
@@ -79,6 +79,16 @@ public:
         Threat = 0;
     }
 
+    friend void to_json(nlohmann::json& j, const RegionClass& p)
+    {
+        FIELD_TO_JSON(Threat);
+    }
+
+    friend void from_json(const nlohmann::json& j, RegionClass& p)
+    {
+        FIELD_FROM_JSON(Threat);
+    }
+
 protected:
     int Threat;
 };

--- a/tiberiandawn/house.cpp
+++ b/tiberiandawn/house.cpp
@@ -8482,7 +8482,7 @@ TO_JSON(HouseClass)
     FIELD_TO_JSON(IQ);
     CONVERT_TD_FIELD_TO_JSON(Difficulty);
 #endif
-    FIELD_TO_JSON(Allies);
+    BITFIELD_OF_WIDTH_TO_JSON(Allies, HOUSE_COUNT);
     FIELD_TO_JSON(AlertTime);
     FIELD_TO_JSON(BorrowedTime);
     FIELD_TO_JSON(FreeHarvester);
@@ -8502,6 +8502,8 @@ TO_JSON(HouseClass)
 
     // Class field
     FIELD_VALUE_TO_JSON(Class, TdTypeConverter::To_String(p.Class == nullptr ? HOUSE_NONE : p.Class->House));
+
+    FIELD_TO_JSON(Regions);
 }
 
 FROM_JSON(HouseClass)
@@ -8638,7 +8640,7 @@ FROM_JSON(HouseClass)
     FIELD_FROM_JSON(IQ);
     PARSE_TD_FIELD_FROM_JSON(HouseClass, Difficulty, DiffType);
 #endif
-    FIELD_FROM_JSON(Allies);
+    BITFIELD_OF_WIDTH_FROM_JSON(HouseClass, Allies, HOUSE_COUNT);
     FIELD_FROM_JSON(AlertTime);
     FIELD_FROM_JSON(BorrowedTime);
     FIELD_FROM_JSON(FreeHarvester);
@@ -8655,6 +8657,7 @@ FROM_JSON(HouseClass)
     FIELD_FROM_JSON(NukeDest);
     FIELD_FROM_JSON(VisibleCredits);
     FIELD_FROM_JSON(DebugUnlockBuildables);
+    FIELD_FROM_JSON(Regions);
 
     // Class field
     const_cast<HouseTypeClass const*&>(p.Class) = reinterpret_cast<HouseTypeClass const*>(

--- a/tiberiandawn/ioobj.cpp
+++ b/tiberiandawn/ioobj.cpp
@@ -1340,6 +1340,16 @@ void HouseClass::Decode_Pointers(void)
     */
     ((HouseTypeClass const*&)Class) = &HouseTypeClass::As_Reference((HousesType) * ((intptr_t*)&Class));
     Check_Ptr((void*)Class, __FILE__, __LINE__);
+
+    if (RemapTable == nullptr) {
+        /*
+        ** We have loaded a house class into memory that is missing a remap table, so reset it to default.
+        ** This is normally important when a non-multiplayer class is present in a multiplayer scenario -
+        ** the multiplayer remap logic uses the HouseClass field instead of the reference to HouseTypeClass.
+        */
+        RemapTable = Class->RemapTable;
+    }
+    Check_Ptr((void*)RemapTable, __FILE__, __LINE__);
 }
 
 /***********************************************************************************************

--- a/tiberiandawn/saveload.cpp
+++ b/tiberiandawn/saveload.cpp
@@ -1165,7 +1165,7 @@ void Decode_All_Pointers(const HousesType& player_house)
     ** can change colors, this fix only makes sense on multiplayer houses
     ** - mrparrot 07/12/2021
     */
-    for (HousesType house = HOUSE_MULTI1; house <= HOUSE_MULTI6; house++) {
+    for (HousesType house = HOUSE_MULTI1; house <= HOUSE_MULTI6; ++house) {
         HouseClass* hptr = HouseClass::As_Pointer(house);
         if (hptr && hptr->IsActive) {
             hptr->Init_Data(hptr->RemapColor, hptr->ActLike, hptr->Credits);


### PR DESCRIPTION
This change ensures that JSON save games restore the remap table reference found in `HouseClass` instances when decoding pointers. Not doing this causes issues in Skirmish games which rely on this reference for all houses, but non-multiplayer houses don't get their reference explicitly restored during load (Neutral etc.).

Also, adding missing field serialization for `Regions` in `HouseClass` and fixing the serialization of the `Allies` bitfield.
