### PR TITLE
feat(td): Skirmish AI Player Config

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -92,7 +92,10 @@ jobs:
       run: |
         PRESET=""
 
-        if [ "${{ steps.changes.outputs.nco }}" = "true" ]; then
+        if [ "${{ github.event_name}}" != "pull_request" ] && [ "${{ github.ref }}" = "refs/heads/main" ]; then
+          echo "Main branch detected - building everything using cmake preset: release"
+          PRESET="release"
+        elif [ "${{ steps.changes.outputs.nco }}" = "true" ]; then
           echo "Changes to shared files detected - building everything using cmake preset: release"
           PRESET="release"
         elif [ "${{ steps.changes.outputs.ra }}" = "true" ] && [ "${{ steps.changes.outputs.td }}" = "true" ]; then

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -84,7 +84,10 @@ jobs:
       run: |
         PRESET=""
 
-        if [ "${{ steps.changes.outputs.nco }}" = "true" ]; then
+        if [ "${{ github.event_name}}" != "pull_request" ] && [ "${{ github.ref }}" = "refs/heads/main" ]; then
+          echo "Main branch detected - building everything using cmake preset: release"
+          PRESET="release"
+        elif [ "${{ steps.changes.outputs.nco }}" = "true" ]; then
           echo "Changes to shared files detected - building everything using cmake preset: release"
           PRESET="release"
         elif [ "${{ steps.changes.outputs.ra }}" = "true" ] && [ "${{ steps.changes.outputs.td }}" = "true" ]; then

--- a/.github/workflows/mingw.yml
+++ b/.github/workflows/mingw.yml
@@ -107,7 +107,10 @@ jobs:
       run: |
         PRESET=""
 
-        if [ "${{ steps.changes.outputs.nco }}" = "true" ]; then
+        if [ "${{ github.event_name}}" != "pull_request" ] && [ "${{ github.ref }}" = "refs/heads/main" ]; then
+          echo "Main branch detected - building everything using cmake preset: release"
+          PRESET="release"
+        elif [ "${{ steps.changes.outputs.nco }}" = "true" ]; then
           echo "Changes to shared files detected - building everything using cmake preset: release"
           PRESET="release"
         elif [ "${{ steps.changes.outputs.ra }}" = "true" ] && [ "${{ steps.changes.outputs.td }}" = "true" ]; then

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -79,7 +79,11 @@ jobs:
         PRESET=""
         REMASTER_PRESET=""
 
-        if [ "${{ steps.changes.outputs.nco }}" = "true" ]; then
+        if [ "${{ github.event_name}}" != "pull_request" ] && [ "${{ github.ref }}" = "refs/heads/main" ]; then
+          echo "Main branch detected - building everything using cmake preset: release"
+          PRESET="release"
+          REMASTER_PRESET="remaster"
+        elif [ "${{ steps.changes.outputs.nco }}" = "true" ]; then
           echo "Changes to shared files detected - building everything using cmake preset: release"
           PRESET="release"
           REMASTER_PRESET="remaster"

--- a/common/rulesections.cpp
+++ b/common/rulesections.cpp
@@ -381,6 +381,11 @@ std::optional<std::string> RuleSection::Try_Get_Rule_Comment(const std::string_v
     return std::nullopt;
 }
 
+RuleValueVariant RuleSection::operator[](const std::string_view name) const
+{
+    return Get_Variant(name);
+}
+
 TO_JSON(RuleSection)
 {
     for (const auto& [ name, value ] : p.Rules) {
@@ -469,6 +474,12 @@ RuleSection& RuleSections::Add_Section(std::string_view name)
             OnRulesChangedDefault.value()(s, r, v);
         }
     });
+}
+
+void RuleSections::Clear()
+{
+    Sections.clear();
+    OnRulesChangedDefault.reset();
 }
 
 RuleSection& RuleSections::operator[](std::string_view name)

--- a/common/rulesections.h
+++ b/common/rulesections.h
@@ -428,6 +428,8 @@ public:
     RuleSection& Set_Rule_Comment(std::string_view name, std::string comment);
     std::optional<std::string> Try_Get_Rule_Comment(std::string_view name) const;
 
+    RuleValueVariant operator[](std::string_view name) const;
+
     // TODO: Handle OnRulesChanged, if needed
     JSON_FUNCTIONS(RuleSection)
 private:
@@ -828,6 +830,8 @@ public:
     RuleSection& Add_Section(std::string_view name, std::function<void(RuleSection&, std::string_view, const RuleValueVariant&)> on_rules_changed);
 
     RuleSection& Add_Section(std::string_view name);
+
+    void Clear();
 
     RuleSection& operator[](std::string_view name);
 

--- a/tiberiandawn/CMakeLists.txt
+++ b/tiberiandawn/CMakeLists.txt
@@ -92,7 +92,6 @@ set(TIBDAWN_SRC
     mplayer.cpp
     msgbox.cpp
     msglist.cpp
-    nulldlg.cpp
     object.cpp
     odata.cpp
     options.cpp
@@ -156,6 +155,7 @@ set(TIBDAWN_SRC
     savegame_v1.cpp
     savegameheader.cpp
     savegameresolver.cpp
+    skirmishdlg.cpp
     technotypejsonreference.cpp
     tiberiandawnsettings.cpp
     typeconverter.cpp

--- a/tiberiandawn/aircraft.cpp
+++ b/tiberiandawn/aircraft.cpp
@@ -335,9 +335,9 @@ void AircraftClass::Draw_It(int x, int y, WindowNumberType window)
     int facing = Facing_To_32(SecondaryFacing);
 
     /*
-    **	Guard against object in shroud.
+    **	Guard against flying aircraft in shroud.
     */
-    if (!Debug_Map && !Map[Coord_Cell(Map.Pixel_To_Coord(x, y))].Is_Visible(PlayerPtr)) {
+    if (!Debug_Map && Altitude == FLIGHT_LEVEL && !Map[Coord_Cell(Map.Pixel_To_Coord(x, y))].Is_Visible(PlayerPtr)) {
         return;
     }
 

--- a/tiberiandawn/anim.cpp
+++ b/tiberiandawn/anim.cpp
@@ -229,13 +229,6 @@ void AnimClass::Draw_It(int x, int y, WindowNumberType window)
 {
     Validate();
 
-    /*
-    **	Guard against object in shroud.
-    */
-    if (!Debug_Map && !Map[Coord_Cell(Map.Pixel_To_Coord(x, y))].Is_Visible(PlayerPtr)) {
-        return;
-    }
-
     bool render_legacy = !IsInvisible && (Class->VirtualAnim == ANIM_NONE || window != WINDOW_VIRTUAL);
     bool render_virtual = VirtualAnim != NULL && window == WINDOW_VIRTUAL;
     if (render_legacy) {

--- a/tiberiandawn/building.cpp
+++ b/tiberiandawn/building.cpp
@@ -549,13 +549,6 @@ void BuildingClass::Draw_It(int x, int y, WindowNumberType window)
     shapenum = Fetch_Stage();
 
     /*
-    **	Guard against object in shroud.
-    */
-    if (!Debug_Map && !Map[Coord_Cell(Map.Pixel_To_Coord(x, y))].Is_Visible(PlayerPtr)) {
-        return;
-    }
-
-    /*
     **	The shape file to use for rendering depends on whether the building
     **	is undergoing construction or not.
     */

--- a/tiberiandawn/bullet.cpp
+++ b/tiberiandawn/bullet.cpp
@@ -504,13 +504,6 @@ void BulletClass::Draw_It(int x, int y, WindowNumberType window)
         return;
 
     /*
-    **	Guard against object in shroud.
-    */
-    if (!Debug_Map && !Map[Coord_Cell(Map.Pixel_To_Coord(x, y))].Is_Visible(PlayerPtr)) {
-        return;
-    }
-
-    /*
     **	If there is no shape loaded for this object, then
     **	it obviously can't be rendered -- just bail.
     */

--- a/tiberiandawn/defines.h
+++ b/tiberiandawn/defines.h
@@ -220,16 +220,16 @@ typedef enum FactoryType : unsigned char {
 /**********************************************************************
 **	These are the difficulty settings of the game.
 */
-typedef enum DiffType : unsigned char
+typedef enum DiffType : signed char
 {
+    DIFF_NONE = -1,
     DIFF_EASY,
     DIFF_NORMAL,
     DIFF_HARD,
 
     DIFF_COUNT,
     DIFF_FIRST = 0,
-    DIFF_LAST = DIFF_HARD,
-    DIFF_NONE = 3
+    DIFF_LAST = DIFF_HARD
 } DiffType;
 
 /**********************************************************************

--- a/tiberiandawn/defines.h
+++ b/tiberiandawn/defines.h
@@ -228,7 +228,8 @@ typedef enum DiffType : unsigned char
 
     DIFF_COUNT,
     DIFF_FIRST = 0,
-    DIFF_LAST = DIFF_HARD
+    DIFF_LAST = DIFF_HARD,
+    DIFF_NONE = 3
 } DiffType;
 
 /**********************************************************************

--- a/tiberiandawn/externs.h
+++ b/tiberiandawn/externs.h
@@ -290,6 +290,7 @@ extern unsigned int MPlayerMaxAhead;
 extern unsigned int FrameSendRate;
 extern unsigned char MPlayerID[MAX_PLAYERS];
 extern HousesType MPlayerHouses[MAX_PLAYERS];
+extern DiffType MPlayerDifficulty[MAX_PLAYERS];
 extern char MPlayerNames[MAX_PLAYERS][MPLAYER_NAME_MAX];
 extern MessageListClass Messages;
 #ifdef NETWORKING

--- a/tiberiandawn/function.h
+++ b/tiberiandawn/function.h
@@ -581,6 +581,11 @@ uint32_t Compute_Name_CRC(char* name);
 void Net_Reconnect_Dialog(int reconn, int fresh, int oldest_index, unsigned int timeval);
 
 /*
+** SKIRMISHDLG.CPP
+*/
+int Skirmish_Scenario_Dialog(void);
+
+/*
 ** NULLDLG.CPP
 */
 int Init_Null_Modem(SerialSettingsType* settings);

--- a/tiberiandawn/function.h
+++ b/tiberiandawn/function.h
@@ -491,7 +491,7 @@ void Set_Scenario_Name(char* buf,
                        ScenarioDirType dir = SCEN_DIR_NONE,
                        ScenarioVarType var = SCEN_VAR_NONE);
 void Write_Scenario_Ini(char* root);
-bool Read_Scenario_Ini(char* root, SpecialClass special_options, bool allow_superweapons, bool fresh = true);
+bool Read_Scenario_Ini(char* root, const SpecialClass& special_options, std::optional<bool> allow_superweapons = std::nullopt, bool fresh = true);
 bool Read_Scenario_Ini_File(char* scenario_file_name, char* bin_file_name, const char* root, bool fresh);
 int Scan_Place_Object(ObjectClass* obj, CELL cell);
 

--- a/tiberiandawn/globals.cpp
+++ b/tiberiandawn/globals.cpp
@@ -547,6 +547,7 @@ unsigned char MPlayerID[MAX_PLAYERS];
 ** This array stores the actual HousesType for all players (MULT1, etc).
 */
 HousesType MPlayerHouses[MAX_PLAYERS];
+DiffType MPlayerDifficulty[MAX_PLAYERS];
 
 /***************************************************************************
 ** This array stores the names of all players in a multiplayer game.

--- a/tiberiandawn/infantry.cpp
+++ b/tiberiandawn/infantry.cpp
@@ -585,13 +585,6 @@ void InfantryClass::Draw_It(int x, int y, WindowNumberType window)
     if (!shapefile)
         return;
 
-    /*
-    **	Guard against object in shroud.
-    */
-    if (!Debug_Map && !Map[Coord_Cell(Map.Pixel_To_Coord(x, y))].Is_Visible(PlayerPtr)) {
-        return;
-    }
-
     y += 4;
     x -= 2;
 

--- a/tiberiandawn/init.cpp
+++ b/tiberiandawn/init.cpp
@@ -1164,7 +1164,7 @@ bool Select_Game(bool fade)
 
                 case GAME_SKIRMISH:
 #ifndef REMASTER_BUILD
-                    if (!Com_Scenario_Dialog()) {
+                    if (!Skirmish_Scenario_Dialog()) {
                         GameToPlay = Select_MPlayer_Game();
                         if (GameToPlay == GAME_NORMAL) { // user hit Cancel
                             display = true;

--- a/tiberiandawn/list.cpp
+++ b/tiberiandawn/list.cpp
@@ -104,6 +104,7 @@ ListClass::ListClass(int id, int x, int y, int w, int h, TextPrintType flags, vo
     Fancy_Text_Print(TXT_NONE, 0, 0, TBLACK, TBLACK, TextFlags);
     LineHeight = FontHeight + FontYSpacing - 1;
     LineCount = (h - 1) / LineHeight;
+    PreviousIndex = std::nullopt;
 }
 
 /***********************************************************************************************
@@ -195,6 +196,8 @@ int ListClass::Add_Item(const std::string& text)
 void ListClass::Remove_Item(int index)
 {
     if (index < List.Count()) {
+        PreviousIndex = Current_Index();
+
         List.Delete(index);
 
         /*
@@ -216,6 +219,8 @@ void ListClass::Remove_Item(int index)
         ** If we just removed the selected entry, select the previous one
         */
         if (SelectedIndex >= List.Count()) {
+            PreviousIndex = SelectedIndex;
+
             SelectedIndex--;
             if (SelectedIndex < 0) {
                 SelectedIndex = 0;
@@ -301,6 +306,8 @@ int ListClass::Action(unsigned flags, KeyNumType& key)
 
             int index = Get_Mouse_Y() - (Y + 1);
             index = index / LineHeight;
+
+            PreviousIndex = SelectedIndex;
             SelectedIndex = CurrentTopIndex + index;
             SelectedIndex = MIN(SelectedIndex, List.Count() - 1);
         }
@@ -864,6 +871,8 @@ GadgetClass* ListClass::Remove(void)
  *=============================================================================================*/
 void ListClass::Set_Selected_Index(int index)
 {
+    PreviousIndex = SelectedIndex;
+
     if (List.Count() == 0 || index >= List.Count()) {
         SelectedIndex = 0;
     } else if (index < 0) {
@@ -879,6 +888,21 @@ void ListClass::Set_Selected_Index(int index)
     if (SelectedIndex >= CurrentTopIndex + LineCount) {
         Set_View_Index(SelectedIndex - (LineCount - 1));
     }
+}
+
+bool ListClass::Index_Changed()
+{
+    return PreviousIndex.has_value() && PreviousIndex != Current_Index();
+}
+
+int ListClass::Get_Previous_Index()
+{
+    return PreviousIndex.value_or(-1);
+}
+
+void ListClass::Reset_Index_Change()
+{
+    PreviousIndex = std::nullopt;
 }
 
 /***********************************************************************************************

--- a/tiberiandawn/list.h
+++ b/tiberiandawn/list.h
@@ -80,6 +80,9 @@ public:
     virtual void Remove_Item(int);
     virtual int Remove_Scroll_Bar(void);
     virtual void Set_Selected_Index(int index);
+    virtual bool Index_Changed();
+    virtual int Get_Previous_Index();
+    virtual void Reset_Index_Change();
     virtual void Set_Tabs(int const* tabs);
     virtual int Set_View_Index(int index);
     virtual void Step(int up);
@@ -146,6 +149,8 @@ protected:
     **	This specifies the line (index) that is at the top of the list box.
     */
     int CurrentTopIndex;
+
+    std::optional<int> PreviousIndex;
 };
 
 #endif

--- a/tiberiandawn/map.cpp
+++ b/tiberiandawn/map.cpp
@@ -1424,7 +1424,7 @@ void MapClass::Logic(void)
         /*
         ** Use the Tiberium setting as a multiplier on growth rate. ST - 7/1/2020 3:05PM
         */
-        if (GameToPlay == GAME_GLYPHX_MULTIPLAYER) {
+        if (GameToPlay != GAME_NORMAL) {
             if (MPlayerTiberium > 1) {
                 tries += (MPlayerTiberium - 1) << 1;
             }

--- a/tiberiandawn/missionselect.cpp
+++ b/tiberiandawn/missionselect.cpp
@@ -167,7 +167,7 @@ static std::string Build_Mission_Description(
 
         // {country name} {direction} ({variation})
         mission_description = country_name_str + (country.has_value() ? " " : "") +
-            std::format("({} {})", direction_str, TdTypeConverter::To_String(variation));
+            std::format("({} {})", direction_str, variation);
     }
 
     // {campaign player}: Mission {number} - {mission description}
@@ -237,7 +237,7 @@ static void Fill_Mission_Cache(std::vector<MissionVariables>& mission_cache)
         RequiredCD = player;
 
         if (!Force_CD_Available(player)) {
-            CNC_LOG_WARN("Missing CD data detected when looking for {} missions", TdTypeConverter::To_String(player));
+            CNC_LOG_WARN("Missing CD data detected when looking for {} missions", player);
             RequiredCD = old_cd;
         }
 

--- a/tiberiandawn/mplayer.cpp
+++ b/tiberiandawn/mplayer.cpp
@@ -367,7 +367,7 @@ GameType Select_MPlayer_Game(void)
             case (BUTTON_SKIRMISH):
                 GameToPlay = GAME_SKIRMISH;
                 Read_MultiPlayer_Settings();
-                if (Com_Scenario_Dialog()) {
+                if (Skirmish_Scenario_Dialog()) {
                     retval = GAME_SKIRMISH;
                     process = false;
                 } else {

--- a/tiberiandawn/nulldlg.cpp
+++ b/tiberiandawn/nulldlg.cpp
@@ -35,7 +35,1342 @@
 #include "function.h"
 #include "drop.h"
 #include "framelimit.h"
-#include <time.h>
+
+struct ControlDimension
+{
+    int x = 0;
+    int y = 0;
+    int w = 0;
+    int h = 0;
+};
+
+class SkirmishScenarioDialog final
+{
+    /*........................................................................
+    Button Enumerations
+    ........................................................................*/
+    typedef enum
+    {
+        BUTTON_NAME = 100,
+        BUTTON_HOUSE,
+        BUTTON_AI_DIFF_1,
+        BUTTON_AI_DIFF_2,
+        BUTTON_AI_DIFF_3,
+        BUTTON_AI_DIFF_4,
+        BUTTON_AI_DIFF_5,
+        BUTTON_AI_HOUSE_1,
+        BUTTON_AI_HOUSE_2,
+        BUTTON_AI_HOUSE_3,
+        BUTTON_AI_HOUSE_4,
+        BUTTON_AI_HOUSE_5,
+        BUTTON_CREDITS,
+        BUTTON_TIBERIUMSCALE,
+        BUTTON_OPTIONS,
+        BUTTON_SCENARIOLIST,
+        BUTTON_COUNT,
+        BUTTON_LEVEL,
+        BUTTON_OK,
+        BUTTON_LOAD,
+        BUTTON_CANCEL,
+        BUTTON_DIFFICULTY,
+    } ButtonType;
+
+    /*........................................................................
+    Redraw values: in order from "top" to "bottom" layer of the dialog
+    ........................................................................*/
+    typedef enum
+    {
+        REDRAW_NONE = 0,
+        REDRAW_MESSAGE,
+        REDRAW_COLORS,
+        REDRAW_BUTTONS,
+        REDRAW_BACKGROUND,
+        REDRAW_ALL = REDRAW_BACKGROUND
+    } RedrawType;
+
+    static constexpr auto DropdownTextLength = 25;
+    static inline int OptionTabs[] = {8};
+
+    // dimensions
+    int Factor;
+
+    int X;
+    int Y;
+    int Width;
+    int Height;
+    int Center;
+
+    int TextHeight;
+    int MarginWidth;
+    int MarginHeight;
+
+    int d_ok_w;
+    int d_ok_h;
+    int d_ok_x;
+    int d_ok_y;
+
+    int d_cancel_w;
+    int d_cancel_h;
+    int d_cancel_x;
+    int d_cancel_y;
+
+    int d_name_w;
+    int d_name_h;
+    int d_name_x;
+    int d_name_y;
+
+    int d_house_w;
+    int d_house_h;
+    int d_house_x;
+    int d_house_y;
+
+    int d_color_w;
+    int d_color_h;
+    int d_color_y;
+    int d_color_x;
+
+    int d_playerlist_w;
+    int d_playerlist_x;
+
+    int d_scenariolist_w;
+    int d_scenariolist_h;
+    int d_scenariolist_x;
+    int d_scenariolist_y;
+
+    int d_aihouse_w;
+    int d_aihouse_h;
+    int d_aihouse_x;
+    int d_aihouse_y;
+    int d_aihouse_ystep;
+
+    int d_options_w;
+    int d_options_h;
+    int d_options_x;
+    int d_options_y;
+
+    int d_count_w;
+    int d_count_h;
+    int d_count_y;
+    int d_count_x;
+
+    int d_level_w;
+    int d_level_h;
+    int d_level_y;
+    int d_level_x;
+
+    int d_credits_w;
+    int d_credits_h;
+    int d_credits_x;
+    int d_credits_y;
+
+    int d_tiberiumscale_w;
+    int d_tiberiumscale_h;
+    int d_tiberiumscale_x;
+    int d_tiberiumscale_y;
+
+    int ColorBoxes[6];
+
+    // button shapes
+    void const* UpButtonShape;
+    void const* DownButtonShape;
+
+    std::map<ButtonType, ControlDimension> Dimensions;
+    std::map<ButtonType, std::unique_ptr<char[]>> Text;
+    std::map<ButtonType, std::unique_ptr<GadgetClass>> Controls;
+    GadgetClass* CommandChain;
+
+    template<class T>
+    T& Get_Control(const ButtonType type)
+    {
+        return *reinterpret_cast<T*>(Controls[type].get());
+    }
+
+    void Render(RedrawType& display)
+    {
+        if (!display) {
+            return;
+        }
+        char txt[80];
+
+        Hide_Mouse();
+        /*
+        .................. Redraw backgound & dialog box ...................
+        */
+        if (display >= REDRAW_BACKGROUND) {
+            Dialog_Box(X, Y, Width, Height);
+
+            // init font variables
+
+            Fancy_Text_Print(
+                TXT_NONE, 0, 0, TBLACK, TBLACK, TPF_CENTER | TPF_6PT_GRAD | TPF_USE_GRAD_PAL | TPF_NOSHADOW);
+
+            /*...............................................................
+            Dialog & Field labels
+            ...............................................................*/
+#ifdef FORCE_WINSOCK
+            if (Winsock.Get_Connected()) {
+                Draw_Caption(TXT_HOST_INTERNET_GAME, X, Y, Width);
+            } else {
+                Draw_Caption(TXT_HOST_SERIAL_GAME, X, Y, Width);
+            }
+#else
+            Draw_Caption(TXT_NONE, X, Y, Width);
+#endif // FORCE_WINSOCK
+
+            Fancy_Text_Print(TXT_YOUR_NAME,
+                             d_name_x + (d_name_w / 2),
+                             d_name_y - TextHeight - (1 * Factor),
+                             CC_GREEN,
+                             TBLACK,
+                             TPF_RIGHT | TPF_6PT_GRAD | TPF_USE_GRAD_PAL | TPF_NOSHADOW);
+
+            Fancy_Text_Print(TXT_SIDE_COLON,
+                             d_house_x + (d_house_w / 2),
+                             d_house_y - TextHeight - (1 * Factor),
+                             CC_GREEN,
+                             TBLACK,
+                             TPF_RIGHT | TPF_6PT_GRAD | TPF_USE_GRAD_PAL | TPF_NOSHADOW);
+
+            Fancy_Text_Print(TXT_COLOR_COLON,
+                             X + ((Width / 4) * 3),
+                             d_color_y - TextHeight - (1 * Factor),
+                             CC_GREEN,
+                             TBLACK,
+                             TPF_RIGHT | TPF_6PT_GRAD | TPF_USE_GRAD_PAL | TPF_NOSHADOW);
+
+            auto& difficulty = Get_Control<SliderClass>(BUTTON_DIFFICULTY);
+
+            Fancy_Text_Print("Easy", // TODO: Locale file entry
+                             difficulty.X,
+                             difficulty.Y - 8 * Factor,
+                             CC_GREEN,
+                             TBLACK,
+                             TPF_6PT_GRAD | TPF_USE_GRAD_PAL | TPF_NOSHADOW);
+
+            Fancy_Text_Print("Hard", // TODO: Locale file entry
+                             difficulty.X + difficulty.Width,
+                             difficulty.Y - 8 * Factor,
+                             CC_GREEN,
+                             TBLACK,
+                             TPF_RIGHT | TPF_6PT_GRAD | TPF_USE_GRAD_PAL | TPF_NOSHADOW);
+
+            Fancy_Text_Print("Normal", // TODO: Locale file entry
+                             difficulty.X + difficulty.Width / 2,
+                             difficulty.Y - 8 * Factor,
+                             CC_GREEN,
+                             TBLACK,
+                             TPF_CENTER | TPF_6PT_GRAD | TPF_USE_GRAD_PAL | TPF_NOSHADOW);
+
+            Fancy_Text_Print(TXT_SCENARIOS,
+                             d_scenariolist_x + (d_scenariolist_w / 2),
+                             d_scenariolist_y - TextHeight - (1 * Factor),
+                             CC_GREEN,
+                             TBLACK,
+                             TPF_CENTER | TPF_6PT_GRAD | TPF_USE_GRAD_PAL | TPF_NOSHADOW);
+
+            Fancy_Text_Print(TXT_COUNT,
+                             d_count_x - 3 * Factor,
+                             d_count_y,
+                             CC_GREEN,
+                             TBLACK,
+                             TPF_NOSHADOW | TPF_6PT_GRAD | TPF_USE_GRAD_PAL | TPF_RIGHT);
+
+            Fancy_Text_Print(TXT_LEVEL,
+                             d_level_x - 3 * Factor,
+                             d_level_y,
+                             CC_GREEN,
+                             TBLACK,
+                             TPF_NOSHADOW | TPF_6PT_GRAD | TPF_USE_GRAD_PAL | TPF_RIGHT);
+
+            Fancy_Text_Print(TXT_START_CREDITS_COLON,
+                             d_credits_x - 3 * Factor,
+                             d_credits_y,
+                             CC_GREEN,
+                             TBLACK,
+                             TPF_RIGHT | TPF_6PT_GRAD | TPF_USE_GRAD_PAL | TPF_NOSHADOW);
+
+            Fancy_Text_Print("Tiberium Growth:", // TODO: Locale file entry
+                             d_tiberiumscale_x - 3 * Factor,
+                             d_tiberiumscale_y,
+                             CC_GREEN,
+                             TBLACK,
+                             TPF_RIGHT | TPF_6PT_GRAD | TPF_USE_GRAD_PAL | TPF_NOSHADOW);
+
+            // AI player setting headers
+            Fancy_Text_Print("Player", // TODO: Locale file entry
+                             (d_aihouse_x - static_cast<int>(nearbyint(d_aihouse_w * 1.5)) - (10 * Factor))
+                                + (static_cast<int>((d_aihouse_w * 1.5) / 1.25)),
+                             d_aihouse_y - TextHeight - (2 * Factor),
+                             CC_GREEN,
+                             TBLACK,
+                             TPF_RIGHT | TPF_6PT_GRAD | TPF_USE_GRAD_PAL | TPF_NOSHADOW);
+
+            Fancy_Text_Print("Side", // TODO: Locale file entry
+                             d_aihouse_x + static_cast<int>(nearbyint(d_aihouse_w / 1.25)),
+                             d_aihouse_y - TextHeight - (2 * Factor),
+                             CC_GREEN,
+                             TBLACK,
+                             TPF_RIGHT | TPF_6PT_GRAD | TPF_USE_GRAD_PAL | TPF_NOSHADOW);
+
+            // AI player difficulty and house checkbox labels
+            const auto cur_ai_house_label_x = (d_aihouse_x - static_cast<int>(nearbyint(d_aihouse_w * 1.5))
+                - (10 * Factor)) - 3 * Factor;
+            auto cur_ai_house_label_y = d_aihouse_y;
+
+            for (int idx = BUTTON_AI_DIFF_1; idx <= BUTTON_AI_DIFF_5; idx++) {
+                Fancy_Text_Print(std::format("AI {}:", idx - BUTTON_HOUSE).c_str(), // TODO: Locale file entry
+                                 cur_ai_house_label_x,
+                                 cur_ai_house_label_y,
+                                 CC_GREEN,
+                                 TBLACK,
+                                 TPF_RIGHT | TPF_6PT_GRAD | TPF_USE_GRAD_PAL | TPF_NOSHADOW);
+
+                cur_ai_house_label_y += d_aihouse_ystep;
+            }
+        }
+
+        /*..................................................................
+        Draw the color boxes
+        ..................................................................*/
+        if (display >= REDRAW_COLORS) {
+            for (auto i = 0; i < MAX_MPLAYER_COLORS; i++) {
+                LogicPage->Fill_Rect(ColorBoxes[i] + 1 * Factor,
+                                     d_color_y + 1 * Factor,
+                                     ColorBoxes[i] + 1 * Factor + d_color_w - 2 * Factor,
+                                     d_color_y + 1 * Factor + d_color_h - 2 * Factor,
+                                     MPlayerGColors[i]);
+
+                if (i == MPlayerColorIdx) {
+                    Draw_Box(ColorBoxes[i], d_color_y, d_color_w, d_color_h, BOXSTYLE_GREEN_DOWN, false);
+                } else {
+                    Draw_Box(ColorBoxes[i], d_color_y, d_color_w, d_color_h, BOXSTYLE_GREEN_RAISED, false);
+                }
+            }
+        }
+
+        /*..................................................................
+        Draw the message:
+        - Erase an old message first
+        ..................................................................*/
+        if (display >= REDRAW_MESSAGE) {
+            sprintf(txt, "%d ", MPlayerUnitCount);
+            Fancy_Text_Print(txt,
+                             d_count_x + d_count_w + 3 * Factor,
+                             d_count_y,
+                             CC_GREEN,
+                             BLACK,
+                             TPF_6PT_GRAD | TPF_USE_GRAD_PAL | TPF_NOSHADOW);
+
+            if (BuildLevel <= MPLAYER_BUILD_LEVEL_MAX) {
+                sprintf(txt, "%d ", BuildLevel);
+            } else {
+                sprintf(txt, "**");
+            }
+            Fancy_Text_Print(txt,
+                             d_level_x + d_level_w + 3 * Factor,
+                             d_level_y,
+                             CC_GREEN,
+                             BLACK,
+                             TPF_6PT_GRAD | TPF_USE_GRAD_PAL | TPF_NOSHADOW);
+            sprintf(txt, "%d ", MPlayerCredits);
+            Fancy_Text_Print(txt,
+                             d_credits_x + d_credits_w + 3 * Factor,
+                             d_credits_y,
+                             CC_GREEN,
+                             BLACK,
+                             TPF_6PT_GRAD | TPF_USE_GRAD_PAL | TPF_NOSHADOW);
+
+            sprintf(txt, "%dx ", Get_Control<GaugeClass>(BUTTON_TIBERIUMSCALE).Get_Value() + 1);
+            Fancy_Text_Print(txt,
+                             d_tiberiumscale_x + d_tiberiumscale_w + 3 * Factor,
+                             d_tiberiumscale_y,
+                             CC_GREEN,
+                             BLACK,
+                             TPF_6PT_GRAD | TPF_USE_GRAD_PAL | TPF_NOSHADOW);
+        }
+
+        /*
+        .......................... Redraw buttons ..........................
+        */
+        if (display >= REDRAW_BUTTONS) {
+            CommandChain->Flag_List_To_Redraw();
+        }
+
+        Show_Mouse();
+        display = REDRAW_NONE;
+    }
+
+    void Init_UI_State()
+    {
+        auto& option_list = Get_Control<CheckListClass>(BUTTON_OPTIONS);
+
+        option_list.Set_Tabs(OptionTabs);
+        option_list.Set_Read_Only(0);
+
+        option_list.Add_Item(Text_String(TXT_BASES_ON));
+        option_list.Add_Item("Tiberium Regrows"); // TODO: Locale file entry
+        option_list.Add_Item(Text_String(TXT_CRATES_ON));
+        //optionlist.Add_Item(Text_String(TXT_SHADOW_REGROWS)); // TODO: Implement for TD? (copied from RA)
+        option_list.Add_Item(Text_String(TXT_CAPTURE_THE_FLAG));
+
+        option_list.Check_Item(0, MPlayerBases);
+        option_list.Check_Item(1, MPlayerTiberium);
+        option_list.Check_Item(2, MPlayerGoodies);
+        //optionlist.Check_Item(3, Special.IsShadowGrow);
+        option_list.Check_Item(3, Special.IsCaptureTheFlag);
+
+        auto& levelgauge = Get_Control<GaugeClass>(BUTTON_LEVEL);
+        levelgauge.Set_Maximum(MPLAYER_BUILD_LEVEL_MAX - 1);
+        levelgauge.Set_Value(BuildLevel - 1);
+
+        auto& countgauge = Get_Control<GaugeClass>(BUTTON_COUNT);
+        countgauge.Set_Maximum(MPlayerCountMax[MPlayerBases] - MPlayerCountMin[MPlayerBases]);
+        countgauge.Set_Value(MPlayerUnitCount - MPlayerCountMin[MPlayerBases]);
+
+        auto& creditsgauge = Get_Control<GaugeClass>(BUTTON_CREDITS);
+        creditsgauge.Set_Maximum(Rule.Get_Rule_Value<int>(GAME_MULTIPLAYER_SECTION, START_CREDITS_MAX_RULE));
+        creditsgauge.Set_Value(MPlayerCredits);
+
+        auto& tiberiumscalegauge = Get_Control<GaugeClass>(BUTTON_TIBERIUMSCALE);
+        tiberiumscalegauge.Set_Maximum(4);
+        tiberiumscalegauge.Set_Value(MPlayerTiberium < 2 ? 0 : MPlayerTiberium - 1);
+
+        auto& scenariolist = Get_Control<ListClass>(BUTTON_SCENARIOLIST);
+
+        for (auto i = 0; i < MPlayerScenarios.Count(); i++) {
+            scenariolist.Add_Item(strupr(MPlayerScenarios[i]));
+        }
+        ScenarioIdx = 0; // 1st scenario is selected
+
+        // select the last scenario chosen by the player (if present)
+        for (auto i = 0; i < MPlayerFilenum.Count(); i++) {
+            if (MPlayerFilenum[i] == MPlayerScenarioNumber) {
+                ScenarioIdx = i;
+                scenariolist.Set_Selected_Index(i);
+                break;
+            }
+        }
+    }
+
+    void Init_Data()
+    {
+        MPlayerColorIdx = MPlayerPrefColor; // init my preferred color
+
+        strcpy(Text[BUTTON_NAME].get(), MPlayerName);       // set my name
+
+        auto& name = Get_Control<EditClass>(BUTTON_NAME);
+
+        name.Set_Text(Text[BUTTON_NAME].get(), MPLAYER_NAME_MAX);
+        name.Set_Color(MPlayerTColors[MPlayerColorIdx]);
+
+        auto& house = Get_Control<DropListClass>(BUTTON_HOUSE);
+
+        // TODO: Add mystery option ? (random house selection)
+        house.Add_Item(Text_String(TXT_G_D_I));
+        house.Add_Item(Text_String(TXT_N_O_D));
+        // TODO: Add dinosaur support (no bases ONLY)
+        house.Set_Selected_Index(MPlayerHouse - HOUSE_GOOD);
+        house.Set_Read_Only(true);
+
+        if (MPlayerGhosts > 5) {
+            MPlayerGhosts = 5;
+        }
+        MPlayerGhosts = max(MPlayerGhosts, 1);
+
+        for (auto control = BUTTON_AI_DIFF_1; control <= BUTTON_AI_DIFF_5; ++control) {
+            auto& dropdown = Get_Control<DropListClass>(control);
+
+            dropdown.Add_Item("Disabled"); // TODO: Locale file entries
+            dropdown.Add_Item("Easy");
+            dropdown.Add_Item("Normal");
+            dropdown.Add_Item("Hard");
+            dropdown.Set_Selected_Index(control - BUTTON_AI_DIFF_1 < MPlayerGhosts ? 2 : 0);
+            dropdown.Set_Read_Only(true);
+        }
+
+        for (auto control = BUTTON_AI_HOUSE_1; control <= BUTTON_AI_HOUSE_5; ++control) {
+            auto& dropdown = Get_Control<DropListClass>(control);
+
+            dropdown.Add_Item("None"); // TODO: Locale file entries
+            dropdown.Add_Item("?");
+            dropdown.Add_Item(Text_String(TXT_G_D_I));
+            dropdown.Add_Item(Text_String(TXT_N_O_D));
+            // TODO: Add dinosaur support (no bases ONLY)
+            dropdown.Set_Selected_Index(control - BUTTON_AI_HOUSE_1 < MPlayerGhosts ? 1 : 0);
+            dropdown.Set_Read_Only(true);
+        }
+
+        // GB 2022 set defaults for skirmish also:
+        BuildLevel = 7;
+
+        // init credits & credit buffer
+        MPlayerCredits = Rule.Get_Rule_Value<int>(GAME_MULTIPLAYER_SECTION, START_CREDITS_DEFAULT_RULE);
+        MPlayerGhosts = 1;
+        MPlayerUnitCount = (MPlayerCountMax[MPlayerBases] + MPlayerCountMin[MPlayerBases]) / 2;
+        MPlayerTiberium = 1;
+
+        Special.IsTGrowth = MPlayerTiberium;
+        Special.IsTSpread = MPlayerTiberium;
+
+        for (auto& player_house : MPlayerHouses) {
+            player_house = HOUSE_NONE;
+        }
+
+        for (auto& player_difficulty : MPlayerDifficulty) {
+            player_difficulty = DIFF_NONE;
+        }
+    }
+
+    void Init_Dialog_Buttons()
+    {
+        Controls[BUTTON_OK] = std::unique_ptr<GadgetClass>(
+            new TextButtonClass(
+                BUTTON_OK,
+                TXT_OK,
+                TPF_CENTER | TPF_6PT_GRAD | TPF_USE_GRAD_PAL | TPF_NOSHADOW,
+                d_ok_x,
+                d_ok_y,
+                d_ok_w,
+                d_ok_h
+            )
+        );
+        Get_Control<TextButtonClass>(BUTTON_OK).Add_Tail(*CommandChain);
+
+        Controls[BUTTON_CANCEL] = std::unique_ptr<GadgetClass>(
+            new TextButtonClass(
+                BUTTON_CANCEL,
+                TXT_CANCEL,
+                TPF_CENTER | TPF_6PT_GRAD | TPF_USE_GRAD_PAL | TPF_NOSHADOW,
+                d_cancel_x,
+                d_cancel_y,
+                d_cancel_w,
+                d_cancel_h
+            )
+        );
+        Get_Control<TextButtonClass>(BUTTON_CANCEL).Add_Tail(*CommandChain);
+    }
+
+    void Init_Difficulty_Slider()
+    {
+        Controls[BUTTON_DIFFICULTY] = std::unique_ptr<GadgetClass>(
+            new SliderClass(
+                BUTTON_DIFFICULTY,
+                d_name_x,
+                d_ok_y - (8 * Factor) - MarginWidth,
+                Width - (d_name_x - X) * 2,
+                8 * Factor,
+                true
+            )
+        );
+
+        auto& difficulty = Get_Control<SliderClass>(BUTTON_DIFFICULTY);
+
+        difficulty.Add_Tail(*CommandChain);
+
+        if (Rule.IsFineDifficulty) {
+            difficulty.Set_Maximum(5);
+            difficulty.Set_Value(2);
+        } else {
+            difficulty.Set_Maximum(3);
+            difficulty.Set_Value(1);
+        }
+    }
+
+    void Init_Bottom_Row()
+    {
+        Controls[BUTTON_COUNT] = std::unique_ptr<GadgetClass>(
+            new GaugeClass(BUTTON_COUNT, d_count_x, d_count_y, d_count_w, d_count_h)
+        );
+        Get_Control<GaugeClass>(BUTTON_COUNT).Add_Tail(*CommandChain);
+
+        Controls[BUTTON_LEVEL] = std::unique_ptr<GadgetClass>(
+            new GaugeClass(BUTTON_LEVEL, d_level_x, d_level_y, d_level_w, d_level_h)
+        );
+        Get_Control<GaugeClass>(BUTTON_LEVEL).Add_Tail(*CommandChain);
+
+        Controls[BUTTON_CREDITS] = std::unique_ptr<GadgetClass>(
+            new GaugeClass(BUTTON_CREDITS, d_credits_x, d_credits_y, d_credits_w, d_credits_h)
+        );
+        Get_Control<GaugeClass>(BUTTON_CREDITS).Add_Tail(*CommandChain);
+
+        Controls[BUTTON_TIBERIUMSCALE] = std::unique_ptr<GadgetClass>(
+            new GaugeClass(
+                BUTTON_TIBERIUMSCALE,
+                d_tiberiumscale_x,
+                d_tiberiumscale_y,
+                d_tiberiumscale_w,
+                d_tiberiumscale_h
+            )
+        );
+        Get_Control<GaugeClass>(BUTTON_TIBERIUMSCALE).Add_Tail(*CommandChain);
+
+        Controls[BUTTON_OPTIONS] = std::unique_ptr<GadgetClass>(
+            new CheckListClass(
+                BUTTON_OPTIONS,
+                d_options_x,
+                d_options_y,
+                d_options_w,
+                d_options_h,
+                TPF_6PT_GRAD | TPF_USE_GRAD_PAL | TPF_NOSHADOW,
+                UpButtonShape,
+                DownButtonShape
+            )
+        );
+        Get_Control<GaugeClass>(BUTTON_OPTIONS).Add_Tail(*CommandChain);
+    }
+
+    void Init_Middle_Row()
+    {
+        auto cur_ai_house_y = d_aihouse_y;
+
+        for (auto h = BUTTON_AI_DIFF_1; h <= BUTTON_AI_DIFF_5; ++h) {
+            const auto house_button = static_cast<ButtonType>(h + 5);
+
+            Text[h] = std::make_unique<char[]>(DropdownTextLength);
+            Text[house_button] = std::make_unique<char[]>(DropdownTextLength);
+
+            Controls[h] = std::unique_ptr<GadgetClass>(
+                new DropListClass(
+                    h,
+                    Text[h].get(),
+                    DropdownTextLength,
+                    TPF_6PT_GRAD | TPF_USE_GRAD_PAL | TPF_NOSHADOW,
+                    d_aihouse_x - static_cast<int>(nearbyint(d_aihouse_w * 1.5)) - (10 * Factor),
+                    cur_ai_house_y,
+                    static_cast<int>(nearbyint(d_aihouse_w * 1.5)),
+                    d_aihouse_h,
+                    UpButtonShape,
+                    DownButtonShape
+                )
+            );
+            Get_Control<DropListClass>(h).Add_Tail(*CommandChain);
+
+            Controls[house_button] = std::unique_ptr<GadgetClass>(
+                new DropListClass(
+                    house_button,
+                    Text[house_button].get(),
+                    DropdownTextLength,
+                    TPF_6PT_GRAD | TPF_USE_GRAD_PAL | TPF_NOSHADOW,
+                    d_aihouse_x,
+                    cur_ai_house_y,
+                    d_aihouse_w,
+                    d_aihouse_h,
+                    UpButtonShape,
+                    DownButtonShape
+                )
+            );
+            Get_Control<DropListClass>(house_button).Add_Tail(*CommandChain);
+
+            cur_ai_house_y += d_aihouse_ystep;
+        }
+
+        Controls[BUTTON_SCENARIOLIST] = std::unique_ptr<GadgetClass>(
+            new ListClass(
+                BUTTON_SCENARIOLIST,
+                d_scenariolist_x,
+                d_scenariolist_y,
+                d_scenariolist_w,
+                d_scenariolist_h,
+                TPF_6PT_GRAD | TPF_USE_GRAD_PAL | TPF_NOSHADOW,
+                UpButtonShape,
+                DownButtonShape
+            )
+        );
+        Get_Control<ListClass>(BUTTON_SCENARIOLIST).Add_Tail(*CommandChain);
+    }
+
+    void Init_Top_Row()
+    {
+        Text[BUTTON_NAME] = std::make_unique<char[]>(MPLAYER_NAME_MAX);
+        Controls[BUTTON_NAME] = std::unique_ptr<GadgetClass>(
+            new EditClass(
+                BUTTON_NAME,
+                Text[BUTTON_NAME].get(),
+                MPLAYER_NAME_MAX,
+                TPF_6PT_GRAD | TPF_USE_GRAD_PAL | TPF_NOSHADOW,
+                d_name_x,
+                d_name_y,
+                d_name_w,
+                d_name_h,
+                EditClass::ALPHANUMERIC
+            )
+        );
+        CommandChain = Controls[BUTTON_NAME].get();
+
+        Text[BUTTON_HOUSE] = std::make_unique<char[]>(DropdownTextLength);
+        Controls[BUTTON_HOUSE] = std::unique_ptr<GadgetClass>(
+            new DropListClass(BUTTON_HOUSE,
+                Text[BUTTON_HOUSE].get(),
+                DropdownTextLength,
+                TPF_6PT_GRAD | TPF_USE_GRAD_PAL | TPF_NOSHADOW,
+                d_house_x,
+                d_house_y,
+                d_house_w,
+                d_house_h,
+                UpButtonShape,
+                DownButtonShape
+            )
+        );
+        Get_Control<DropListClass>(BUTTON_HOUSE).Add_Tail(*CommandChain);
+    }
+
+    void Init_Controls()
+    {
+        Text.clear();
+        Controls.clear();
+        CommandChain = nullptr;
+
+        Init_Top_Row();
+        Init_Middle_Row();
+        Init_Bottom_Row();
+        Init_Difficulty_Slider();
+        Init_Dialog_Buttons();
+    }
+
+    void Init_Shapes()
+    {
+        if (InMainLoop || Factor == 1) {
+            UpButtonShape = UpButtonShape == nullptr ? Hires_Retrieve("BTN-UP.SHP") : UpButtonShape;
+            DownButtonShape = DownButtonShape == nullptr ? Hires_Retrieve("BTN-DN.SHP") : DownButtonShape;
+        } else {
+            UpButtonShape = UpButtonShape == nullptr ? Hires_Retrieve("BTN-UP2.SHP") : UpButtonShape;
+            DownButtonShape = DownButtonShape == nullptr ? Hires_Retrieve("BTN-DN2.SHP") : DownButtonShape;
+        }
+    }
+
+    void Init_Dimensions(const int screen_width, const int screen_height)
+    {
+        /*........................................................................
+        Dialog & button dimensions
+        ........................................................................*/
+        Width = 300 * Factor;                      // dialog width
+        Height = 195 * Factor;                      // dialog height
+        X = (screen_width - Width) / 2; // dialog x-coord
+        Y = (screen_height - Height) / 2; // dialog y-coord
+        Center = X + (Width / 2);    // center x-coord
+
+        TextHeight = 6 * Factor + 1; // ht of 6-pt text
+        MarginWidth = 10 * Factor;    // margin width/height
+        MarginHeight = 4 * Factor;    // margin width/height
+
+        Dimensions[BUTTON_OK].w = 45 * Factor;
+        Dimensions[BUTTON_OK].h = 9 * Factor;
+        Dimensions[BUTTON_OK].x = X + (Width / 6) - (Dimensions[BUTTON_OK].w / 2);
+        Dimensions[BUTTON_OK].y = Y + Height - Dimensions[BUTTON_OK].h - MarginWidth - Factor * 6;
+
+        Dimensions[BUTTON_CANCEL].w = 45 * Factor;
+        Dimensions[BUTTON_CANCEL].h = 9 * Factor;
+        Dimensions[BUTTON_CANCEL].x = X + Width - (Width / 6) - (Dimensions[BUTTON_CANCEL].w / 2);
+        Dimensions[BUTTON_CANCEL].y = Y + Height - Dimensions[BUTTON_CANCEL].h - MarginWidth - Factor * 6;
+
+        d_ok_w = 45 * Factor;
+        d_ok_h = 9 * Factor;
+        d_ok_x = X + (Width / 6) - (d_ok_w / 2);
+        d_ok_y = Y + Height - d_ok_h - MarginWidth - Factor * 6;
+
+        d_cancel_w = 45 * Factor;
+        d_cancel_h = 9 * Factor;
+        d_cancel_x = X + Width - (Width / 6) - (d_cancel_w / 2);
+        d_cancel_y = Y + Height - d_cancel_h - MarginWidth - Factor * 6;
+
+        d_name_w = 70 * Factor;
+        d_name_h = 9 * Factor;
+        d_name_x = X + 5 + (Width / 4) - (d_name_w / 2);
+        d_name_y = Y + MarginHeight + TextHeight + 1 * Factor;
+
+        d_house_w = 60 * Factor;
+        d_house_h = (3 * 5 * Factor);
+        d_house_x = Center - (d_house_w / 2);
+        d_house_y = d_name_y;
+
+        d_color_w = 10 * Factor;
+        d_color_h = 9 * Factor;
+        d_color_y = d_name_y;
+        d_color_x = X + ((Width / 4) * 3) - (d_color_w * 3);
+
+        d_playerlist_w = 118 * Factor;
+        d_playerlist_x = X + MarginWidth + MarginWidth + 5 * Factor;
+
+        d_scenariolist_w = 140 * Factor;
+        d_scenariolist_h = 30 * Factor;
+        d_scenariolist_x = (d_cancel_x + static_cast<int>(nearbyint(d_cancel_w * 0.8))) - d_scenariolist_w + (20 * Factor);
+        d_scenariolist_y = d_color_y + TextHeight + 5 * Factor + TextHeight;
+
+        d_scenariolist_h *= 2;
+
+        d_aihouse_w = static_cast<int>(nearbyint(d_house_w / 1.75));
+        d_aihouse_h = (6 * 5 * Factor);
+        d_aihouse_x = d_scenariolist_x - d_aihouse_w - (10 * Factor);
+        d_aihouse_y = d_scenariolist_y + (5 * Factor);
+        d_aihouse_ystep = 10 * Factor;
+
+        d_options_w = static_cast<int>(nearbyint(d_scenariolist_w * 0.8));
+        d_options_h = (5 * 6 * Factor) + 5 * Factor;
+        d_options_x = (d_scenariolist_x + d_scenariolist_w) - d_options_w;
+        d_options_y = d_scenariolist_y + d_scenariolist_h + MarginWidth - 2 * Factor;
+
+        d_count_w = 25 * Factor;
+        d_count_h = 7 * Factor;
+        d_count_y = d_options_y;
+        d_count_x = d_playerlist_x + (d_playerlist_w / 2) + 20 * Factor; // fudged
+
+        d_level_w = 25 * Factor;
+        d_level_h = 7 * Factor;
+        d_level_y = d_count_y + d_count_h;
+        d_level_x = d_playerlist_x + (d_playerlist_w / 2) + 20 * Factor; // fudged
+
+        d_credits_w = 25 * Factor;
+        d_credits_h = 7 * Factor;
+        d_credits_x = d_playerlist_x + (d_playerlist_w / 2) + 20 * Factor; // fudged;
+        d_credits_y = d_level_y + d_level_h;
+
+        d_tiberiumscale_w = 25 * Factor;
+        d_tiberiumscale_h = 7 * Factor;
+        d_tiberiumscale_x = d_playerlist_x + (d_playerlist_w / 2) + 20 * Factor; // fudged;
+        d_tiberiumscale_y = d_credits_y + d_credits_h;
+
+        ColorBoxes[0] = d_color_x;
+        ColorBoxes[1] = d_color_x + d_color_w;
+        ColorBoxes[2] = d_color_x + (d_color_w * 2);
+        ColorBoxes[3] = d_color_x + (d_color_w * 3);
+        ColorBoxes[4] = d_color_x + (d_color_w * 4);
+        ColorBoxes[5] = d_color_x + (d_color_w * 5);
+    }
+
+public:
+    SkirmishScenarioDialog(const int factor)
+    {
+        Factor = factor;
+        UpButtonShape = nullptr;
+        DownButtonShape = nullptr;
+        CommandChain = nullptr;
+    }
+
+    ~SkirmishScenarioDialog()
+    {
+        if (!Controls.contains(BUTTON_SCENARIOLIST) || Controls[BUTTON_SCENARIOLIST].get() == nullptr) {
+            return;
+        }
+
+        auto& scenario_list = Get_Control<ListClass>(BUTTON_SCENARIOLIST);
+
+        while (scenario_list.Count()) {
+            // free dynamically allocated strings
+            scenario_list.Remove_Item(scenario_list.Get_Item(0));
+        }
+    }
+
+    void Init(const int screen_width, const int screen_height)
+    {
+        Init_Dimensions(screen_width, screen_height);
+        Init_Shapes();
+        Init_Controls();
+        Init_Data();
+        Init_UI_State();
+    }
+
+    bool Present()
+    {
+        auto display = REDRAW_ALL; // redraw level
+
+        while (true) {
+            /*
+            ** If we have just received input focus again after running in the background then
+            ** we need to redraw.
+            */
+            if (AllSurfaces.SurfacesRestored) {
+                AllSurfaces.SurfacesRestored = false;
+                display = REDRAW_ALL;
+            }
+
+            /*
+            ........................ Invoke game callback .........................
+            */
+            Call_Back();
+
+            /*
+            ...................... Refresh display if needed ......................
+            */
+            Render(display);
+
+            /*
+            ........................... Get user input ............................
+            */
+            auto& house_dropdown = Get_Control<DropListClass>(BUTTON_HOUSE);
+            const bool droplist_is_dropped = house_dropdown.IsDropped;
+            std::vector<ButtonType> ai_diffs_collapsed;
+            std::vector<ButtonType> ai_houses_collapsed;
+
+            for (auto control = BUTTON_AI_DIFF_1; control <= BUTTON_AI_DIFF_5; ++control) {
+                if (Get_Control<DropListClass>(control).IsDropped) {
+                    ai_diffs_collapsed.emplace_back(control);
+                }
+
+                const auto house_btn = static_cast<ButtonType>(control + 5);
+
+                if (Get_Control<DropListClass>(house_btn).IsDropped) {
+                    ai_houses_collapsed.emplace_back(house_btn);
+                }
+            }
+
+            auto input = CommandChain->Input();
+
+            /*
+            ** Redraw everything if the player house droplist collapsed
+            */
+            if (droplist_is_dropped && !house_dropdown.IsDropped) {
+                display = REDRAW_BACKGROUND;
+            }
+
+            /*
+            ** Redraw everything if an AI house droplist collapsed
+            */
+            for (const auto& control: ai_diffs_collapsed) {
+                if (!Get_Control<DropListClass>(control).IsDropped) {
+                    display = REDRAW_BACKGROUND;
+                }
+            }
+
+            for (const auto& control: ai_houses_collapsed) {
+                if (!Get_Control<DropListClass>(control).IsDropped) {
+                    display = REDRAW_BACKGROUND;
+                }
+            }
+
+            const auto collapse_visible_dropdowns = [&]() {
+                if (house_dropdown.IsDropped) {
+                    house_dropdown.Collapse();
+                    display = REDRAW_BACKGROUND;
+                }
+
+                for (auto control = BUTTON_AI_DIFF_1; control <= BUTTON_AI_DIFF_5; ++control) {
+                    const auto house_btn = static_cast<ButtonType>(control + 5);
+                    auto& diff_dropdown = Get_Control<DropListClass>(control);
+                    auto& house_dropdown = Get_Control<DropListClass>(house_btn);
+
+                    if (diff_dropdown.IsDropped) {
+                        diff_dropdown.Collapse();
+                        display = REDRAW_BACKGROUND;
+                    }
+
+                    if (house_dropdown.IsDropped) {
+                        house_dropdown.Collapse();
+                        display = REDRAW_BACKGROUND;
+                    }
+                }
+            };
+
+            if (input & KN_BUTTON) {
+                // user is interacting with a button, so hide dropdown lists
+                collapse_visible_dropdowns();
+            }
+
+            // for any visible AI house dropdown, if mouse input is received outside it's bounds, hide it
+            for (auto control = BUTTON_AI_DIFF_1; control <= BUTTON_AI_DIFF_5; ++control) {
+                const auto house_btn = static_cast<ButtonType>(control + 5);
+                auto& diff_dropdown = Get_Control<DropListClass>(control);
+                auto& house_dropdown = Get_Control<DropListClass>(house_btn);
+
+                if (diff_dropdown.IsDropped) {
+                    if ((Keyboard->MouseQX < diff_dropdown.X || Keyboard->MouseQX > diff_dropdown.X + diff_dropdown.Width)
+                    && (Keyboard->MouseQY < diff_dropdown.Y || Keyboard->MouseQY > diff_dropdown.Y + diff_dropdown.Height)) {
+                        diff_dropdown.Collapse();
+                        display = REDRAW_BACKGROUND;
+                    }
+                }
+
+                if (house_dropdown.IsDropped) {
+                    if ((Keyboard->MouseQX < house_dropdown.X || Keyboard->MouseQX > house_dropdown.X + house_dropdown.Width)
+                    && (Keyboard->MouseQY < house_dropdown.Y || Keyboard->MouseQY > house_dropdown.Y + house_dropdown.Height)) {
+                        house_dropdown.Collapse();
+                        display = REDRAW_BACKGROUND;
+                    }
+                }
+            }
+
+            /*
+            ---------------------------- Process input ----------------------------
+            */
+            switch (input) {
+                /*------------------------------------------------------------------
+                User clicks on a color button
+                ------------------------------------------------------------------*/
+                case KN_LMOUSE:
+                    if (Keyboard->MouseQX > ColorBoxes[0] && Keyboard->MouseQX < (ColorBoxes[MAX_MPLAYER_COLORS - 1] + d_color_w)
+                        && Keyboard->MouseQY > d_color_y && Keyboard->MouseQY < (d_color_y + d_color_h)) {
+                        MPlayerPrefColor = (Keyboard->MouseQX - ColorBoxes[0]) / d_color_w;
+                        MPlayerColorIdx = MPlayerPrefColor;
+                        display = REDRAW_COLORS;
+
+                        auto& name_edt = Get_Control<EditClass>(BUTTON_NAME);
+
+                        name_edt.Set_Color(MPlayerTColors[MPlayerColorIdx]);
+                        name_edt.Flag_To_Redraw();
+                        strcpy(MPlayerName, Text[BUTTON_NAME].get());
+
+                        collapse_visible_dropdowns();
+                    }
+                    break;
+
+                    /*------------------------------------------------------------------
+                    User edits the name field; retransmit new game options
+                    ------------------------------------------------------------------*/
+                case (BUTTON_NAME | KN_BUTTON): {
+                    strcpy(MPlayerName, Text[BUTTON_NAME].get());
+                    collapse_visible_dropdowns();
+                    break;
+                }
+
+                    /*------------------------------------------------------------------
+                    House Buttons: set the player's desired House
+                    ------------------------------------------------------------------*/
+                case (BUTTON_HOUSE | KN_BUTTON): {
+                    MPlayerHouse = HousesType(house_dropdown.Current_Index() + HOUSE_GOOD);
+                    strcpy(MPlayerName, Text[BUTTON_NAME].get());
+
+                    collapse_visible_dropdowns();
+
+                    display = REDRAW_BACKGROUND;
+                    break;
+                }
+
+                    /*------------------------------------------------------------------
+                    New Scenario selected.
+                    ------------------------------------------------------------------*/
+                case (BUTTON_SCENARIOLIST | KN_BUTTON): {
+                    auto& scenariolist = Get_Control<ListClass>(BUTTON_SCENARIOLIST);
+                    if (scenariolist.Current_Index() != ScenarioIdx) {
+                        ScenarioIdx = scenariolist.Current_Index();
+
+                        // store the scenario number rather than current scenario list index
+                        // (index will change if maps are added/removed by player)
+                        MPlayerScenarioNumber = MPlayerFilenum[ScenarioIdx];
+
+                        strcpy(MPlayerName, Text[BUTTON_NAME].get());
+                    }
+                    break;
+                }
+
+                    /*------------------------------------------------------------------
+                    AI player difficulty dropdown selection changed.
+                    ------------------------------------------------------------------*/
+                case (BUTTON_AI_DIFF_1 | KN_BUTTON):
+                case (BUTTON_AI_DIFF_2 | KN_BUTTON):
+                case (BUTTON_AI_DIFF_3 | KN_BUTTON):
+                case (BUTTON_AI_DIFF_4 | KN_BUTTON):
+                case (BUTTON_AI_DIFF_5 | KN_BUTTON): {
+                    for (auto control = BUTTON_AI_DIFF_1; control <= BUTTON_AI_DIFF_5; ++control) {
+                        if (input != (control | KN_BUTTON)) {
+                            continue;
+                        }
+
+                        const auto house_btn = static_cast<ButtonType>(control + 5);
+                        auto& diff_dropdown = Get_Control<DropListClass>(control);
+                        auto& house_dropdown = Get_Control<DropListClass>(house_btn);
+
+                        // nothing changed, ignore input
+                        if (!diff_dropdown.List.Index_Changed()) {
+                            break;
+                        }
+
+                        const auto diff_was_disabled = diff_dropdown.Current_Index() == 0;
+                        const auto diff_was_activated = diff_dropdown.List.Get_Previous_Index() == 0;
+                        const auto house_is_disabled = house_dropdown.Current_Index() == 0;
+
+                        if (diff_was_disabled) {
+                            // reset house to match disabled AI diff
+                            house_dropdown.Set_Selected_Index(0);
+                        } else if (diff_was_activated && house_is_disabled) {
+                            // select a default house of '?' since none is selected
+                            house_dropdown.Set_Selected_Index(1);
+                        }
+
+                        diff_dropdown.Collapse();
+                        house_dropdown.Collapse();
+                        display = REDRAW_BACKGROUND;
+                        break;
+                    }
+
+                    break;
+                }
+
+                    /*------------------------------------------------------------------
+                    AI player house dropdown selection changed.
+                    ------------------------------------------------------------------*/
+                case (BUTTON_AI_HOUSE_1 | KN_BUTTON):
+                case (BUTTON_AI_HOUSE_2 | KN_BUTTON):
+                case (BUTTON_AI_HOUSE_3 | KN_BUTTON):
+                case (BUTTON_AI_HOUSE_4 | KN_BUTTON):
+                case (BUTTON_AI_HOUSE_5 | KN_BUTTON): {
+                    for (auto control = BUTTON_AI_HOUSE_1; control <= BUTTON_AI_HOUSE_5; ++control) {
+                        if (input != (control | KN_BUTTON)) {
+                            continue;
+                        }
+
+                        const auto diff_btn = static_cast<ButtonType>(control - 5);
+                        auto& diff_dropdown = Get_Control<DropListClass>(diff_btn);
+                        auto& house_dropdown = Get_Control<DropListClass>(control);
+
+                        // nothing changed, ignore input
+                        if (!house_dropdown.List.Index_Changed()) {
+                            break;
+                        }
+
+                        const auto house_was_disabled = house_dropdown.Current_Index() == 0;
+                        const auto house_was_activated = house_dropdown.List.Get_Previous_Index() == 0;
+                        const auto diff_is_disabled = diff_dropdown.Current_Index() == 0;
+
+                        if (house_was_disabled) {
+                            // reset diff to match disabled AI house
+                            diff_dropdown.Set_Selected_Index(0);
+                        } else if (house_was_activated && diff_is_disabled) {
+                            // select a default diff of 'Normal' since none is selected
+                            diff_dropdown.Set_Selected_Index(2);
+                        }
+
+                        house_dropdown.Collapse();
+                        diff_dropdown.Collapse();
+                        display = REDRAW_BACKGROUND;
+                    }
+
+                    break;
+                }
+
+                /*------------------------------------------------------------------
+                User adjusts max # units
+                ------------------------------------------------------------------*/
+                case (BUTTON_COUNT | KN_BUTTON): {
+                    MPlayerUnitCount = Get_Control<GaugeClass>(BUTTON_COUNT).Get_Value()
+                        + MPlayerCountMin[MPlayerBases];
+                    if (display < REDRAW_MESSAGE) {
+                        display = REDRAW_MESSAGE;
+                    }
+                    collapse_visible_dropdowns();
+                    break;
+                }
+
+                /*------------------------------------------------------------------
+                User adjusts build level
+                ------------------------------------------------------------------*/
+                case (BUTTON_LEVEL | KN_BUTTON): {
+                    BuildLevel = Get_Control<GaugeClass>(BUTTON_LEVEL).Get_Value() + 1;
+                    if (BuildLevel > MPLAYER_BUILD_LEVEL_MAX) // if it's pegged, max it out
+                        BuildLevel = MPLAYER_BUILD_LEVEL_MAX;
+                    if (display < REDRAW_MESSAGE) {
+                        display = REDRAW_MESSAGE;
+                    }
+                    collapse_visible_dropdowns();
+                    break;
+                }
+
+                /*------------------------------------------------------------------
+                User edits the credits value; retransmit new game options
+                ------------------------------------------------------------------*/
+                case (BUTTON_CREDITS | KN_BUTTON): {
+                    MPlayerCredits = Get_Control<GaugeClass>(BUTTON_CREDITS).Get_Value();
+
+                    if (MPlayerCredits == 0) {
+                        // clear lingering digits when player quickly slides to zero
+                        display = REDRAW_ALL;
+                    }
+
+                    if (display < REDRAW_MESSAGE) {
+                        display = REDRAW_MESSAGE;
+                    }
+                    collapse_visible_dropdowns();
+                    break;
+                }
+
+                case (BUTTON_TIBERIUMSCALE | KN_BUTTON): {
+                    MPlayerTiberium = Get_Control<GaugeClass>(BUTTON_TIBERIUMSCALE).Get_Value() + 1;
+
+                    Get_Control<CheckListClass>(BUTTON_OPTIONS).Check_Item(1, MPlayerTiberium > 0);
+
+                    Special.IsTGrowth = MPlayerTiberium;
+                    Special.IsTSpread = MPlayerTiberium;
+
+                    if (display < REDRAW_MESSAGE)
+                        display = REDRAW_MESSAGE;
+
+                    collapse_visible_dropdowns();
+                    break;
+                }
+
+                /*------------------------------------------------------------------
+                Toggle-able options:
+                If 'Bases' gets toggled, we have to change the range of the
+                UnitCount slider.
+                Also, if Tiberium gets toggled, we have to set the flags
+                in SpecialClass.
+                ------------------------------------------------------------------*/
+                case (BUTTON_OPTIONS | KN_BUTTON): {
+                    auto& optionlist = Get_Control<CheckListClass>(BUTTON_OPTIONS);
+                    auto countgauge = Get_Control<GaugeClass>(BUTTON_COUNT);
+                    auto tiberiumscalegauge = Get_Control<GaugeClass>(BUTTON_TIBERIUMSCALE);
+
+                    if (MPlayerBases != optionlist.Is_Checked(0)) {
+                        MPlayerBases = optionlist.Is_Checked(0);
+                        if (MPlayerBases) {
+                            MPlayerUnitCount = Fixed_To_Cardinal(MPlayerCountMax[1] - MPlayerCountMin[1],
+                                                                 Cardinal_To_Fixed(MPlayerCountMax[0] - MPlayerCountMin[0],
+                                                                                   MPlayerUnitCount - MPlayerCountMin[0]))
+                                               + MPlayerCountMin[1];
+                        } else {
+                            MPlayerUnitCount = Fixed_To_Cardinal(MPlayerCountMax[0] - MPlayerCountMin[0],
+                                                                 Cardinal_To_Fixed(MPlayerCountMax[1] - MPlayerCountMin[1],
+                                                                                   MPlayerUnitCount - MPlayerCountMin[1]))
+                                               + MPlayerCountMin[0];
+                        }
+                        countgauge.Set_Maximum(MPlayerCountMax[MPlayerBases] - MPlayerCountMin[MPlayerBases]);
+                        countgauge.Set_Value(MPlayerUnitCount - MPlayerCountMin[MPlayerBases]);
+                    }
+                    MPlayerTiberium = optionlist.Is_Checked(1) ? 1 : 0;
+
+                    if (tiberiumscalegauge.Get_Value() + 1 > 1) {
+                        MPlayerTiberium = tiberiumscalegauge.Get_Value() + 1;
+                    }
+
+                    tiberiumscalegauge.Set_Value(MPlayerTiberium < 2 ? 0 : MPlayerTiberium - 1);
+
+                    Special.IsTGrowth = MPlayerTiberium;
+                    Special.IsTSpread = MPlayerTiberium;
+
+                    MPlayerGoodies = optionlist.Is_Checked(2);
+                    Special.IsCaptureTheFlag = optionlist.Is_Checked(3);
+
+                    if (display < REDRAW_MESSAGE)
+                        display = REDRAW_MESSAGE;
+
+                    collapse_visible_dropdowns();
+                    break;
+                }
+
+                /*------------------------------------------------------------------
+                OK: exit loop with true status
+                ------------------------------------------------------------------*/
+                case (BUTTON_OK | KN_BUTTON): {
+                    // check if at least one AI player enabled
+                    auto ai_players = false;
+
+                    for (auto button = BUTTON_AI_DIFF_1; button <= BUTTON_AI_DIFF_5; ++button) {
+                        if (Get_Control<DropListClass>(button).Current_Index() > 0) {
+                            ai_players = true;
+                            break;
+                        }
+                    }
+
+                    if (ai_players) {
+                        // at least one AI player enabled, allow user to proceed
+                        return true;
+                    }
+
+                    // warn that no AI players are enabled
+                    WWMessageBox().Process(TXT_ONLY_ONE, TXT_OOPS);
+                    display = REDRAW_ALL;
+                    break;
+                }
+
+                /*------------------------------------------------------------------
+                CANCEL: send a SIGN_OFF, bail out with error code
+                ------------------------------------------------------------------*/
+                case (KN_ESC): {
+                    if (Messages.Get_Edit_Buf() != NULL) {
+                        Messages.Input(input);
+                        if (display < REDRAW_MESSAGE)
+                            display = REDRAW_MESSAGE;
+                        break;
+                    }
+                }
+                case (BUTTON_CANCEL | KN_BUTTON): return false;
+
+                default: break;
+            } /* end of input processing */
+
+            Frame_Limiter();
+        }
+    }
+
+    void Apply_Skirmish_Settings()
+    {
+        /*.....................................................................
+        Set the number of players in this game, and my ID
+        .....................................................................*/
+        MPlayerCount = 1;
+        MPlayerLocalID = Build_MPlayerID(MPlayerColorIdx, MPlayerHouse);
+
+        /*.....................................................................
+        Store every player's ID in the MPlayerID[] array.  This array will
+        determine the order of event execution, so the ID's must be stored
+        in the same order on all systems.
+        .....................................................................*/
+        MPlayerID[0] = MPlayerLocalID;
+        strcpy(MPlayerName, Text[BUTTON_NAME].get());
+        strcpy(MPlayerNames[0], MPlayerName);
+
+        /*.....................................................................
+        Get the scenario filename
+        .....................................................................*/
+        Scen.Scenario = MPlayerFilenum[ScenarioIdx];
+
+        int diff = Get_Control<SliderClass>(BUTTON_DIFFICULTY).Get_Value() * (Rule.IsFineDifficulty ? 1 : 2);
+        switch (diff) {
+        case 0:
+            Scen.CDifficulty = DIFF_HARD;
+            Scen.Difficulty = DIFF_EASY;
+            break;
+
+        case 1:
+            Scen.CDifficulty = DIFF_HARD;
+            Scen.Difficulty = DIFF_NORMAL;
+            break;
+
+        case 2:
+            Scen.CDifficulty = DIFF_NORMAL;
+            Scen.Difficulty = DIFF_NORMAL;
+            break;
+
+        case 3:
+            Scen.CDifficulty = DIFF_EASY;
+            Scen.Difficulty = DIFF_NORMAL;
+            break;
+
+        case 4:
+            Scen.CDifficulty = DIFF_EASY;
+            Scen.Difficulty = DIFF_HARD;
+            break;
+        }
+
+        // set AI player variables from difficulty/house dropdowns
+        MPlayerGhosts = 0;
+
+        for (auto control = BUTTON_AI_DIFF_1; control <= BUTTON_AI_DIFF_5; ++control) {
+            const auto house_btn = static_cast<ButtonType>(control + 5);
+            auto& diff_dropdown = Get_Control<DropListClass>(control);
+            auto& house_dropdown = Get_Control<DropListClass>(house_btn);
+
+            // skip disabled slots
+            if (diff_dropdown.Current_Index() == 0) {
+                continue;
+            }
+
+            // populate 'slot' with correct difficulty and house overrides
+            const auto selected_diff_idx = diff_dropdown.Current_Index();
+            const auto selected_house_idx = house_dropdown.Current_Index();
+
+            const auto selected_diff = selected_diff_idx == 0
+                ? DIFF_NONE
+                : static_cast<DiffType>(selected_diff_idx - 1);
+            const auto selected_house = selected_house_idx < 2
+                ? HOUSE_NONE
+                : static_cast<HousesType>(selected_house_idx - 2);
+
+            MPlayerHouses[MPlayerGhosts + 1] = selected_house;
+            MPlayerDifficulty[MPlayerGhosts + 1] = selected_diff;
+
+            MPlayerGhosts++;
+        }
+    }
+};
 
 /***********************************************************************************************
  * Com_Scenario_Dialog -- Serial game scenario selection dialog                                *
@@ -83,430 +1418,12 @@
 #define TXT_JOIN_INTERNET_GAME 4567 + 2
 int Com_Scenario_Dialog(void)
 {
-    int factor = (SeenBuff.Get_Width() == 320) ? 1 : 2;
-    /*........................................................................
-    Dialog & button dimensions
-    ........................................................................*/
-    int d_dialog_w = 300 * factor;                      // dialog width
-    int d_dialog_h = 195 * factor;                      // dialog height
-    int d_dialog_x = ((Try_Get_Resolution_Mode_Width().value_or(SeenBuff.Get_Width()) - d_dialog_w) / 2); // dialog x-coord
-    int d_dialog_y = ((Try_Get_Resolution_Mode_Height().value_or(SeenBuff.Get_Height()) - d_dialog_h) / 2); // dialog y-coord
-    int d_dialog_cx = d_dialog_x + (d_dialog_w / 2);    // center x-coord
+    const auto factor = (SeenBuff.Get_Width() == 320) ? 1 : 2;
+    const auto width = Try_Get_Resolution_Mode_Width().value_or(SeenBuff.Get_Width());
+    const auto height = Try_Get_Resolution_Mode_Height().value_or(SeenBuff.Get_Height());
 
-    int d_txt6_h = 6 * factor + 1; // ht of 6-pt text
-    int d_margin1 = 10 * factor;    // margin width/height
-    int d_margin2 = 4 * factor;    // margin width/height
-
-    int d_ok_w = 45 * factor;
-    int d_ok_h = 9 * factor;
-    int d_ok_x = d_dialog_x + (d_dialog_w / 6) - (d_ok_w / 2);
-    int d_ok_y = d_dialog_y + d_dialog_h - d_ok_h - d_margin1 - factor * 6;
-
-    int d_cancel_w = 45 * factor;
-    int d_cancel_h = 9 * factor;
-    int d_cancel_x = d_dialog_x + d_dialog_w - (d_dialog_w / 6) - (d_cancel_w / 2) /*d_dialog_cx - (d_cancel_w / 2)*/;
-    int d_cancel_y = d_dialog_y + d_dialog_h - d_cancel_h - d_margin1 - factor * 6;
-
-    int d_name_w = 70 * factor;
-    int d_name_h = 9 * factor;
-    int d_name_x = d_dialog_x + 5 + (d_dialog_w / 4) - (d_name_w / 2);
-    int d_name_y = d_dialog_y + d_margin2 + d_txt6_h + 1 * factor;
-
-    int d_house_w = 60 * factor;
-    int d_house_h = (3 * 5 * factor);
-    int d_house_x = d_dialog_cx - (d_house_w / 2);
-    int d_house_y = d_name_y;
-
-    int d_color_w = 10 * factor;
-    int d_color_h = 9 * factor;
-    int d_color_y = d_name_y;
-    int d_color_x = d_dialog_x + ((d_dialog_w / 4) * 3) - (d_color_w * 3);
-
-    int d_playerlist_w = 118 * factor;
-    int d_playerlist_x = d_dialog_x + d_margin1 + d_margin1 + 5 * factor;
-
-    int d_scenariolist_w = 140 * factor;
-    int d_scenariolist_h = 30 * factor;
-    int d_scenariolist_x = (d_cancel_x + static_cast<int>(nearbyint(d_cancel_w * 0.8))) - d_scenariolist_w + (20 * factor);
-    int d_scenariolist_y = d_color_y + d_txt6_h + 5 * factor + d_txt6_h;
-    d_scenariolist_h *= 2;
-
-    int d_aihouse_w = static_cast<int>(nearbyint(d_house_w / 1.75));
-    int d_aihouse_h = (6 * 5 * factor);
-    int d_aihouse_x = d_scenariolist_x - d_aihouse_w - (10 * factor);
-    int d_aihouse_y = d_scenariolist_y + (5 * factor);
-    int d_aihouse_ystep = 10 * factor;
-
-    int d_options_w = static_cast<int>(nearbyint(d_scenariolist_w * 0.8));
-    int d_options_h = (5 * 6 * factor) + 5 * factor;
-    int d_options_x = (d_scenariolist_x + d_scenariolist_w) - d_options_w;
-    int d_options_y = d_scenariolist_y + d_scenariolist_h + d_margin1 - 2 * factor;
-
-    int d_count_w = 25 * factor;
-    int d_count_h = 7 * factor;
-    int d_count_y = d_options_y;
-    int d_count_x = d_playerlist_x + (d_playerlist_w / 2) + 20 * factor; // fudged
-
-    int d_level_w = 25 * factor;
-    int d_level_h = 7 * factor;
-    int d_level_y = d_count_y + d_count_h;
-    int d_level_x = d_playerlist_x + (d_playerlist_w / 2) + 20 * factor; // fudged
-
-    int d_credits_w = 25 * factor;
-    int d_credits_h = 7 * factor;
-    int d_credits_x = d_playerlist_x + (d_playerlist_w / 2) + 20 * factor; // fudged;
-    int d_credits_y = d_level_y + d_level_h;
-
-    int d_tiberiumscale_w = 25 * factor;
-    int d_tiberiumscale_h = 7 * factor;
-    int d_tiberiumscale_x = d_playerlist_x + (d_playerlist_w / 2) + 20 * factor; // fudged;
-    int d_tiberiumscale_y = d_credits_y + d_credits_h;
-
-    /*........................................................................
-    Button Enumerations
-    ........................................................................*/
-    enum
-    {
-        BUTTON_NAME = 100,
-        BUTTON_HOUSE,
-        BUTTON_AI_DIFF_1,
-        BUTTON_AI_DIFF_2,
-        BUTTON_AI_DIFF_3,
-        BUTTON_AI_DIFF_4,
-        BUTTON_AI_DIFF_5,
-        BUTTON_AI_HOUSE_1,
-        BUTTON_AI_HOUSE_2,
-        BUTTON_AI_HOUSE_3,
-        BUTTON_AI_HOUSE_4,
-        BUTTON_AI_HOUSE_5,
-        BUTTON_CREDITS,
-        BUTTON_TIBERIUMSCALE,
-        BUTTON_OPTIONS,
-        BUTTON_SCENARIOLIST,
-        BUTTON_COUNT,
-        BUTTON_LEVEL,
-        BUTTON_OK,
-        BUTTON_LOAD,
-        BUTTON_CANCEL,
-        BUTTON_DIFFICULTY,
-    };
-
-    /*........................................................................
-    Redraw values: in order from "top" to "bottom" layer of the dialog
-    ........................................................................*/
-    typedef enum
-    {
-        REDRAW_NONE = 0,
-        REDRAW_MESSAGE,
-        REDRAW_COLORS,
-        REDRAW_BUTTONS,
-        REDRAW_BACKGROUND,
-        REDRAW_ALL = REDRAW_BACKGROUND
-    } RedrawType;
-
-    /*........................................................................
-    Dialog variables
-    ........................................................................*/
-    RedrawType display = REDRAW_ALL; // redraw level
-    bool process = true;             // process while true
-    KeyNumType input;
-
-    int optiontabs[] = {8};               // tabs for player list box
-    char namebuf[MPLAYER_NAME_MAX] = {0}; // buffer for player's name
-    int cbox_x[] = {d_color_x,
-                    d_color_x + d_color_w,
-                    d_color_x + (d_color_w * 2),
-                    d_color_x + (d_color_w * 3),
-                    d_color_x + (d_color_w * 4),
-                    d_color_x + (d_color_w * 5)};
-
-    int rc;
-    int i;
-    char txt[80];
-    static bool first_time = true;
-    bool gameoptions = GameToPlay == GAME_SKIRMISH;
-
-    bool ready_to_go = false;
-    CountDownTimerClass ready_time;
-
-    void const* up_button;
-    void const* down_button;
-
-    if (InMainLoop || factor == 1) {
-        up_button = Hires_Retrieve("BTN-UP.SHP");
-        down_button = Hires_Retrieve("BTN-DN.SHP");
-    } else {
-        up_button = Hires_Retrieve("BTN-UP2.SHP");
-        down_button = Hires_Retrieve("BTN-DN2.SHP");
-    }
-
-    /*........................................................................
-    Buttons
-    ........................................................................*/
-    GadgetClass* commands; // button list
-
-    EditClass name_edt(BUTTON_NAME,
-                       namebuf,
-                       MPLAYER_NAME_MAX,
-                       TPF_6PT_GRAD | TPF_USE_GRAD_PAL | TPF_NOSHADOW,
-                       d_name_x,
-                       d_name_y,
-                       d_name_w,
-                       d_name_h,
-                       EditClass::ALPHANUMERIC);
-
-    char housetext[25] = "";
-    Fancy_Text_Print("", 0, 0, 0, 0, TPF_6PT_GRAD | TPF_USE_GRAD_PAL | TPF_NOSHADOW);
-    DropListClass housebtn(BUTTON_HOUSE,
-                           housetext,
-                           sizeof(housetext),
-                           TPF_6PT_GRAD | TPF_USE_GRAD_PAL | TPF_NOSHADOW,
-                           d_house_x,
-                           d_house_y,
-                           d_house_w,
-                           d_house_h,
-                           up_button,
-                           down_button);
-
-    // dropdowns for AI player options
-    std::vector<std::unique_ptr<char[]>> ai_diff_strings(5);
-    std::vector<DropListClass> ai_diff_dropdowns;
-    std::vector<std::unique_ptr<char[]>> ai_house_strings(5);
-    std::vector<DropListClass> ai_house_dropdowns;
-
-    auto cur_ai_house_y = d_aihouse_y;
-
-    for (auto h = BUTTON_AI_DIFF_1; h <= BUTTON_AI_DIFF_5; ++h) {
-        constexpr auto label_str_length = 25;
-        ai_diff_strings.emplace_back() = std::make_unique<char[]>(label_str_length);
-        ai_house_strings.emplace_back() = std::make_unique<char[]>(label_str_length);
-
-        ai_diff_dropdowns.emplace_back(
-            h,
-            ai_diff_strings.back().get(),
-            label_str_length,
-            TPF_6PT_GRAD | TPF_USE_GRAD_PAL | TPF_NOSHADOW,
-            d_aihouse_x - static_cast<int>(nearbyint(d_aihouse_w * 1.5)) - (10 * factor),
-            cur_ai_house_y,
-            static_cast<int>(nearbyint(d_aihouse_w * 1.5)),
-            d_aihouse_h,
-            up_button,
-            down_button
-        );
-
-        ai_house_dropdowns.emplace_back(
-            h + 5,
-            ai_house_strings.back().get(),
-            label_str_length,
-            TPF_6PT_GRAD | TPF_USE_GRAD_PAL | TPF_NOSHADOW,
-            d_aihouse_x,
-            cur_ai_house_y,
-            d_aihouse_w,
-            d_aihouse_h,
-            up_button,
-            down_button
-        );
-
-        cur_ai_house_y += d_aihouse_ystep;
-    }
-
-    ListClass scenariolist(BUTTON_SCENARIOLIST,
-                           d_scenariolist_x,
-                           d_scenariolist_y,
-                           d_scenariolist_w,
-                           d_scenariolist_h,
-                           TPF_6PT_GRAD | TPF_USE_GRAD_PAL | TPF_NOSHADOW,
-                           up_button,
-                           down_button);
-
-    GaugeClass countgauge(BUTTON_COUNT, d_count_x, d_count_y, d_count_w, d_count_h);
-
-    GaugeClass levelgauge(BUTTON_LEVEL, d_level_x, d_level_y, d_level_w, d_level_h);
-
-    GaugeClass creditsgauge(BUTTON_CREDITS, d_credits_x, d_credits_y, d_credits_w, d_credits_h);
-
-    GaugeClass tiberiumscalegauge(BUTTON_TIBERIUMSCALE, d_tiberiumscale_x, d_tiberiumscale_y, d_tiberiumscale_w, d_tiberiumscale_h);
-
-    CheckListClass optionlist(BUTTON_OPTIONS,
-                              d_options_x,
-                              d_options_y,
-                              d_options_w,
-                              d_options_h,
-                              TPF_6PT_GRAD | TPF_USE_GRAD_PAL | TPF_NOSHADOW,
-                              up_button,
-                              down_button);
-
-    TextButtonClass okbtn(
-        BUTTON_OK, TXT_OK, TPF_CENTER | TPF_6PT_GRAD | TPF_USE_GRAD_PAL | TPF_NOSHADOW, d_ok_x, d_ok_y, d_ok_w, d_ok_h);
-
-    TextButtonClass cancelbtn(BUTTON_CANCEL,
-                              TXT_CANCEL,
-                              TPF_CENTER | TPF_6PT_GRAD | TPF_USE_GRAD_PAL | TPF_NOSHADOW,
-                              d_cancel_x,
-                              d_cancel_y,
-                              d_cancel_w,
-                              d_cancel_h);
-
-    SliderClass difficulty(BUTTON_DIFFICULTY,
-                           d_name_x,
-                           d_ok_y - (8 * factor) - d_margin1,
-                           d_dialog_w - (d_name_x - d_dialog_x) * 2,
-                           8 * factor,
-                           true);
-    if (Rule.IsFineDifficulty) {
-        difficulty.Set_Maximum(5);
-        difficulty.Set_Value(2);
-    } else {
-        difficulty.Set_Maximum(3);
-        difficulty.Set_Value(1);
-    }
-
-    /*
-    ------------------------- Build the button list --------------------------
-    */
-    commands = &name_edt;
-    difficulty.Add_Tail(*commands);
-    scenariolist.Add_Tail(*commands);
-
-    for (auto& dropdown : ai_diff_dropdowns) {
-        dropdown.Add_Tail(*commands);
-    }
-
-    for (auto& dropdown : ai_house_dropdowns) {
-        dropdown.Add_Tail(*commands);
-    }
-
-    countgauge.Add_Tail(*commands);
-    levelgauge.Add_Tail(*commands);
-    creditsgauge.Add_Tail(*commands);
-    tiberiumscalegauge.Add_Tail(*commands);
-    optionlist.Add_Tail(*commands);
-    okbtn.Add_Tail(*commands);
-    cancelbtn.Add_Tail(*commands);
-    housebtn.Add_Tail(*commands);
-
-    /*
-    ----------------------------- Various Inits ------------------------------
-    */
-    /*........................................................................
-    Init player name & house
-    ........................................................................*/
-    MPlayerColorIdx = MPlayerPrefColor; // init my preferred color
-    strcpy(namebuf, MPlayerName);       // set my name
-    name_edt.Set_Text(namebuf, MPLAYER_NAME_MAX);
-    name_edt.Set_Color(MPlayerTColors[MPlayerColorIdx]);
-
-    // TODO: Add mystery option ? (random house selection)
-    housebtn.Add_Item(Text_String(TXT_G_D_I));
-    housebtn.Add_Item(Text_String(TXT_N_O_D));
-    // TODO: Add dinosaur support (no bases ONLY)
-    housebtn.Set_Selected_Index(MPlayerHouse - HOUSE_GOOD);
-    housebtn.Set_Read_Only(true);
-
-    if (MPlayerGhosts > 5) {
-        MPlayerGhosts = 5;
-    }
-    MPlayerGhosts = max(MPlayerGhosts, 1);
-
-    for (auto idx = 0; idx < ai_diff_dropdowns.size(); idx++) {
-        ai_diff_dropdowns[idx].Add_Item("Disabled"); // TODO: Locale file entries
-        ai_diff_dropdowns[idx].Add_Item("Easy");
-        ai_diff_dropdowns[idx].Add_Item("Normal");
-        ai_diff_dropdowns[idx].Add_Item("Hard");
-        ai_diff_dropdowns[idx].Set_Selected_Index(idx < MPlayerGhosts ? 2 : 0);
-        ai_diff_dropdowns[idx].Set_Read_Only(true);
-
-        ai_house_dropdowns[idx].Add_Item("None"); // TODO: Locale file entries
-        ai_house_dropdowns[idx].Add_Item("?");
-        ai_house_dropdowns[idx].Add_Item(Text_String(TXT_G_D_I));
-        ai_house_dropdowns[idx].Add_Item(Text_String(TXT_N_O_D));
-        // TODO: Add dinosaur support (no bases ONLY)
-        ai_house_dropdowns[idx].Set_Selected_Index(idx < MPlayerGhosts ? 1 : 0);
-        ai_house_dropdowns[idx].Set_Read_Only(true);
-    }
-
-    /*........................................................................
-    Init scenario values, only the first time through
-    ........................................................................*/
-    if (first_time) {
-        // GB 2022 set defaults for skirmish also:
-        BuildLevel = 7;
-
-        // init credits & credit buffer
-        MPlayerCredits = Rule.Get_Rule_Value<int>(GAME_MULTIPLAYER_SECTION, START_CREDITS_DEFAULT_RULE);
-        MPlayerGhosts = 1;
-        MPlayerUnitCount = (MPlayerCountMax[MPlayerBases] + MPlayerCountMin[MPlayerBases]) / 2;
-        MPlayerTiberium = 1;
-        first_time = false;
-
-        for (auto& player_house : MPlayerHouses) {
-            player_house = HOUSE_NONE;
-        }
-
-        for (auto& player_difficulty : MPlayerDifficulty) {
-            player_difficulty = DIFF_NONE;
-        }
-    }
-
-    /*........................................................................
-    Init button states
-    ........................................................................*/
-    optionlist.Set_Tabs(optiontabs);
-    optionlist.Set_Read_Only(0);
-
-    optionlist.Add_Item(Text_String(TXT_BASES_ON));
-    optionlist.Add_Item("Tiberium Regrows"); // TODO: Locale file entry
-    optionlist.Add_Item(Text_String(TXT_CRATES_ON));
-    //optionlist.Add_Item(Text_String(TXT_SHADOW_REGROWS)); // TODO: Implement for TD? (copied from RA)
-    optionlist.Add_Item(Text_String(TXT_CAPTURE_THE_FLAG));
-
-    optionlist.Check_Item(0, MPlayerBases);
-    optionlist.Check_Item(1, MPlayerTiberium);
-    optionlist.Check_Item(2, MPlayerGoodies);
-    //optionlist.Check_Item(3, Special.IsShadowGrow);
-    optionlist.Check_Item(3, Special.IsCaptureTheFlag);
-
-    levelgauge.Set_Maximum(MPLAYER_BUILD_LEVEL_MAX - 1);
-    levelgauge.Set_Value(BuildLevel - 1);
-
-    countgauge.Set_Maximum(MPlayerCountMax[MPlayerBases] - MPlayerCountMin[MPlayerBases]);
-    countgauge.Set_Value(MPlayerUnitCount - MPlayerCountMin[MPlayerBases]);
-
-    creditsgauge.Set_Maximum(Rule.Get_Rule_Value<int>(GAME_MULTIPLAYER_SECTION, START_CREDITS_MAX_RULE));
-    creditsgauge.Set_Value(MPlayerCredits);
-
-    tiberiumscalegauge.Set_Maximum(4);
-    tiberiumscalegauge.Set_Value(MPlayerTiberium < 2 ? 0 : MPlayerTiberium - 1);
-
-    /*........................................................................
-    Init other scenario parameters
-    ........................................................................*/
-    Special.IsTGrowth = MPlayerTiberium;
-    Special.IsTSpread = MPlayerTiberium;
-    
-    /*........................................................................
-    Init scenario description list box
-    ........................................................................*/
-    for (i = 0; i < MPlayerScenarios.Count(); i++) {
-        scenariolist.Add_Item(strupr(MPlayerScenarios[i]));
-    }
-    ScenarioIdx = 0; // 1st scenario is selected
-
-    // select the last scenario chosen by the player (if present)
-    for (i = 0; i < MPlayerFilenum.Count(); i++) {
-        if (MPlayerFilenum[i] == MPlayerScenarioNumber) {
-            ScenarioIdx = i;
-            scenariolist.Set_Selected_Index(i);
-            break;
-        }
-    }
-
-    /*........................................................................
-    Init random-number generator, & create a seed to be used for all random
-    numbers from here on out
-    ........................................................................*/
-    srand((unsigned)time(NULL));
-    Seed = rand();
+    auto dialog = SkirmishScenarioDialog(factor);
+    dialog.Init(width, height);
 
     Load_Title_Screen(TitlePicture, &HidPage, Palette);
     Blit_Hid_Page_To_Seen_Buff();
@@ -515,711 +1432,10 @@ int Com_Scenario_Dialog(void)
     while (Get_Mouse_State() > 0)
         Show_Mouse();
 
-    while (process) {
+    const auto result = dialog.Present();
 
-        /*
-        ** If we have just received input focus again after running in the background then
-        ** we need to redraw.
-        */
-        if (AllSurfaces.SurfacesRestored) {
-            AllSurfaces.SurfacesRestored = false;
-            display = REDRAW_ALL;
-        }
-
-        /*
-        ........................ Invoke game callback .........................
-        */
-        Call_Back();
-
-        /*
-        ...................... Refresh display if needed ......................
-        */
-        if (display) {
-            Hide_Mouse();
-            /*
-            .................. Redraw backgound & dialog box ...................
-            */
-            if (display >= REDRAW_BACKGROUND) {
-                Dialog_Box(d_dialog_x, d_dialog_y, d_dialog_w, d_dialog_h);
-
-                // init font variables
-
-                Fancy_Text_Print(
-                    TXT_NONE, 0, 0, TBLACK, TBLACK, TPF_CENTER | TPF_6PT_GRAD | TPF_USE_GRAD_PAL | TPF_NOSHADOW);
-
-                /*...............................................................
-                Dialog & Field labels
-                ...............................................................*/
-#ifdef FORCE_WINSOCK
-                if (Winsock.Get_Connected()) {
-                    Draw_Caption(TXT_HOST_INTERNET_GAME, d_dialog_x, d_dialog_y, d_dialog_w);
-                } else {
-                    Draw_Caption(TXT_HOST_SERIAL_GAME, d_dialog_x, d_dialog_y, d_dialog_w);
-                }
-#else
-                Draw_Caption(TXT_NONE, d_dialog_x, d_dialog_y, d_dialog_w);
-#endif // FORCE_WINSOCK
-
-                Fancy_Text_Print(TXT_YOUR_NAME,
-                                 d_name_x + (d_name_w / 2),
-                                 d_name_y - d_txt6_h - (1 * factor),
-                                 CC_GREEN,
-                                 TBLACK,
-                                 TPF_RIGHT | TPF_6PT_GRAD | TPF_USE_GRAD_PAL | TPF_NOSHADOW);
-
-                Fancy_Text_Print(TXT_SIDE_COLON,
-                                 d_house_x + (d_house_w / 2),
-                                 d_house_y - d_txt6_h - (1 * factor),
-                                 CC_GREEN,
-                                 TBLACK,
-                                 TPF_RIGHT | TPF_6PT_GRAD | TPF_USE_GRAD_PAL | TPF_NOSHADOW);
-
-                Fancy_Text_Print(TXT_COLOR_COLON,
-                                 d_dialog_x + ((d_dialog_w / 4) * 3),
-                                 d_color_y - d_txt6_h - (1 * factor),
-                                 CC_GREEN,
-                                 TBLACK,
-                                 TPF_RIGHT | TPF_6PT_GRAD | TPF_USE_GRAD_PAL | TPF_NOSHADOW);
-
-                Fancy_Text_Print("Easy", // TODO: Locale file entry
-                                 difficulty.X,
-                                 difficulty.Y - 8 * factor,
-                                 CC_GREEN,
-                                 TBLACK,
-                                 TPF_6PT_GRAD | TPF_USE_GRAD_PAL | TPF_NOSHADOW);
-
-                Fancy_Text_Print("Hard", // TODO: Locale file entry
-                                 difficulty.X + difficulty.Width,
-                                 difficulty.Y - 8 * factor,
-                                 CC_GREEN,
-                                 TBLACK,
-                                 TPF_RIGHT | TPF_6PT_GRAD | TPF_USE_GRAD_PAL | TPF_NOSHADOW);
-
-                Fancy_Text_Print("Normal", // TODO: Locale file entry
-                                 difficulty.X + difficulty.Width / 2,
-                                 difficulty.Y - 8 * factor,
-                                 CC_GREEN,
-                                 TBLACK,
-                                 TPF_CENTER | TPF_6PT_GRAD | TPF_USE_GRAD_PAL | TPF_NOSHADOW);
-
-                Fancy_Text_Print(TXT_SCENARIOS,
-                                 d_scenariolist_x + (d_scenariolist_w / 2),
-                                 d_scenariolist_y - d_txt6_h - (1 * factor),
-                                 CC_GREEN,
-                                 TBLACK,
-                                 TPF_CENTER | TPF_6PT_GRAD | TPF_USE_GRAD_PAL | TPF_NOSHADOW);
-
-                Fancy_Text_Print(TXT_COUNT,
-                                 d_count_x - 3 * factor,
-                                 d_count_y,
-                                 CC_GREEN,
-                                 TBLACK,
-                                 TPF_NOSHADOW | TPF_6PT_GRAD | TPF_USE_GRAD_PAL | TPF_RIGHT);
-
-                Fancy_Text_Print(TXT_LEVEL,
-                                 d_level_x - 3 * factor,
-                                 d_level_y,
-                                 CC_GREEN,
-                                 TBLACK,
-                                 TPF_NOSHADOW | TPF_6PT_GRAD | TPF_USE_GRAD_PAL | TPF_RIGHT);
-
-                Fancy_Text_Print(TXT_START_CREDITS_COLON,
-                                 d_credits_x - 3 * factor,
-                                 d_credits_y,
-                                 CC_GREEN,
-                                 TBLACK,
-                                 TPF_RIGHT | TPF_6PT_GRAD | TPF_USE_GRAD_PAL | TPF_NOSHADOW);
-
-                Fancy_Text_Print("Tiberium Growth:", // TODO: Locale file entry
-                                 d_tiberiumscale_x - 3 * factor,
-                                 d_tiberiumscale_y,
-                                 CC_GREEN,
-                                 TBLACK,
-                                 TPF_RIGHT | TPF_6PT_GRAD | TPF_USE_GRAD_PAL | TPF_NOSHADOW);
-
-                // AI player setting headers
-                Fancy_Text_Print("Player", // TODO: Locale file entry
-                                 (d_aihouse_x - static_cast<int>(nearbyint(d_aihouse_w * 1.5)) - (10 * factor))
-                                    + (static_cast<int>((d_aihouse_w * 1.5) / 1.25)),
-                                 d_aihouse_y - d_txt6_h - (2 * factor),
-                                 CC_GREEN,
-                                 TBLACK,
-                                 TPF_RIGHT | TPF_6PT_GRAD | TPF_USE_GRAD_PAL | TPF_NOSHADOW);
-
-                Fancy_Text_Print("Side", // TODO: Locale file entry
-                                 d_aihouse_x + static_cast<int>(nearbyint(d_aihouse_w / 1.25)),
-                                 d_aihouse_y - d_txt6_h - (2 * factor),
-                                 CC_GREEN,
-                                 TBLACK,
-                                 TPF_RIGHT | TPF_6PT_GRAD | TPF_USE_GRAD_PAL | TPF_NOSHADOW);
-
-                // AI player difficulty and house checkbox labels
-                const auto cur_ai_house_label_x = (d_aihouse_x - static_cast<int>(nearbyint(d_aihouse_w * 1.5))
-                    - (10 * factor)) - 3 * factor;
-                auto cur_ai_house_label_y = d_aihouse_y;
-
-                for (auto idx = 0; idx < ai_diff_dropdowns.size(); idx++) {
-                    Fancy_Text_Print(std::format("AI {}:", idx + 1).c_str(), // TODO: Locale file entry
-                                     cur_ai_house_label_x,
-                                     cur_ai_house_label_y,
-                                     CC_GREEN,
-                                     TBLACK,
-                                     TPF_RIGHT | TPF_6PT_GRAD | TPF_USE_GRAD_PAL | TPF_NOSHADOW);
-
-                    cur_ai_house_label_y += d_aihouse_ystep;
-                }
-            }
-
-            /*..................................................................
-            Draw the color boxes
-            ..................................................................*/
-            if (display >= REDRAW_COLORS) {
-                for (i = 0; i < MAX_MPLAYER_COLORS; i++) {
-                    LogicPage->Fill_Rect(cbox_x[i] + 1 * factor,
-                                         d_color_y + 1 * factor,
-                                         cbox_x[i] + 1 * factor + d_color_w - 2 * factor,
-                                         d_color_y + 1 * factor + d_color_h - 2 * factor,
-                                         MPlayerGColors[i]);
-
-                    if (i == MPlayerColorIdx) {
-                        Draw_Box(cbox_x[i], d_color_y, d_color_w, d_color_h, BOXSTYLE_GREEN_DOWN, false);
-                    } else {
-                        Draw_Box(cbox_x[i], d_color_y, d_color_w, d_color_h, BOXSTYLE_GREEN_RAISED, false);
-                    }
-                }
-            }
-
-            /*..................................................................
-            Draw the message:
-            - Erase an old message first
-            ..................................................................*/
-            if (display >= REDRAW_MESSAGE) {
-                sprintf(txt, "%d ", MPlayerUnitCount);
-                Fancy_Text_Print(txt,
-                                 d_count_x + d_count_w + 3 * factor,
-                                 d_count_y,
-                                 CC_GREEN,
-                                 BLACK,
-                                 TPF_6PT_GRAD | TPF_USE_GRAD_PAL | TPF_NOSHADOW);
-
-                if (BuildLevel <= MPLAYER_BUILD_LEVEL_MAX) {
-                    sprintf(txt, "%d ", BuildLevel);
-                } else {
-                    sprintf(txt, "**");
-                }
-                Fancy_Text_Print(txt,
-                                 d_level_x + d_level_w + 3 * factor,
-                                 d_level_y,
-                                 CC_GREEN,
-                                 BLACK,
-                                 TPF_6PT_GRAD | TPF_USE_GRAD_PAL | TPF_NOSHADOW);
-                sprintf(txt, "%d ", MPlayerCredits);
-                Fancy_Text_Print(txt,
-                                 d_credits_x + d_credits_w + 3 * factor,
-                                 d_credits_y,
-                                 CC_GREEN,
-                                 BLACK,
-                                 TPF_6PT_GRAD | TPF_USE_GRAD_PAL | TPF_NOSHADOW);
-
-                sprintf(txt, "%dx ", tiberiumscalegauge.Get_Value() + 1);
-                Fancy_Text_Print(txt,
-                                 d_tiberiumscale_x + d_tiberiumscale_w + 3 * factor,
-                                 d_tiberiumscale_y,
-                                 CC_GREEN,
-                                 BLACK,
-                                 TPF_6PT_GRAD | TPF_USE_GRAD_PAL | TPF_NOSHADOW);
-            }
-
-            /*
-            .......................... Redraw buttons ..........................
-            */
-            if (display >= REDRAW_BUTTONS) {
-                commands->Flag_List_To_Redraw();
-            }
-
-            Show_Mouse();
-            display = REDRAW_NONE;
-        }
-
-        /*
-        ........................... Get user input ............................
-        */
-        bool droplist_is_dropped = housebtn.IsDropped;
-        std::vector<int> ai_diffs_collapsed;
-        std::vector<int> ai_houses_collapsed;
-
-        for (auto idx = 0; idx < ai_houses_collapsed.size(); idx++) {
-            if (ai_diff_dropdowns[idx].IsDropped) {
-                ai_diffs_collapsed.emplace_back(idx);
-            }
-
-            if (ai_house_dropdowns[idx].IsDropped) {
-                ai_houses_collapsed.emplace_back(idx);
-            }
-        }
-
-        input = commands->Input();
-
-        /*
-        ** Redraw everything if the player house droplist collapsed
-        */
-        if (droplist_is_dropped && !housebtn.IsDropped) {
-            display = REDRAW_BACKGROUND;
-        }
-
-        /*
-        ** Redraw everything if an AI house droplist collapsed
-        */
-        for (const auto& idx: ai_diffs_collapsed) {
-            if (!ai_diff_dropdowns[idx].IsDropped) {
-                display = REDRAW_BACKGROUND;
-            }
-        }
-
-        for (const auto& idx: ai_houses_collapsed) {
-            if (!ai_house_dropdowns[idx].IsDropped) {
-                display = REDRAW_BACKGROUND;
-            }
-        }
-
-        const auto collapse_visible_dropdowns = [&]() {
-            if (housebtn.IsDropped) {
-                housebtn.Collapse();
-                display = REDRAW_BACKGROUND;
-            }
-
-            for (auto idx = 0; idx < ai_houses_collapsed.size(); idx++) {
-                if (ai_diff_dropdowns[i].IsDropped) {
-                    ai_diff_dropdowns[i].Collapse();
-                    display = REDRAW_BACKGROUND;
-                }
-
-                if (ai_house_dropdowns[i].IsDropped) {
-                    ai_house_dropdowns[i].Collapse();
-                    display = REDRAW_BACKGROUND;
-                }
-            }
-        };
-
-        if (input & KN_BUTTON) {
-            // user is interacting with a button, so hide dropdown lists
-            collapse_visible_dropdowns();
-        }
-
-        // for any visible AI house dropdown, if mouse input is received outside it's bounds, hide it
-        for (auto idx = 0; idx < ai_diff_dropdowns.size(); idx++) {
-            if (ai_diff_dropdowns[idx].IsDropped) {
-                if ((Keyboard->MouseQX < ai_diff_dropdowns[idx].X || Keyboard->MouseQX > ai_diff_dropdowns[idx].X + ai_diff_dropdowns[idx].Width)
-                && (Keyboard->MouseQY < ai_diff_dropdowns[idx].Y || Keyboard->MouseQY > ai_diff_dropdowns[idx].Y + ai_diff_dropdowns[idx].Height)) {
-                    ai_diff_dropdowns[idx].Collapse();
-                    display = REDRAW_BACKGROUND;
-                }
-            }
-
-            if (ai_house_dropdowns[idx].IsDropped) {
-                if ((Keyboard->MouseQX < ai_house_dropdowns[idx].X || Keyboard->MouseQX > ai_house_dropdowns[idx].X + ai_house_dropdowns[idx].Width)
-                && (Keyboard->MouseQY < ai_house_dropdowns[idx].Y || Keyboard->MouseQY > ai_house_dropdowns[idx].Y + ai_house_dropdowns[idx].Height)) {
-                    ai_house_dropdowns[idx].Collapse();
-                    display = REDRAW_BACKGROUND;
-                }
-            }
-        }
-
-        /*
-        ---------------------------- Process input ----------------------------
-        */
-        switch (input) {
-        /*------------------------------------------------------------------
-        User clicks on a color button
-        ------------------------------------------------------------------*/
-        case KN_LMOUSE:
-            if (Keyboard->MouseQX > cbox_x[0] && Keyboard->MouseQX < (cbox_x[MAX_MPLAYER_COLORS - 1] + d_color_w)
-                && Keyboard->MouseQY > d_color_y && Keyboard->MouseQY < (d_color_y + d_color_h)) {
-                if (!ready_to_go) {
-                    MPlayerPrefColor = (Keyboard->MouseQX - cbox_x[0]) / d_color_w;
-                    MPlayerColorIdx = MPlayerPrefColor;
-                    display = REDRAW_COLORS;
-
-                    name_edt.Set_Color(MPlayerTColors[MPlayerColorIdx]);
-                    name_edt.Flag_To_Redraw();
-                    strcpy(MPlayerName, namebuf);
-
-                    collapse_visible_dropdowns();
-                }
-            }
-            break;
-
-            /*------------------------------------------------------------------
-            User edits the name field; retransmit new game options
-            ------------------------------------------------------------------*/
-        case (BUTTON_NAME | KN_BUTTON):
-            if (!ready_to_go) {
-                strcpy(MPlayerName, namebuf);
-                                collapse_visible_dropdowns();
-            }
-            break;
-
-            /*------------------------------------------------------------------
-            House Buttons: set the player's desired House
-            ------------------------------------------------------------------*/
-        case (BUTTON_HOUSE | KN_BUTTON):
-            MPlayerHouse = HousesType(housebtn.Current_Index() + HOUSE_GOOD);
-            strcpy(MPlayerName, namebuf);
-
-            collapse_visible_dropdowns();
-
-            display = REDRAW_BACKGROUND;
-            break;
-
-            /*------------------------------------------------------------------
-            New Scenario selected.
-            ------------------------------------------------------------------*/
-        case (BUTTON_SCENARIOLIST | KN_BUTTON):
-            if (scenariolist.Current_Index() != ScenarioIdx && !ready_to_go) {
-                ScenarioIdx = scenariolist.Current_Index();
-
-                // store the scenario number rather than current scenario list index
-                // (index will change if maps are added/removed by player)
-                MPlayerScenarioNumber = MPlayerFilenum[ScenarioIdx];
-
-                strcpy(MPlayerName, namebuf);
-            }
-            break;
-
-            /*------------------------------------------------------------------
-            AI player difficulty dropdown selection changed.
-            ------------------------------------------------------------------*/
-        case (BUTTON_AI_DIFF_1 | KN_BUTTON):
-        case (BUTTON_AI_DIFF_2 | KN_BUTTON):
-        case (BUTTON_AI_DIFF_3 | KN_BUTTON):
-        case (BUTTON_AI_DIFF_4 | KN_BUTTON):
-        case (BUTTON_AI_DIFF_5 | KN_BUTTON): {
-            for (auto idx = BUTTON_AI_DIFF_1; idx <= BUTTON_AI_DIFF_5; ++idx) {
-                if (input != (idx | KN_BUTTON)) {
-                    continue;
-                }
-
-                auto& diff_dropdown = ai_diff_dropdowns[idx - BUTTON_AI_DIFF_1];
-
-                // nothing changed, ignore input
-                if (!diff_dropdown.List.Index_Changed()) {
-                    break;
-                }
-
-                auto& house_dropdown = ai_house_dropdowns[idx - BUTTON_AI_DIFF_1];
-
-                const auto diff_was_disabled = diff_dropdown.Current_Index() == 0;
-                const auto diff_was_activated = diff_dropdown.List.Get_Previous_Index() == 0;
-                const auto house_is_disabled = house_dropdown.Current_Index() == 0;
-
-                if (diff_was_disabled) {
-                    // reset house to match disabled AI diff
-                    house_dropdown.Set_Selected_Index(0);
-                } else if (diff_was_activated && house_is_disabled) {
-                    // select a default house of '?' since none is selected
-                    house_dropdown.Set_Selected_Index(1);
-                }
-
-                CNC_LOG_WARN("REDRAW: {}", (int)idx);
-                diff_dropdown.Collapse();
-                house_dropdown.Collapse();
-                display = REDRAW_BACKGROUND;
-                                break;
-            }
-
-            break;
-        }
-
-            /*------------------------------------------------------------------
-            AI player house dropdown selection changed.
-            ------------------------------------------------------------------*/
-        case (BUTTON_AI_HOUSE_1 | KN_BUTTON):
-        case (BUTTON_AI_HOUSE_2 | KN_BUTTON):
-        case (BUTTON_AI_HOUSE_3 | KN_BUTTON):
-        case (BUTTON_AI_HOUSE_4 | KN_BUTTON):
-        case (BUTTON_AI_HOUSE_5 | KN_BUTTON): {
-            for (auto idx = BUTTON_AI_HOUSE_1; idx <= BUTTON_AI_HOUSE_5; ++idx) {
-                if (input != (idx | KN_BUTTON)) {
-                    continue;
-                }
-
-                auto& house_dropdown = ai_house_dropdowns[idx - BUTTON_AI_HOUSE_1];
-
-                // nothing changed, ignore input
-                if (!house_dropdown.List.Index_Changed()) {
-                    break;
-                }
-
-                auto& diff_dropdown = ai_diff_dropdowns[idx - BUTTON_AI_HOUSE_1];
-
-                const auto house_was_disabled = house_dropdown.Current_Index() == 0;
-                const auto house_was_activated = house_dropdown.List.Get_Previous_Index() == 0;
-                const auto diff_is_disabled = diff_dropdown.Current_Index() == 0;
-
-                if (house_was_disabled) {
-                    // reset diff to match disabled AI house
-                    diff_dropdown.Set_Selected_Index(0);
-                } else if (house_was_activated && diff_is_disabled) {
-                    // select a default diff of 'Normal' since none is selected
-                    diff_dropdown.Set_Selected_Index(2);
-                }
-
-                house_dropdown.Collapse();
-                diff_dropdown.Collapse();
-                display = REDRAW_BACKGROUND;
-            }
-
-            break;
-        }
-
-        /*------------------------------------------------------------------
-        User adjusts max # units
-        ------------------------------------------------------------------*/
-        case (BUTTON_COUNT | KN_BUTTON):
-            if (!ready_to_go) {
-                MPlayerUnitCount = countgauge.Get_Value() + MPlayerCountMin[MPlayerBases];
-                if (display < REDRAW_MESSAGE) {
-                    display = REDRAW_MESSAGE;
-                }
-                collapse_visible_dropdowns();
-            }
-            break;
-
-        /*------------------------------------------------------------------
-        User adjusts build level
-        ------------------------------------------------------------------*/
-        case (BUTTON_LEVEL | KN_BUTTON):
-            if (!ready_to_go) {
-                BuildLevel = levelgauge.Get_Value() + 1;
-                if (BuildLevel > MPLAYER_BUILD_LEVEL_MAX) // if it's pegged, max it out
-                    BuildLevel = MPLAYER_BUILD_LEVEL_MAX;
-                if (display < REDRAW_MESSAGE) {
-                    display = REDRAW_MESSAGE;
-                }
-                collapse_visible_dropdowns();
-            }
-            break;
-
-        /*------------------------------------------------------------------
-        User edits the credits value; retransmit new game options
-        ------------------------------------------------------------------*/
-        case (BUTTON_CREDITS | KN_BUTTON):
-            if (!ready_to_go) {
-                MPlayerCredits = creditsgauge.Get_Value();
-
-                if (MPlayerCredits == 0) {
-                    // clear lingering digits when player quickly slides to zero
-                    display = REDRAW_ALL;
-                }
-
-                if (display < REDRAW_MESSAGE) {
-                    display = REDRAW_MESSAGE;
-                }
-                collapse_visible_dropdowns();
-            }
-            break;
-
-        case (BUTTON_TIBERIUMSCALE | KN_BUTTON):
-            if (!ready_to_go) {
-                MPlayerTiberium = tiberiumscalegauge.Get_Value() + 1;
-
-                optionlist.Check_Item(1, MPlayerTiberium > 0);
-
-                Special.IsTGrowth = MPlayerTiberium;
-                Special.IsTSpread = MPlayerTiberium;
-
-                if (display < REDRAW_MESSAGE)
-                    display = REDRAW_MESSAGE;
-
-                collapse_visible_dropdowns();
-            }
-            break;
-
-        /*------------------------------------------------------------------
-        Toggle-able options:
-        If 'Bases' gets toggled, we have to change the range of the
-        UnitCount slider.
-        Also, if Tiberium gets toggled, we have to set the flags
-        in SpecialClass.
-        ------------------------------------------------------------------*/
-        case (BUTTON_OPTIONS | KN_BUTTON): {
-            if (MPlayerBases != optionlist.Is_Checked(0)) {
-                MPlayerBases = optionlist.Is_Checked(0);
-                if (MPlayerBases) {
-                    MPlayerUnitCount = Fixed_To_Cardinal(MPlayerCountMax[1] - MPlayerCountMin[1],
-                                                         Cardinal_To_Fixed(MPlayerCountMax[0] - MPlayerCountMin[0],
-                                                                           MPlayerUnitCount - MPlayerCountMin[0]))
-                                       + MPlayerCountMin[1];
-                } else {
-                    MPlayerUnitCount = Fixed_To_Cardinal(MPlayerCountMax[0] - MPlayerCountMin[0],
-                                                         Cardinal_To_Fixed(MPlayerCountMax[1] - MPlayerCountMin[1],
-                                                                           MPlayerUnitCount - MPlayerCountMin[1]))
-                                       + MPlayerCountMin[0];
-                }
-                countgauge.Set_Maximum(MPlayerCountMax[MPlayerBases] - MPlayerCountMin[MPlayerBases]);
-                countgauge.Set_Value(MPlayerUnitCount - MPlayerCountMin[MPlayerBases]);
-            }
-            MPlayerTiberium = optionlist.Is_Checked(1) ? 1 : 0;
-
-            if (tiberiumscalegauge.Get_Value() + 1 > 1) {
-                MPlayerTiberium = tiberiumscalegauge.Get_Value() + 1;
-            }
-
-            tiberiumscalegauge.Set_Value(MPlayerTiberium < 2 ? 0 : MPlayerTiberium - 1);
-
-            Special.IsTGrowth = MPlayerTiberium;
-            Special.IsTSpread = MPlayerTiberium;
-
-            MPlayerGoodies = optionlist.Is_Checked(2);
-            Special.IsCaptureTheFlag = optionlist.Is_Checked(3);
-
-            if (display < REDRAW_MESSAGE)
-                display = REDRAW_MESSAGE;
-
-            collapse_visible_dropdowns();
-            break;
-        }
-
-        /*------------------------------------------------------------------
-        OK: exit loop with true status
-        ------------------------------------------------------------------*/
-        case (BUTTON_OK | KN_BUTTON):
-            if (!ready_to_go) {
-                //
-                // make sure we got a game options packet from the other player
-                //
-                if (gameoptions) {
-                    rc = true;
-                    process = false;
-
-                    // force transmitting of game options packet one last time
-
-                    ready_to_go = true;
-                } else {
-                    WWMessageBox().Process(TXT_ONLY_ONE, TXT_OOPS);
-                    display = REDRAW_ALL;
-                }
-            }
-            break;
-
-        /*------------------------------------------------------------------
-        CANCEL: send a SIGN_OFF, bail out with error code
-        ------------------------------------------------------------------*/
-        case (KN_ESC):
-            if (!ready_to_go) {
-                if (Messages.Get_Edit_Buf() != NULL) {
-                    Messages.Input(input);
-                    if (display < REDRAW_MESSAGE)
-                        display = REDRAW_MESSAGE;
-                    break;
-                }
-            }
-        case (BUTTON_CANCEL | KN_BUTTON):
-            if (!ready_to_go) {
-                process = false;
-                rc = false;
-            }
-            break;
-
-        /*------------------------------------------------------------------
-        Default: manage the inter-player messages
-        ------------------------------------------------------------------*/
-        default:
-            break;
-
-        } /* end of input processing */
-
-        Frame_Limiter();
-    } /* end of while */
-
-    /*------------------------------------------------------------------------
-    Sort player ID's, so we can execute commands in the same order on both
-    machines.
-    ------------------------------------------------------------------------*/
-    if (rc) {
-        /*.....................................................................
-        Set the number of players in this game, and my ID
-        .....................................................................*/
-        MPlayerCount = 1;
-        MPlayerLocalID = Build_MPlayerID(MPlayerColorIdx, MPlayerHouse);
-
-        /*.....................................................................
-        Store every player's ID in the MPlayerID[] array.  This array will
-        determine the order of event execution, so the ID's must be stored
-        in the same order on all systems.
-        .....................................................................*/
-        MPlayerID[0] = MPlayerLocalID;
-        strcpy(MPlayerName, namebuf);
-        strcpy(MPlayerNames[0], MPlayerName);
-
-        /*.....................................................................
-        Get the scenario filename
-        .....................................................................*/
-        Scen.Scenario = MPlayerFilenum[ScenarioIdx];
-
-        int diff = difficulty.Get_Value() * (Rule.IsFineDifficulty ? 1 : 2);
-        switch (diff) {
-        case 0:
-            Scen.CDifficulty = DIFF_HARD;
-            Scen.Difficulty = DIFF_EASY;
-            break;
-
-        case 1:
-            Scen.CDifficulty = DIFF_HARD;
-            Scen.Difficulty = DIFF_NORMAL;
-            break;
-
-        case 2:
-            Scen.CDifficulty = DIFF_NORMAL;
-            Scen.Difficulty = DIFF_NORMAL;
-            break;
-
-        case 3:
-            Scen.CDifficulty = DIFF_EASY;
-            Scen.Difficulty = DIFF_NORMAL;
-            break;
-
-        case 4:
-            Scen.CDifficulty = DIFF_EASY;
-            Scen.Difficulty = DIFF_HARD;
-            break;
-        }
-
-        // set AI player variables from difficulty/house dropdowns
-        MPlayerGhosts = 0;
-
-        for (auto idx = 0; idx < ai_diff_dropdowns.size(); idx++) {
-            auto& diff_dropdown = ai_diff_dropdowns[idx];
-            auto& house_dropdown = ai_house_dropdowns[idx];
-
-            // skip disabled slots
-            if (diff_dropdown.Current_Index() == 0) {
-                continue;
-            }
-
-            // populate 'slot' with correct difficulty and house overrides
-            const auto selected_diff_idx = diff_dropdown.Current_Index();
-            const auto selected_house_idx = house_dropdown.Current_Index();
-
-            const auto selected_diff = selected_diff_idx == 0
-                ? DIFF_NONE
-                : static_cast<DiffType>(selected_diff_idx - 1);
-            const auto selected_house = selected_house_idx < 2
-                ? HOUSE_NONE
-                : static_cast<HousesType>(selected_house_idx - 2);
-
-            MPlayerHouses[MPlayerGhosts + 1] = selected_house;
-            MPlayerDifficulty[MPlayerGhosts + 1] = selected_diff;
-
-            MPlayerGhosts++;
-        }
-    }
-
-    /*------------------------------------------------------------------------
-    Clear all lists
-    ------------------------------------------------------------------------*/
-    while (scenariolist.Count()) {
-        scenariolist.Remove_Item(scenariolist.Get_Item(0));
+    if (result) {
+        dialog.Apply_Skirmish_Settings();
     }
 
     /*------------------------------------------------------------------------
@@ -1235,6 +1451,5 @@ int Com_Scenario_Dialog(void)
     ------------------------------------------------------------------------*/
     Write_MultiPlayer_Settings();
 
-    return (rc);
-
+    return result;
 } /* end of Com_Scenario_Dialog */

--- a/tiberiandawn/nulldlg.cpp
+++ b/tiberiandawn/nulldlg.cpp
@@ -123,26 +123,21 @@ int Com_Scenario_Dialog(void)
     int d_color_x = d_dialog_x + ((d_dialog_w / 4) * 3) - (d_color_w * 3);
 
     int d_playerlist_w = 118 * factor;
-    int d_playerlist_h = (6 * 6 * factor) + 3 * factor; // 6 rows high
     int d_playerlist_x = d_dialog_x + d_margin1 + d_margin1 + 5 * factor;
-    int d_playerlist_y = d_color_y + d_color_h + d_margin2 + 2 * factor /*KO + d_txt6_h*/;
 
-    int d_opponent_x = d_name_x;
-    int d_opponent_y = d_color_y + d_color_h + d_margin2;
-
-    int d_scenariolist_w = 152 * factor;
+    int d_scenariolist_w = 140 * factor;
     int d_scenariolist_h = 30 * factor;
-    int d_scenariolist_x = (d_cancel_x + static_cast<int>(nearbyint(d_cancel_w * 0.8))) - d_scenariolist_w + (10 * factor);
+    int d_scenariolist_x = (d_cancel_x + static_cast<int>(nearbyint(d_cancel_w * 0.8))) - d_scenariolist_w + (20 * factor);
     int d_scenariolist_y = d_color_y + d_txt6_h + 5 * factor + d_txt6_h;
     d_scenariolist_h *= 2;
 
-    int d_aihouse_w = d_house_w / 3;
+    int d_aihouse_w = static_cast<int>(nearbyint(d_house_w / 1.75));
     int d_aihouse_h = (6 * 5 * factor);
     int d_aihouse_x = d_scenariolist_x - d_aihouse_w - (10 * factor);
     int d_aihouse_y = d_scenariolist_y + (5 * factor);
     int d_aihouse_ystep = 10 * factor;
 
-    int d_options_w = static_cast<int>(nearbyint(d_scenariolist_w * 0.6));
+    int d_options_w = static_cast<int>(nearbyint(d_scenariolist_w * 0.8));
     int d_options_h = (5 * 6 * factor) + 5 * factor;
     int d_options_x = (d_scenariolist_x + d_scenariolist_w) - d_options_w;
     int d_options_y = d_scenariolist_y + d_scenariolist_h + d_margin1 - 2 * factor;
@@ -161,11 +156,6 @@ int Com_Scenario_Dialog(void)
     int d_credits_h = 7 * factor;
     int d_credits_x = d_playerlist_x + (d_playerlist_w / 2) + 20 * factor; // fudged;
     int d_credits_y = d_level_y + d_level_h;
-
-    //int d_aiplayers_w = 25 * factor;
-    //int d_aiplayers_h = 7 * factor;
-    //int d_aiplayers_x = d_playerlist_x + (d_playerlist_w / 2) + 20 * factor; // fudged;
-    //int d_aiplayers_y = d_credits_y + d_credits_h;
 
     int d_tiberiumscale_w = 25 * factor;
     int d_tiberiumscale_h = 7 * factor;
@@ -190,7 +180,6 @@ int Com_Scenario_Dialog(void)
         BUTTON_AI_HOUSE_4,
         BUTTON_AI_HOUSE_5,
         BUTTON_CREDITS,
-        //BUTTON_AIPLAYERS,
         BUTTON_TIBERIUMSCALE,
         BUTTON_OPTIONS,
         BUTTON_SCENARIOLIST,
@@ -224,28 +213,18 @@ int Com_Scenario_Dialog(void)
 
     int optiontabs[] = {8};               // tabs for player list box
     char namebuf[MPLAYER_NAME_MAX] = {0}; // buffer for player's name
-    int transmit;                         // 1 = re-transmit new game options
     int cbox_x[] = {d_color_x,
                     d_color_x + d_color_w,
                     d_color_x + (d_color_w * 2),
                     d_color_x + (d_color_w * 3),
                     d_color_x + (d_color_w * 4),
                     d_color_x + (d_color_w * 5)};
-    int parms_received = 0; // 1 = game options received
 
     int rc;
-    int recsignedoff = false;
     int i;
     char txt[80];
-    unsigned int timingtime;
-    unsigned int lastmsgtime;
-    unsigned int lastredrawtime;
-    unsigned int transmittime = 0;
-    unsigned int theirresponsetime;
     static bool first_time = true;
-    bool oppscorescreen = false;
     bool gameoptions = GameToPlay == GAME_SKIRMISH;
-    unsigned int msg_timeout = 1200; // init to 20 seconds
 
     bool ready_to_go = false;
     CountDownTimerClass ready_time;
@@ -289,6 +268,7 @@ int Com_Scenario_Dialog(void)
                            up_button,
                            down_button);
 
+    // dropdowns for AI player options
     std::vector<std::unique_ptr<char[]>> ai_diff_strings(5);
     std::vector<DropListClass> ai_diff_dropdowns;
     std::vector<std::unique_ptr<char[]>> ai_house_strings(5);
@@ -345,8 +325,6 @@ int Com_Scenario_Dialog(void)
 
     GaugeClass creditsgauge(BUTTON_CREDITS, d_credits_x, d_credits_y, d_credits_w, d_credits_h);
 
-    //GaugeClass aiplayersgauge(BUTTON_AIPLAYERS, d_aiplayers_x, d_aiplayers_y, d_aiplayers_w, d_aiplayers_h);
-
     GaugeClass tiberiumscalegauge(BUTTON_TIBERIUMSCALE, d_tiberiumscale_x, d_tiberiumscale_y, d_tiberiumscale_w, d_tiberiumscale_h);
 
     CheckListClass optionlist(BUTTON_OPTIONS,
@@ -401,7 +379,6 @@ int Com_Scenario_Dialog(void)
     countgauge.Add_Tail(*commands);
     levelgauge.Add_Tail(*commands);
     creditsgauge.Add_Tail(*commands);
-    //aiplayersgauge.Add_Tail(*commands);
     tiberiumscalegauge.Add_Tail(*commands);
     optionlist.Add_Tail(*commands);
     okbtn.Add_Tail(*commands);
@@ -419,35 +396,31 @@ int Com_Scenario_Dialog(void)
     name_edt.Set_Text(namebuf, MPLAYER_NAME_MAX);
     name_edt.Set_Color(MPlayerTColors[MPlayerColorIdx]);
 
+    // TODO: Add mystery option ? (random house selection)
     housebtn.Add_Item(Text_String(TXT_G_D_I));
     housebtn.Add_Item(Text_String(TXT_N_O_D));
-    //housebtn.Add_Item("Dino");
+    // TODO: Add dinosaur support (no bases ONLY)
     housebtn.Set_Selected_Index(MPlayerHouse - HOUSE_GOOD);
     housebtn.Set_Read_Only(true);
-
-    int maxp = 4 /*Rule.MaxPlayers - 2*/;
-    //aiplayersgauge.Set_Maximum(maxp);
 
     if (MPlayerGhosts > 5) {
         MPlayerGhosts = 5;
     }
     MPlayerGhosts = max(MPlayerGhosts, 1);
 
-    //aiplayersgauge.Set_Value(MPlayerGhosts - 1);
-
     for (auto idx = 0; idx < ai_diff_dropdowns.size(); idx++) {
-        ai_diff_dropdowns[idx].Add_Item("Disabled");
+        ai_diff_dropdowns[idx].Add_Item("Disabled"); // TODO: Locale file entries
         ai_diff_dropdowns[idx].Add_Item("Easy");
         ai_diff_dropdowns[idx].Add_Item("Normal");
         ai_diff_dropdowns[idx].Add_Item("Hard");
         ai_diff_dropdowns[idx].Set_Selected_Index(idx < MPlayerGhosts ? 2 : 0);
         ai_diff_dropdowns[idx].Set_Read_Only(true);
 
-        ai_house_dropdowns[idx].Add_Item("None");
+        ai_house_dropdowns[idx].Add_Item("None"); // TODO: Locale file entries
         ai_house_dropdowns[idx].Add_Item("?");
         ai_house_dropdowns[idx].Add_Item(Text_String(TXT_G_D_I));
         ai_house_dropdowns[idx].Add_Item(Text_String(TXT_N_O_D));
-        //ai_house_dropdowns[idx].Add_Item("Dino");
+        // TODO: Add dinosaur support (no bases ONLY)
         ai_house_dropdowns[idx].Set_Selected_Index(idx < MPlayerGhosts ? 1 : 0);
         ai_house_dropdowns[idx].Set_Read_Only(true);
     }
@@ -459,7 +432,8 @@ int Com_Scenario_Dialog(void)
         // GB 2022 set defaults for skirmish also:
         BuildLevel = 7;
 
-        MPlayerCredits = Rule.Get_Rule_Value<int>(GAME_MULTIPLAYER_SECTION, START_CREDITS_DEFAULT_RULE); // init credits & credit buffer
+        // init credits & credit buffer
+        MPlayerCredits = Rule.Get_Rule_Value<int>(GAME_MULTIPLAYER_SECTION, START_CREDITS_DEFAULT_RULE);
         MPlayerGhosts = 1;
         MPlayerUnitCount = (MPlayerCountMax[MPlayerBases] + MPlayerCountMin[MPlayerBases]) / 2;
         MPlayerTiberium = 1;
@@ -509,8 +483,7 @@ int Com_Scenario_Dialog(void)
     ........................................................................*/
     Special.IsTGrowth = MPlayerTiberium;
     Special.IsTSpread = MPlayerTiberium;
-    transmit = 1;
-
+    
     /*........................................................................
     Init scenario description list box
     ........................................................................*/
@@ -539,8 +512,6 @@ int Com_Scenario_Dialog(void)
     Blit_Hid_Page_To_Seen_Buff();
     Set_Palette(Palette);
 
-    theirresponsetime = 10000; // initialize to an invalid value
-    timingtime = lastmsgtime = lastredrawtime = WinTickCount.Time();
     while (Get_Mouse_State() > 0)
         Show_Mouse();
 
@@ -659,13 +630,6 @@ int Com_Scenario_Dialog(void)
                                  TBLACK,
                                  TPF_RIGHT | TPF_6PT_GRAD | TPF_USE_GRAD_PAL | TPF_NOSHADOW);
 
-                // Fancy_Text_Print(TXT_AI_PLAYERS_COLON,
-                //                  d_aiplayers_x - 3 * factor,
-                //                  d_aiplayers_y,
-                //                  CC_GREEN,
-                //                  TBLACK,
-                //                  TPF_RIGHT | TPF_6PT_GRAD | TPF_USE_GRAD_PAL | TPF_NOSHADOW);
-
                 Fancy_Text_Print("Tiberium Growth:", // TODO: Locale file entry
                                  d_tiberiumscale_x - 3 * factor,
                                  d_tiberiumscale_y,
@@ -673,6 +637,7 @@ int Com_Scenario_Dialog(void)
                                  TBLACK,
                                  TPF_RIGHT | TPF_6PT_GRAD | TPF_USE_GRAD_PAL | TPF_NOSHADOW);
 
+                // AI player setting headers
                 Fancy_Text_Print("Player", // TODO: Locale file entry
                                  (d_aihouse_x - static_cast<int>(nearbyint(d_aihouse_w * 1.5)) - (10 * factor))
                                     + (static_cast<int>((d_aihouse_w * 1.5) / 1.25)),
@@ -756,13 +721,6 @@ int Com_Scenario_Dialog(void)
                                  BLACK,
                                  TPF_6PT_GRAD | TPF_USE_GRAD_PAL | TPF_NOSHADOW);
 
-                // sprintf(txt, "%d ", MPlayerGhosts);
-                // Fancy_Text_Print(txt,
-                //                  d_aiplayers_x + d_aiplayers_w + 3 * factor,
-                //                  d_aiplayers_y,
-                //                  CC_GREEN,
-                //                  BLACK,
-                //                  TPF_6PT_GRAD | TPF_USE_GRAD_PAL | TPF_NOSHADOW);
                 sprintf(txt, "%dx ", tiberiumscalegauge.Get_Value() + 1);
                 Fancy_Text_Print(txt,
                                  d_tiberiumscale_x + d_tiberiumscale_w + 3 * factor,
@@ -810,7 +768,7 @@ int Com_Scenario_Dialog(void)
         }
 
         /*
-        ** Redraw everything if am AI house droplist collapsed
+        ** Redraw everything if an AI house droplist collapsed
         */
         for (const auto& idx: ai_diffs_collapsed) {
             if (!ai_diff_dropdowns[idx].IsDropped) {
@@ -887,9 +845,8 @@ int Com_Scenario_Dialog(void)
                     strcpy(MPlayerName, namebuf);
 
                     collapse_visible_dropdowns();
-                    transmit = 1;
                 }
-                }
+            }
             break;
 
             /*------------------------------------------------------------------
@@ -898,8 +855,7 @@ int Com_Scenario_Dialog(void)
         case (BUTTON_NAME | KN_BUTTON):
             if (!ready_to_go) {
                 strcpy(MPlayerName, namebuf);
-                transmit = 1;
-                collapse_visible_dropdowns();
+                                collapse_visible_dropdowns();
             }
             break;
 
@@ -913,7 +869,6 @@ int Com_Scenario_Dialog(void)
             collapse_visible_dropdowns();
 
             display = REDRAW_BACKGROUND;
-            transmit = true;
             break;
 
             /*------------------------------------------------------------------
@@ -928,7 +883,6 @@ int Com_Scenario_Dialog(void)
                 MPlayerScenarioNumber = MPlayerFilenum[ScenarioIdx];
 
                 strcpy(MPlayerName, namebuf);
-                transmit = 1;
             }
             break;
 
@@ -970,8 +924,7 @@ int Com_Scenario_Dialog(void)
                 diff_dropdown.Collapse();
                 house_dropdown.Collapse();
                 display = REDRAW_BACKGROUND;
-                transmit = true;
-                break;
+                                break;
             }
 
             break;
@@ -1014,7 +967,6 @@ int Com_Scenario_Dialog(void)
                 house_dropdown.Collapse();
                 diff_dropdown.Collapse();
                 display = REDRAW_BACKGROUND;
-                transmit = true;
             }
 
             break;
@@ -1030,7 +982,6 @@ int Com_Scenario_Dialog(void)
                     display = REDRAW_MESSAGE;
                 }
                 collapse_visible_dropdowns();
-                transmit = 1;
             }
             break;
 
@@ -1046,7 +997,6 @@ int Com_Scenario_Dialog(void)
                     display = REDRAW_MESSAGE;
                 }
                 collapse_visible_dropdowns();
-                transmit = 1;
             }
             break;
 
@@ -1066,31 +1016,8 @@ int Com_Scenario_Dialog(void)
                     display = REDRAW_MESSAGE;
                 }
                 collapse_visible_dropdowns();
-                transmit = 1;
             }
             break;
-
-        /*------------------------------------------------------------------
-        User adjusts # of AI players
-        ------------------------------------------------------------------*/
-        // case (BUTTON_AIPLAYERS | KN_BUTTON):
-        //     if (!ready_to_go) {
-        //         MPlayerGhosts = aiplayersgauge.Get_Value();
-        //         int humans = 1; // One humans.
-        //         MPlayerGhosts += 1;
-        //         if (MPlayerGhosts + humans >= 6 /*Rule.MaxPlayers*/) { // if it's pegged, max it out
-        //             MPlayerGhosts = 6 /*Rule.MaxPlayers*/ - humans;
-        //             aiplayersgauge.Set_Value(MPlayerGhosts - 1);
-        //         }
-        //         transmit = true;
-        //         if (display < REDRAW_MESSAGE)
-        //             display = REDRAW_MESSAGE;
-        //
-        //         collapse_visible_dropdowns();
-        //
-        //         break;
-        //     }
-        //     break;
 
         case (BUTTON_TIBERIUMSCALE | KN_BUTTON):
             if (!ready_to_go) {
@@ -1141,14 +1068,11 @@ int Com_Scenario_Dialog(void)
             tiberiumscalegauge.Set_Value(MPlayerTiberium < 2 ? 0 : MPlayerTiberium - 1);
 
             Special.IsTGrowth = MPlayerTiberium;
-            // Rule.IsTGrowth = MPlayerTiberium;
             Special.IsTSpread = MPlayerTiberium;
-            // Rule.IsTSpread = MPlayerTiberium;
 
             MPlayerGoodies = optionlist.Is_Checked(2);
             Special.IsCaptureTheFlag = optionlist.Is_Checked(3);
 
-            transmit = true;
             if (display < REDRAW_MESSAGE)
                 display = REDRAW_MESSAGE;
 
@@ -1171,10 +1095,6 @@ int Com_Scenario_Dialog(void)
                     // force transmitting of game options packet one last time
 
                     ready_to_go = true;
-
-                    transmit = 1;
-                    transmittime = 0;
-
                 } else {
                     WWMessageBox().Process(TXT_ONLY_ONE, TXT_OOPS);
                     display = REDRAW_ALL;

--- a/tiberiandawn/nulldlg.cpp
+++ b/tiberiandawn/nulldlg.cpp
@@ -73,6 +73,13 @@ class SkirmishScenarioDialog final
         BUTTON_LOAD,
         BUTTON_CANCEL,
         BUTTON_DIFFICULTY,
+        BUTTON_COLOR_1,
+        BUTTON_COLOR_2,
+        BUTTON_COLOR_3,
+        BUTTON_COLOR_4,
+        BUTTON_COLOR_5,
+        BUTTON_COLOR_6,
+        BUTTON_PLAYERLIST // not used
     } ButtonType;
 
     /*........................................................................
@@ -103,72 +110,6 @@ class SkirmishScenarioDialog final
     int TextHeight;
     int MarginWidth;
     int MarginHeight;
-
-    int d_ok_w;
-    int d_ok_h;
-    int d_ok_x;
-    int d_ok_y;
-
-    int d_cancel_w;
-    int d_cancel_h;
-    int d_cancel_x;
-    int d_cancel_y;
-
-    int d_name_w;
-    int d_name_h;
-    int d_name_x;
-    int d_name_y;
-
-    int d_house_w;
-    int d_house_h;
-    int d_house_x;
-    int d_house_y;
-
-    int d_color_w;
-    int d_color_h;
-    int d_color_y;
-    int d_color_x;
-
-    int d_playerlist_w;
-    int d_playerlist_x;
-
-    int d_scenariolist_w;
-    int d_scenariolist_h;
-    int d_scenariolist_x;
-    int d_scenariolist_y;
-
-    int d_aihouse_w;
-    int d_aihouse_h;
-    int d_aihouse_x;
-    int d_aihouse_y;
-    int d_aihouse_ystep;
-
-    int d_options_w;
-    int d_options_h;
-    int d_options_x;
-    int d_options_y;
-
-    int d_count_w;
-    int d_count_h;
-    int d_count_y;
-    int d_count_x;
-
-    int d_level_w;
-    int d_level_h;
-    int d_level_y;
-    int d_level_x;
-
-    int d_credits_w;
-    int d_credits_h;
-    int d_credits_x;
-    int d_credits_y;
-
-    int d_tiberiumscale_w;
-    int d_tiberiumscale_h;
-    int d_tiberiumscale_x;
-    int d_tiberiumscale_y;
-
-    int ColorBoxes[6];
 
     // button shapes
     void const* UpButtonShape;
@@ -218,22 +159,22 @@ class SkirmishScenarioDialog final
 #endif // FORCE_WINSOCK
 
             Fancy_Text_Print(TXT_YOUR_NAME,
-                             d_name_x + (d_name_w / 2),
-                             d_name_y - TextHeight - (1 * Factor),
+                             Dimensions[BUTTON_NAME].x + (Dimensions[BUTTON_NAME].w / 2),
+                             Dimensions[BUTTON_NAME].y - TextHeight - (1 * Factor),
                              CC_GREEN,
                              TBLACK,
                              TPF_RIGHT | TPF_6PT_GRAD | TPF_USE_GRAD_PAL | TPF_NOSHADOW);
 
             Fancy_Text_Print(TXT_SIDE_COLON,
-                             d_house_x + (d_house_w / 2),
-                             d_house_y - TextHeight - (1 * Factor),
+                             Dimensions[BUTTON_HOUSE].x + (Dimensions[BUTTON_HOUSE].w / 2),
+                             Dimensions[BUTTON_HOUSE].y - TextHeight - (1 * Factor),
                              CC_GREEN,
                              TBLACK,
                              TPF_RIGHT | TPF_6PT_GRAD | TPF_USE_GRAD_PAL | TPF_NOSHADOW);
 
             Fancy_Text_Print(TXT_COLOR_COLON,
                              X + ((Width / 4) * 3),
-                             d_color_y - TextHeight - (1 * Factor),
+                             Dimensions[BUTTON_COLOR_1].y - TextHeight - (1 * Factor),
                              CC_GREEN,
                              TBLACK,
                              TPF_RIGHT | TPF_6PT_GRAD | TPF_USE_GRAD_PAL | TPF_NOSHADOW);
@@ -262,70 +203,70 @@ class SkirmishScenarioDialog final
                              TPF_CENTER | TPF_6PT_GRAD | TPF_USE_GRAD_PAL | TPF_NOSHADOW);
 
             Fancy_Text_Print(TXT_SCENARIOS,
-                             d_scenariolist_x + (d_scenariolist_w / 2),
-                             d_scenariolist_y - TextHeight - (1 * Factor),
+                             Dimensions[BUTTON_SCENARIOLIST].x + (Dimensions[BUTTON_SCENARIOLIST].w / 2),
+                             Dimensions[BUTTON_SCENARIOLIST].y - TextHeight - (1 * Factor),
                              CC_GREEN,
                              TBLACK,
                              TPF_CENTER | TPF_6PT_GRAD | TPF_USE_GRAD_PAL | TPF_NOSHADOW);
 
             Fancy_Text_Print(TXT_COUNT,
-                             d_count_x - 3 * Factor,
-                             d_count_y,
+                             Dimensions[BUTTON_COUNT].x - 3 * Factor,
+                             Dimensions[BUTTON_COUNT].y,
                              CC_GREEN,
                              TBLACK,
                              TPF_NOSHADOW | TPF_6PT_GRAD | TPF_USE_GRAD_PAL | TPF_RIGHT);
 
             Fancy_Text_Print(TXT_LEVEL,
-                             d_level_x - 3 * Factor,
-                             d_level_y,
+                             Dimensions[BUTTON_LEVEL].x - 3 * Factor,
+                             Dimensions[BUTTON_LEVEL].y,
                              CC_GREEN,
                              TBLACK,
                              TPF_NOSHADOW | TPF_6PT_GRAD | TPF_USE_GRAD_PAL | TPF_RIGHT);
 
             Fancy_Text_Print(TXT_START_CREDITS_COLON,
-                             d_credits_x - 3 * Factor,
-                             d_credits_y,
+                             Dimensions[BUTTON_CREDITS].x - 3 * Factor,
+                             Dimensions[BUTTON_CREDITS].y,
                              CC_GREEN,
                              TBLACK,
                              TPF_RIGHT | TPF_6PT_GRAD | TPF_USE_GRAD_PAL | TPF_NOSHADOW);
 
             Fancy_Text_Print("Tiberium Growth:", // TODO: Locale file entry
-                             d_tiberiumscale_x - 3 * Factor,
-                             d_tiberiumscale_y,
+                             Dimensions[BUTTON_TIBERIUMSCALE].x - 3 * Factor,
+                             Dimensions[BUTTON_TIBERIUMSCALE].y,
                              CC_GREEN,
                              TBLACK,
                              TPF_RIGHT | TPF_6PT_GRAD | TPF_USE_GRAD_PAL | TPF_NOSHADOW);
 
             // AI player setting headers
             Fancy_Text_Print("Player", // TODO: Locale file entry
-                             (d_aihouse_x - static_cast<int>(nearbyint(d_aihouse_w * 1.5)) - (10 * Factor))
-                                + (static_cast<int>((d_aihouse_w * 1.5) / 1.25)),
-                             d_aihouse_y - TextHeight - (2 * Factor),
+                             (Dimensions[BUTTON_AI_HOUSE_1].x
+                                - static_cast<int>(nearbyint(Dimensions[BUTTON_AI_HOUSE_1].w * 1.5)) - (10 * Factor))
+                                + (static_cast<int>((Dimensions[BUTTON_AI_HOUSE_1].w * 1.5) / 1.25)),
+                             Dimensions[BUTTON_AI_HOUSE_1].y - TextHeight - (2 * Factor),
                              CC_GREEN,
                              TBLACK,
                              TPF_RIGHT | TPF_6PT_GRAD | TPF_USE_GRAD_PAL | TPF_NOSHADOW);
 
             Fancy_Text_Print("Side", // TODO: Locale file entry
-                             d_aihouse_x + static_cast<int>(nearbyint(d_aihouse_w / 1.25)),
-                             d_aihouse_y - TextHeight - (2 * Factor),
+                             Dimensions[BUTTON_AI_HOUSE_1].x
+                                + static_cast<int>(nearbyint(Dimensions[BUTTON_AI_HOUSE_1].w / 1.25)),
+                             Dimensions[BUTTON_AI_HOUSE_1].y - TextHeight - (2 * Factor),
                              CC_GREEN,
                              TBLACK,
                              TPF_RIGHT | TPF_6PT_GRAD | TPF_USE_GRAD_PAL | TPF_NOSHADOW);
 
             // AI player difficulty and house checkbox labels
-            const auto cur_ai_house_label_x = (d_aihouse_x - static_cast<int>(nearbyint(d_aihouse_w * 1.5))
+            const auto cur_ai_house_label_x = (Dimensions[BUTTON_AI_HOUSE_1].x
+                - static_cast<int>(nearbyint(Dimensions[BUTTON_AI_HOUSE_1].w * 1.5))
                 - (10 * Factor)) - 3 * Factor;
-            auto cur_ai_house_label_y = d_aihouse_y;
 
-            for (int idx = BUTTON_AI_DIFF_1; idx <= BUTTON_AI_DIFF_5; idx++) {
-                Fancy_Text_Print(std::format("AI {}:", idx - BUTTON_HOUSE).c_str(), // TODO: Locale file entry
+            for (auto control = BUTTON_AI_DIFF_1; control <= BUTTON_AI_DIFF_5; ++control) {
+                Fancy_Text_Print(std::format("AI {}:", control - BUTTON_HOUSE).c_str(), // TODO: Locale file entry
                                  cur_ai_house_label_x,
-                                 cur_ai_house_label_y,
+                                 Dimensions[control].y,
                                  CC_GREEN,
                                  TBLACK,
                                  TPF_RIGHT | TPF_6PT_GRAD | TPF_USE_GRAD_PAL | TPF_NOSHADOW);
-
-                cur_ai_house_label_y += d_aihouse_ystep;
             }
         }
 
@@ -333,18 +274,23 @@ class SkirmishScenarioDialog final
         Draw the color boxes
         ..................................................................*/
         if (display >= REDRAW_COLORS) {
-            for (auto i = 0; i < MAX_MPLAYER_COLORS; i++) {
-                LogicPage->Fill_Rect(ColorBoxes[i] + 1 * Factor,
-                                     d_color_y + 1 * Factor,
-                                     ColorBoxes[i] + 1 * Factor + d_color_w - 2 * Factor,
-                                     d_color_y + 1 * Factor + d_color_h - 2 * Factor,
-                                     MPlayerGColors[i]);
+            for (auto control = BUTTON_COLOR_1; control <= BUTTON_COLOR_6; ++control) {
+                const auto mplayer_idx = control - BUTTON_COLOR_1;
 
-                if (i == MPlayerColorIdx) {
-                    Draw_Box(ColorBoxes[i], d_color_y, d_color_w, d_color_h, BOXSTYLE_GREEN_DOWN, false);
-                } else {
-                    Draw_Box(ColorBoxes[i], d_color_y, d_color_w, d_color_h, BOXSTYLE_GREEN_RAISED, false);
-                }
+                LogicPage->Fill_Rect(Dimensions[control].x + 1 * Factor,
+                                     Dimensions[control].y + 1 * Factor,
+                                     Dimensions[control].x + 1 * Factor + Dimensions[control].w - 2 * Factor,
+                                     Dimensions[control].y + 1 * Factor + Dimensions[control].h - 2 * Factor,
+                                     MPlayerGColors[mplayer_idx]);
+
+                Draw_Box(
+                    Dimensions[control].x,
+                    Dimensions[control].y,
+                    Dimensions[control].w,
+                    Dimensions[control].h,
+                    mplayer_idx == MPlayerColorIdx ? BOXSTYLE_GREEN_DOWN : BOXSTYLE_GREEN_RAISED,
+                    false
+                );
             }
         }
 
@@ -355,8 +301,8 @@ class SkirmishScenarioDialog final
         if (display >= REDRAW_MESSAGE) {
             sprintf(txt, "%d ", MPlayerUnitCount);
             Fancy_Text_Print(txt,
-                             d_count_x + d_count_w + 3 * Factor,
-                             d_count_y,
+                             Dimensions[BUTTON_COUNT].x + Dimensions[BUTTON_COUNT].w + 3 * Factor,
+                             Dimensions[BUTTON_COUNT].y,
                              CC_GREEN,
                              BLACK,
                              TPF_6PT_GRAD | TPF_USE_GRAD_PAL | TPF_NOSHADOW);
@@ -367,23 +313,23 @@ class SkirmishScenarioDialog final
                 sprintf(txt, "**");
             }
             Fancy_Text_Print(txt,
-                             d_level_x + d_level_w + 3 * Factor,
-                             d_level_y,
+                             Dimensions[BUTTON_LEVEL].x + Dimensions[BUTTON_LEVEL].w + 3 * Factor,
+                             Dimensions[BUTTON_LEVEL].y,
                              CC_GREEN,
                              BLACK,
                              TPF_6PT_GRAD | TPF_USE_GRAD_PAL | TPF_NOSHADOW);
             sprintf(txt, "%d ", MPlayerCredits);
             Fancy_Text_Print(txt,
-                             d_credits_x + d_credits_w + 3 * Factor,
-                             d_credits_y,
+                             Dimensions[BUTTON_CREDITS].x + Dimensions[BUTTON_CREDITS].w + 3 * Factor,
+                             Dimensions[BUTTON_CREDITS].y,
                              CC_GREEN,
                              BLACK,
                              TPF_6PT_GRAD | TPF_USE_GRAD_PAL | TPF_NOSHADOW);
 
             sprintf(txt, "%dx ", Get_Control<GaugeClass>(BUTTON_TIBERIUMSCALE).Get_Value() + 1);
             Fancy_Text_Print(txt,
-                             d_tiberiumscale_x + d_tiberiumscale_w + 3 * Factor,
-                             d_tiberiumscale_y,
+                             Dimensions[BUTTON_TIBERIUMSCALE].x + Dimensions[BUTTON_TIBERIUMSCALE].w + 3 * Factor,
+                             Dimensions[BUTTON_TIBERIUMSCALE].y,
                              CC_GREEN,
                              BLACK,
                              TPF_6PT_GRAD | TPF_USE_GRAD_PAL | TPF_NOSHADOW);
@@ -528,10 +474,10 @@ class SkirmishScenarioDialog final
                 BUTTON_OK,
                 TXT_OK,
                 TPF_CENTER | TPF_6PT_GRAD | TPF_USE_GRAD_PAL | TPF_NOSHADOW,
-                d_ok_x,
-                d_ok_y,
-                d_ok_w,
-                d_ok_h
+                Dimensions[BUTTON_OK].x,
+                Dimensions[BUTTON_OK].y,
+                Dimensions[BUTTON_OK].w,
+                Dimensions[BUTTON_OK].h
             )
         );
         Get_Control<TextButtonClass>(BUTTON_OK).Add_Tail(*CommandChain);
@@ -541,10 +487,10 @@ class SkirmishScenarioDialog final
                 BUTTON_CANCEL,
                 TXT_CANCEL,
                 TPF_CENTER | TPF_6PT_GRAD | TPF_USE_GRAD_PAL | TPF_NOSHADOW,
-                d_cancel_x,
-                d_cancel_y,
-                d_cancel_w,
-                d_cancel_h
+                Dimensions[BUTTON_CANCEL].x,
+                Dimensions[BUTTON_CANCEL].y,
+                Dimensions[BUTTON_CANCEL].w,
+                Dimensions[BUTTON_CANCEL].h
             )
         );
         Get_Control<TextButtonClass>(BUTTON_CANCEL).Add_Tail(*CommandChain);
@@ -555,9 +501,9 @@ class SkirmishScenarioDialog final
         Controls[BUTTON_DIFFICULTY] = std::unique_ptr<GadgetClass>(
             new SliderClass(
                 BUTTON_DIFFICULTY,
-                d_name_x,
-                d_ok_y - (8 * Factor) - MarginWidth,
-                Width - (d_name_x - X) * 2,
+                Dimensions[BUTTON_NAME].x,
+                Dimensions[BUTTON_OK].y - (8 * Factor) - MarginWidth,
+                Width - (Dimensions[BUTTON_NAME].x - X) * 2,
                 8 * Factor,
                 true
             )
@@ -579,27 +525,27 @@ class SkirmishScenarioDialog final
     void Init_Bottom_Row()
     {
         Controls[BUTTON_COUNT] = std::unique_ptr<GadgetClass>(
-            new GaugeClass(BUTTON_COUNT, d_count_x, d_count_y, d_count_w, d_count_h)
+            new GaugeClass(BUTTON_COUNT, Dimensions[BUTTON_COUNT].x, Dimensions[BUTTON_COUNT].y, Dimensions[BUTTON_COUNT].w, Dimensions[BUTTON_COUNT].h)
         );
         Get_Control<GaugeClass>(BUTTON_COUNT).Add_Tail(*CommandChain);
 
         Controls[BUTTON_LEVEL] = std::unique_ptr<GadgetClass>(
-            new GaugeClass(BUTTON_LEVEL, d_level_x, d_level_y, d_level_w, d_level_h)
+            new GaugeClass(BUTTON_LEVEL, Dimensions[BUTTON_LEVEL].x, Dimensions[BUTTON_LEVEL].y, Dimensions[BUTTON_LEVEL].w, Dimensions[BUTTON_LEVEL].h)
         );
         Get_Control<GaugeClass>(BUTTON_LEVEL).Add_Tail(*CommandChain);
 
         Controls[BUTTON_CREDITS] = std::unique_ptr<GadgetClass>(
-            new GaugeClass(BUTTON_CREDITS, d_credits_x, d_credits_y, d_credits_w, d_credits_h)
+            new GaugeClass(BUTTON_CREDITS, Dimensions[BUTTON_CREDITS].x, Dimensions[BUTTON_CREDITS].y, Dimensions[BUTTON_CREDITS].w, Dimensions[BUTTON_CREDITS].h)
         );
         Get_Control<GaugeClass>(BUTTON_CREDITS).Add_Tail(*CommandChain);
 
         Controls[BUTTON_TIBERIUMSCALE] = std::unique_ptr<GadgetClass>(
             new GaugeClass(
                 BUTTON_TIBERIUMSCALE,
-                d_tiberiumscale_x,
-                d_tiberiumscale_y,
-                d_tiberiumscale_w,
-                d_tiberiumscale_h
+                Dimensions[BUTTON_TIBERIUMSCALE].x,
+                Dimensions[BUTTON_TIBERIUMSCALE].y,
+                Dimensions[BUTTON_TIBERIUMSCALE].w,
+                Dimensions[BUTTON_TIBERIUMSCALE].h
             )
         );
         Get_Control<GaugeClass>(BUTTON_TIBERIUMSCALE).Add_Tail(*CommandChain);
@@ -607,10 +553,10 @@ class SkirmishScenarioDialog final
         Controls[BUTTON_OPTIONS] = std::unique_ptr<GadgetClass>(
             new CheckListClass(
                 BUTTON_OPTIONS,
-                d_options_x,
-                d_options_y,
-                d_options_w,
-                d_options_h,
+                Dimensions[BUTTON_OPTIONS].x,
+                Dimensions[BUTTON_OPTIONS].y,
+                Dimensions[BUTTON_OPTIONS].w,
+                Dimensions[BUTTON_OPTIONS].h,
                 TPF_6PT_GRAD | TPF_USE_GRAD_PAL | TPF_NOSHADOW,
                 UpButtonShape,
                 DownButtonShape
@@ -621,56 +567,52 @@ class SkirmishScenarioDialog final
 
     void Init_Middle_Row()
     {
-        auto cur_ai_house_y = d_aihouse_y;
+        for (auto control = BUTTON_AI_DIFF_1; control <= BUTTON_AI_DIFF_5; ++control) {
+            const auto house_control = static_cast<ButtonType>(control + 5);
 
-        for (auto h = BUTTON_AI_DIFF_1; h <= BUTTON_AI_DIFF_5; ++h) {
-            const auto house_button = static_cast<ButtonType>(h + 5);
+            Text[control] = std::make_unique<char[]>(DropdownTextLength);
+            Text[house_control] = std::make_unique<char[]>(DropdownTextLength);
 
-            Text[h] = std::make_unique<char[]>(DropdownTextLength);
-            Text[house_button] = std::make_unique<char[]>(DropdownTextLength);
-
-            Controls[h] = std::unique_ptr<GadgetClass>(
+            Controls[control] = std::unique_ptr<GadgetClass>(
                 new DropListClass(
-                    h,
-                    Text[h].get(),
+                    control,
+                    Text[control].get(),
                     DropdownTextLength,
                     TPF_6PT_GRAD | TPF_USE_GRAD_PAL | TPF_NOSHADOW,
-                    d_aihouse_x - static_cast<int>(nearbyint(d_aihouse_w * 1.5)) - (10 * Factor),
-                    cur_ai_house_y,
-                    static_cast<int>(nearbyint(d_aihouse_w * 1.5)),
-                    d_aihouse_h,
+                    Dimensions[control].x,
+                    Dimensions[control].y,
+                    Dimensions[control].w,
+                    Dimensions[control].h,
                     UpButtonShape,
                     DownButtonShape
                 )
             );
-            Get_Control<DropListClass>(h).Add_Tail(*CommandChain);
+            Get_Control<DropListClass>(control).Add_Tail(*CommandChain);
 
-            Controls[house_button] = std::unique_ptr<GadgetClass>(
+            Controls[house_control] = std::unique_ptr<GadgetClass>(
                 new DropListClass(
-                    house_button,
-                    Text[house_button].get(),
+                    house_control,
+                    Text[house_control].get(),
                     DropdownTextLength,
                     TPF_6PT_GRAD | TPF_USE_GRAD_PAL | TPF_NOSHADOW,
-                    d_aihouse_x,
-                    cur_ai_house_y,
-                    d_aihouse_w,
-                    d_aihouse_h,
+                    Dimensions[house_control].x,
+                    Dimensions[house_control].y,
+                    Dimensions[house_control].w,
+                    Dimensions[house_control].h,
                     UpButtonShape,
                     DownButtonShape
                 )
             );
-            Get_Control<DropListClass>(house_button).Add_Tail(*CommandChain);
-
-            cur_ai_house_y += d_aihouse_ystep;
+            Get_Control<DropListClass>(house_control).Add_Tail(*CommandChain);
         }
 
         Controls[BUTTON_SCENARIOLIST] = std::unique_ptr<GadgetClass>(
             new ListClass(
                 BUTTON_SCENARIOLIST,
-                d_scenariolist_x,
-                d_scenariolist_y,
-                d_scenariolist_w,
-                d_scenariolist_h,
+                Dimensions[BUTTON_SCENARIOLIST].x,
+                Dimensions[BUTTON_SCENARIOLIST].y,
+                Dimensions[BUTTON_SCENARIOLIST].w,
+                Dimensions[BUTTON_SCENARIOLIST].h,
                 TPF_6PT_GRAD | TPF_USE_GRAD_PAL | TPF_NOSHADOW,
                 UpButtonShape,
                 DownButtonShape
@@ -688,10 +630,10 @@ class SkirmishScenarioDialog final
                 Text[BUTTON_NAME].get(),
                 MPLAYER_NAME_MAX,
                 TPF_6PT_GRAD | TPF_USE_GRAD_PAL | TPF_NOSHADOW,
-                d_name_x,
-                d_name_y,
-                d_name_w,
-                d_name_h,
+                Dimensions[BUTTON_NAME].x,
+                Dimensions[BUTTON_NAME].y,
+                Dimensions[BUTTON_NAME].w,
+                Dimensions[BUTTON_NAME].h,
                 EditClass::ALPHANUMERIC
             )
         );
@@ -703,10 +645,10 @@ class SkirmishScenarioDialog final
                 Text[BUTTON_HOUSE].get(),
                 DropdownTextLength,
                 TPF_6PT_GRAD | TPF_USE_GRAD_PAL | TPF_NOSHADOW,
-                d_house_x,
-                d_house_y,
-                d_house_w,
-                d_house_h,
+                Dimensions[BUTTON_HOUSE].x,
+                Dimensions[BUTTON_HOUSE].y,
+                Dimensions[BUTTON_HOUSE].w,
+                Dimensions[BUTTON_HOUSE].h,
                 UpButtonShape,
                 DownButtonShape
             )
@@ -743,15 +685,17 @@ class SkirmishScenarioDialog final
         /*........................................................................
         Dialog & button dimensions
         ........................................................................*/
-        Width = 300 * Factor;                      // dialog width
-        Height = 195 * Factor;                      // dialog height
-        X = (screen_width - Width) / 2; // dialog x-coord
-        Y = (screen_height - Height) / 2; // dialog y-coord
-        Center = X + (Width / 2);    // center x-coord
+        Width = 300 * Factor;
+        Height = 195 * Factor;
+        X = (screen_width - Width) / 2;
+        Y = (screen_height - Height) / 2;
+        Center = X + (Width / 2);
 
         TextHeight = 6 * Factor + 1; // ht of 6-pt text
-        MarginWidth = 10 * Factor;    // margin width/height
-        MarginHeight = 4 * Factor;    // margin width/height
+        MarginWidth = 10 * Factor;
+        MarginHeight = 4 * Factor;
+
+        Dimensions.clear();
 
         Dimensions[BUTTON_OK].w = 45 * Factor;
         Dimensions[BUTTON_OK].h = 9 * Factor;
@@ -763,78 +707,96 @@ class SkirmishScenarioDialog final
         Dimensions[BUTTON_CANCEL].x = X + Width - (Width / 6) - (Dimensions[BUTTON_CANCEL].w / 2);
         Dimensions[BUTTON_CANCEL].y = Y + Height - Dimensions[BUTTON_CANCEL].h - MarginWidth - Factor * 6;
 
-        d_ok_w = 45 * Factor;
-        d_ok_h = 9 * Factor;
-        d_ok_x = X + (Width / 6) - (d_ok_w / 2);
-        d_ok_y = Y + Height - d_ok_h - MarginWidth - Factor * 6;
+        Dimensions[BUTTON_NAME].w = 70 * Factor;
+        Dimensions[BUTTON_NAME].h = 9 * Factor;
+        Dimensions[BUTTON_NAME].x = X + 5 + (Width / 4) - (Dimensions[BUTTON_NAME].w / 2);
+        Dimensions[BUTTON_NAME].y = Y + MarginHeight + TextHeight + 1 * Factor;
 
-        d_cancel_w = 45 * Factor;
-        d_cancel_h = 9 * Factor;
-        d_cancel_x = X + Width - (Width / 6) - (d_cancel_w / 2);
-        d_cancel_y = Y + Height - d_cancel_h - MarginWidth - Factor * 6;
+        Dimensions[BUTTON_HOUSE].w = 60 * Factor;
+        Dimensions[BUTTON_HOUSE].h = (3 * 5 * Factor);
+        Dimensions[BUTTON_HOUSE].x = Center - (Dimensions[BUTTON_HOUSE].w / 2);
+        Dimensions[BUTTON_HOUSE].y = Dimensions[BUTTON_NAME].y;
 
-        d_name_w = 70 * Factor;
-        d_name_h = 9 * Factor;
-        d_name_x = X + 5 + (Width / 4) - (d_name_w / 2);
-        d_name_y = Y + MarginHeight + TextHeight + 1 * Factor;
+        Dimensions[BUTTON_COLOR_1].w = 10 * Factor;
+        Dimensions[BUTTON_COLOR_1].h = 9 * Factor;
+        Dimensions[BUTTON_COLOR_1].y = Dimensions[BUTTON_NAME].y;
+        Dimensions[BUTTON_COLOR_1].x = X + ((Width / 4) * 3) - (Dimensions[BUTTON_COLOR_1].w * 3);
 
-        d_house_w = 60 * Factor;
-        d_house_h = (3 * 5 * Factor);
-        d_house_x = Center - (d_house_w / 2);
-        d_house_y = d_name_y;
+        for (auto control = BUTTON_COLOR_2; control <= BUTTON_COLOR_6; ++control) {
+            Dimensions[control] = Dimensions[BUTTON_COLOR_1];
+            Dimensions[control].x = Dimensions[control].x + (Dimensions[control].w * (control - BUTTON_COLOR_1));
+        }
 
-        d_color_w = 10 * Factor;
-        d_color_h = 9 * Factor;
-        d_color_y = d_name_y;
-        d_color_x = X + ((Width / 4) * 3) - (d_color_w * 3);
+        Dimensions[BUTTON_PLAYERLIST].w = 118 * Factor;
+        Dimensions[BUTTON_PLAYERLIST].x = X + MarginWidth + MarginWidth + 5 * Factor;
 
-        d_playerlist_w = 118 * Factor;
-        d_playerlist_x = X + MarginWidth + MarginWidth + 5 * Factor;
+        Dimensions[BUTTON_SCENARIOLIST].w = 140 * Factor;
+        Dimensions[BUTTON_SCENARIOLIST].h = 30 * Factor;
+        Dimensions[BUTTON_SCENARIOLIST].x =
+            (Dimensions[BUTTON_CANCEL].x + static_cast<int>(nearbyint(Dimensions[BUTTON_CANCEL].w * 0.8)))
+            - Dimensions[BUTTON_SCENARIOLIST].w + (20 * Factor);
+        Dimensions[BUTTON_SCENARIOLIST].y = Dimensions[BUTTON_COLOR_1].y + TextHeight + 5 * Factor + TextHeight;
 
-        d_scenariolist_w = 140 * Factor;
-        d_scenariolist_h = 30 * Factor;
-        d_scenariolist_x = (d_cancel_x + static_cast<int>(nearbyint(d_cancel_w * 0.8))) - d_scenariolist_w + (20 * Factor);
-        d_scenariolist_y = d_color_y + TextHeight + 5 * Factor + TextHeight;
+        Dimensions[BUTTON_SCENARIOLIST].h *= 2;
 
-        d_scenariolist_h *= 2;
+        // right column of AI house controls
+        Dimensions[BUTTON_AI_HOUSE_1].w = static_cast<int>(nearbyint(Dimensions[BUTTON_HOUSE].w / 1.75));
+        Dimensions[BUTTON_AI_HOUSE_1].h = (6 * 5 * Factor);
+        Dimensions[BUTTON_AI_HOUSE_1].x = Dimensions[BUTTON_SCENARIOLIST].x
+            - Dimensions[BUTTON_AI_HOUSE_1].w - (10 * Factor);
+        Dimensions[BUTTON_AI_HOUSE_1].y = Dimensions[BUTTON_SCENARIOLIST].y + (5 * Factor);
 
-        d_aihouse_w = static_cast<int>(nearbyint(d_house_w / 1.75));
-        d_aihouse_h = (6 * 5 * Factor);
-        d_aihouse_x = d_scenariolist_x - d_aihouse_w - (10 * Factor);
-        d_aihouse_y = d_scenariolist_y + (5 * Factor);
-        d_aihouse_ystep = 10 * Factor;
+        for (auto control = BUTTON_AI_HOUSE_2; control <= BUTTON_AI_HOUSE_5; ++control) {
+            const auto previous_control = static_cast<ButtonType>(control - 1);
 
-        d_options_w = static_cast<int>(nearbyint(d_scenariolist_w * 0.8));
-        d_options_h = (5 * 6 * Factor) + 5 * Factor;
-        d_options_x = (d_scenariolist_x + d_scenariolist_w) - d_options_w;
-        d_options_y = d_scenariolist_y + d_scenariolist_h + MarginWidth - 2 * Factor;
+            Dimensions[control] = Dimensions[BUTTON_AI_HOUSE_1];
+            Dimensions[control].y = Dimensions[previous_control].y + 10 * Factor;
+        }
 
-        d_count_w = 25 * Factor;
-        d_count_h = 7 * Factor;
-        d_count_y = d_options_y;
-        d_count_x = d_playerlist_x + (d_playerlist_w / 2) + 20 * Factor; // fudged
+        // left column of AI house controls
+        Dimensions[BUTTON_AI_DIFF_1].w = static_cast<int>(nearbyint(Dimensions[BUTTON_AI_HOUSE_1].w * 1.5));
+        Dimensions[BUTTON_AI_DIFF_1].h = Dimensions[BUTTON_AI_HOUSE_1].h;
+        Dimensions[BUTTON_AI_DIFF_1].x = Dimensions[BUTTON_AI_HOUSE_1].x
+            - static_cast<int>(nearbyint(Dimensions[BUTTON_AI_HOUSE_1].w * 1.5)) - (10 * Factor);
+        Dimensions[BUTTON_AI_DIFF_1].y = Dimensions[BUTTON_AI_HOUSE_1].y;
 
-        d_level_w = 25 * Factor;
-        d_level_h = 7 * Factor;
-        d_level_y = d_count_y + d_count_h;
-        d_level_x = d_playerlist_x + (d_playerlist_w / 2) + 20 * Factor; // fudged
+        for (auto control = BUTTON_AI_DIFF_2; control <= BUTTON_AI_DIFF_5; ++control) {
+            const auto previous_control = static_cast<ButtonType>(control - 1);
 
-        d_credits_w = 25 * Factor;
-        d_credits_h = 7 * Factor;
-        d_credits_x = d_playerlist_x + (d_playerlist_w / 2) + 20 * Factor; // fudged;
-        d_credits_y = d_level_y + d_level_h;
+            Dimensions[control] = Dimensions[BUTTON_AI_DIFF_1];
+            Dimensions[control].y = Dimensions[previous_control].y + 10 * Factor;
+        }
 
-        d_tiberiumscale_w = 25 * Factor;
-        d_tiberiumscale_h = 7 * Factor;
-        d_tiberiumscale_x = d_playerlist_x + (d_playerlist_w / 2) + 20 * Factor; // fudged;
-        d_tiberiumscale_y = d_credits_y + d_credits_h;
+        Dimensions[BUTTON_OPTIONS].w = static_cast<int>(nearbyint(Dimensions[BUTTON_SCENARIOLIST].w * 0.8));
+        Dimensions[BUTTON_OPTIONS].h = (5 * 6 * Factor) + 5 * Factor;
+        Dimensions[BUTTON_OPTIONS].x = (Dimensions[BUTTON_SCENARIOLIST].x + Dimensions[BUTTON_SCENARIOLIST].w)
+            - Dimensions[BUTTON_OPTIONS].w;
+        Dimensions[BUTTON_OPTIONS].y = Dimensions[BUTTON_SCENARIOLIST].y + Dimensions[BUTTON_SCENARIOLIST].h
+            + MarginWidth - 2 * Factor;
 
-        ColorBoxes[0] = d_color_x;
-        ColorBoxes[1] = d_color_x + d_color_w;
-        ColorBoxes[2] = d_color_x + (d_color_w * 2);
-        ColorBoxes[3] = d_color_x + (d_color_w * 3);
-        ColorBoxes[4] = d_color_x + (d_color_w * 4);
-        ColorBoxes[5] = d_color_x + (d_color_w * 5);
+        Dimensions[BUTTON_COUNT].w = 25 * Factor;
+        Dimensions[BUTTON_COUNT].h = 7 * Factor;
+        Dimensions[BUTTON_COUNT].y = Dimensions[BUTTON_OPTIONS].y;
+        Dimensions[BUTTON_COUNT].x = Dimensions[BUTTON_PLAYERLIST].x + (Dimensions[BUTTON_PLAYERLIST].w / 2)
+            + 20 * Factor;
+
+        Dimensions[BUTTON_LEVEL].w = 25 * Factor;
+        Dimensions[BUTTON_LEVEL].h = 7 * Factor;
+        Dimensions[BUTTON_LEVEL].y = Dimensions[BUTTON_COUNT].y + Dimensions[BUTTON_COUNT].h;
+        Dimensions[BUTTON_LEVEL].x = Dimensions[BUTTON_PLAYERLIST].x + (Dimensions[BUTTON_PLAYERLIST].w / 2)
+            + 20 * Factor;
+
+        Dimensions[BUTTON_CREDITS].w = 25 * Factor;
+        Dimensions[BUTTON_CREDITS].h = 7 * Factor;
+        Dimensions[BUTTON_CREDITS].x = Dimensions[BUTTON_PLAYERLIST].x + (Dimensions[BUTTON_PLAYERLIST].w / 2)
+            + 20 * Factor;
+        Dimensions[BUTTON_CREDITS].y = Dimensions[BUTTON_LEVEL].y + Dimensions[BUTTON_LEVEL].h;
+
+        Dimensions[BUTTON_TIBERIUMSCALE].w = 25 * Factor;
+        Dimensions[BUTTON_TIBERIUMSCALE].h = 7 * Factor;
+        Dimensions[BUTTON_TIBERIUMSCALE].x = Dimensions[BUTTON_PLAYERLIST].x + (Dimensions[BUTTON_PLAYERLIST].w / 2)
+            + 20 * Factor;
+        Dimensions[BUTTON_TIBERIUMSCALE].y = Dimensions[BUTTON_CREDITS].y + Dimensions[BUTTON_CREDITS].h;
     }
 
 public:
@@ -996,9 +958,9 @@ public:
                 User clicks on a color button
                 ------------------------------------------------------------------*/
                 case KN_LMOUSE:
-                    if (Keyboard->MouseQX > ColorBoxes[0] && Keyboard->MouseQX < (ColorBoxes[MAX_MPLAYER_COLORS - 1] + d_color_w)
-                        && Keyboard->MouseQY > d_color_y && Keyboard->MouseQY < (d_color_y + d_color_h)) {
-                        MPlayerPrefColor = (Keyboard->MouseQX - ColorBoxes[0]) / d_color_w;
+                    if (Keyboard->MouseQX > Dimensions[BUTTON_COLOR_1].x && Keyboard->MouseQX < (Dimensions[BUTTON_COLOR_6].x + Dimensions[BUTTON_COLOR_6].w)
+                        && Keyboard->MouseQY > Dimensions[BUTTON_COLOR_1].y && Keyboard->MouseQY < (Dimensions[BUTTON_COLOR_6].y + Dimensions[BUTTON_COLOR_6].h)) {
+                        MPlayerPrefColor = (Keyboard->MouseQX - Dimensions[BUTTON_COLOR_1].x) / Dimensions[BUTTON_COLOR_1].w;
                         MPlayerColorIdx = MPlayerPrefColor;
                         display = REDRAW_COLORS;
 

--- a/tiberiandawn/nulldlg.cpp
+++ b/tiberiandawn/nulldlg.cpp
@@ -1011,7 +1011,6 @@ int Com_Scenario_Dialog(void)
                     diff_dropdown.Set_Selected_Index(2);
                 }
 
-                CNC_LOG_WARN("REDRAW: {}", (int)idx);
                 house_dropdown.Collapse();
                 diff_dropdown.Collapse();
                 display = REDRAW_BACKGROUND;

--- a/tiberiandawn/nulldlg.cpp
+++ b/tiberiandawn/nulldlg.cpp
@@ -940,7 +940,7 @@ int Com_Scenario_Dialog(void)
         case (BUTTON_AI_DIFF_3 | KN_BUTTON):
         case (BUTTON_AI_DIFF_4 | KN_BUTTON):
         case (BUTTON_AI_DIFF_5 | KN_BUTTON): {
-            for (auto idx = BUTTON_AI_DIFF_1; idx < BUTTON_AI_DIFF_5; ++idx) {
+            for (auto idx = BUTTON_AI_DIFF_1; idx <= BUTTON_AI_DIFF_5; ++idx) {
                 if (input != (idx | KN_BUTTON)) {
                     continue;
                 }
@@ -966,6 +966,7 @@ int Com_Scenario_Dialog(void)
                     house_dropdown.Set_Selected_Index(1);
                 }
 
+                CNC_LOG_WARN("REDRAW: {}", (int)idx);
                 diff_dropdown.Collapse();
                 house_dropdown.Collapse();
                 display = REDRAW_BACKGROUND;
@@ -984,7 +985,7 @@ int Com_Scenario_Dialog(void)
         case (BUTTON_AI_HOUSE_3 | KN_BUTTON):
         case (BUTTON_AI_HOUSE_4 | KN_BUTTON):
         case (BUTTON_AI_HOUSE_5 | KN_BUTTON): {
-            for (auto idx = BUTTON_AI_HOUSE_1; idx < BUTTON_AI_HOUSE_5; ++idx) {
+            for (auto idx = BUTTON_AI_HOUSE_1; idx <= BUTTON_AI_HOUSE_5; ++idx) {
                 if (input != (idx | KN_BUTTON)) {
                     continue;
                 }
@@ -1010,6 +1011,7 @@ int Com_Scenario_Dialog(void)
                     diff_dropdown.Set_Selected_Index(2);
                 }
 
+                CNC_LOG_WARN("REDRAW: {}", (int)idx);
                 house_dropdown.Collapse();
                 diff_dropdown.Collapse();
                 display = REDRAW_BACKGROUND;

--- a/tiberiandawn/nulldlg.cpp
+++ b/tiberiandawn/nulldlg.cpp
@@ -132,17 +132,17 @@ int Com_Scenario_Dialog(void)
 
     int d_scenariolist_w = 152 * factor;
     int d_scenariolist_h = 30 * factor;
-    int d_scenariolist_x = (d_cancel_x + nearbyint(d_cancel_w * 0.8)) - d_scenariolist_w + (10 * factor);
+    int d_scenariolist_x = (d_cancel_x + static_cast<int>(nearbyint(d_cancel_w * 0.8))) - d_scenariolist_w + (10 * factor);
     int d_scenariolist_y = d_color_y + d_txt6_h + 5 * factor + d_txt6_h;
     d_scenariolist_h *= 2;
 
     int d_aihouse_w = d_house_w / 3;
     int d_aihouse_h = (6 * 5 * factor);
     int d_aihouse_x = d_scenariolist_x - d_aihouse_w - (10 * factor);
-    int d_aihouse_y = d_scenariolist_y + (2 * factor);
+    int d_aihouse_y = d_scenariolist_y + (5 * factor);
     int d_aihouse_ystep = 10 * factor;
 
-    int d_options_w = nearbyint(d_scenariolist_w * 0.6);
+    int d_options_w = static_cast<int>(nearbyint(d_scenariolist_w * 0.6));
     int d_options_h = (5 * 6 * factor) + 5 * factor;
     int d_options_x = (d_scenariolist_x + d_scenariolist_w) - d_options_w;
     int d_options_y = d_scenariolist_y + d_scenariolist_h + d_margin1 - 2 * factor;
@@ -162,15 +162,15 @@ int Com_Scenario_Dialog(void)
     int d_credits_x = d_playerlist_x + (d_playerlist_w / 2) + 20 * factor; // fudged;
     int d_credits_y = d_level_y + d_level_h;
 
-    int d_aiplayers_w = 25 * factor;
-    int d_aiplayers_h = 7 * factor;
-    int d_aiplayers_x = d_playerlist_x + (d_playerlist_w / 2) + 20 * factor; // fudged;
-    int d_aiplayers_y = d_credits_y + d_credits_h;
+    //int d_aiplayers_w = 25 * factor;
+    //int d_aiplayers_h = 7 * factor;
+    //int d_aiplayers_x = d_playerlist_x + (d_playerlist_w / 2) + 20 * factor; // fudged;
+    //int d_aiplayers_y = d_credits_y + d_credits_h;
 
     int d_tiberiumscale_w = 25 * factor;
     int d_tiberiumscale_h = 7 * factor;
     int d_tiberiumscale_x = d_playerlist_x + (d_playerlist_w / 2) + 20 * factor; // fudged;
-    int d_tiberiumscale_y = d_aiplayers_y + d_aiplayers_h;
+    int d_tiberiumscale_y = d_credits_y + d_credits_h;
 
     /*........................................................................
     Button Enumerations
@@ -179,13 +179,18 @@ int Com_Scenario_Dialog(void)
     {
         BUTTON_NAME = 100,
         BUTTON_HOUSE,
+        BUTTON_AI_DIFF_1,
+        BUTTON_AI_DIFF_2,
+        BUTTON_AI_DIFF_3,
+        BUTTON_AI_DIFF_4,
+        BUTTON_AI_DIFF_5,
         BUTTON_AI_HOUSE_1,
         BUTTON_AI_HOUSE_2,
         BUTTON_AI_HOUSE_3,
         BUTTON_AI_HOUSE_4,
         BUTTON_AI_HOUSE_5,
         BUTTON_CREDITS,
-        BUTTON_AIPLAYERS,
+        //BUTTON_AIPLAYERS,
         BUTTON_TIBERIUMSCALE,
         BUTTON_OPTIONS,
         BUTTON_SCENARIOLIST,
@@ -291,7 +296,7 @@ int Com_Scenario_Dialog(void)
 
     auto cur_ai_house_y = d_aihouse_y;
 
-    for (auto h = BUTTON_AI_HOUSE_1; h <= BUTTON_AI_HOUSE_5; ++h) {
+    for (auto h = BUTTON_AI_DIFF_1; h <= BUTTON_AI_DIFF_5; ++h) {
         constexpr auto label_str_length = 25;
         ai_diff_strings.emplace_back() = std::make_unique<char[]>(label_str_length);
         ai_house_strings.emplace_back() = std::make_unique<char[]>(label_str_length);
@@ -301,16 +306,16 @@ int Com_Scenario_Dialog(void)
             ai_diff_strings.back().get(),
             label_str_length,
             TPF_6PT_GRAD | TPF_USE_GRAD_PAL | TPF_NOSHADOW,
-            d_aihouse_x - (nearbyint(d_aihouse_w * 1.5)) - (10 * factor),
+            d_aihouse_x - static_cast<int>(nearbyint(d_aihouse_w * 1.5)) - (10 * factor),
             cur_ai_house_y,
-            nearbyint(d_aihouse_w * 1.5),
+            static_cast<int>(nearbyint(d_aihouse_w * 1.5)),
             d_aihouse_h,
             up_button,
             down_button
         );
 
         ai_house_dropdowns.emplace_back(
-            h,
+            h + 5,
             ai_house_strings.back().get(),
             label_str_length,
             TPF_6PT_GRAD | TPF_USE_GRAD_PAL | TPF_NOSHADOW,
@@ -340,7 +345,7 @@ int Com_Scenario_Dialog(void)
 
     GaugeClass creditsgauge(BUTTON_CREDITS, d_credits_x, d_credits_y, d_credits_w, d_credits_h);
 
-    GaugeClass aiplayersgauge(BUTTON_AIPLAYERS, d_aiplayers_x, d_aiplayers_y, d_aiplayers_w, d_aiplayers_h);
+    //GaugeClass aiplayersgauge(BUTTON_AIPLAYERS, d_aiplayers_x, d_aiplayers_y, d_aiplayers_w, d_aiplayers_h);
 
     GaugeClass tiberiumscalegauge(BUTTON_TIBERIUMSCALE, d_tiberiumscale_x, d_tiberiumscale_y, d_tiberiumscale_w, d_tiberiumscale_h);
 
@@ -396,7 +401,7 @@ int Com_Scenario_Dialog(void)
     countgauge.Add_Tail(*commands);
     levelgauge.Add_Tail(*commands);
     creditsgauge.Add_Tail(*commands);
-    aiplayersgauge.Add_Tail(*commands);
+    //aiplayersgauge.Add_Tail(*commands);
     tiberiumscalegauge.Add_Tail(*commands);
     optionlist.Add_Tail(*commands);
     okbtn.Add_Tail(*commands);
@@ -421,14 +426,14 @@ int Com_Scenario_Dialog(void)
     housebtn.Set_Read_Only(true);
 
     int maxp = 4 /*Rule.MaxPlayers - 2*/;
-    aiplayersgauge.Set_Maximum(maxp);
+    //aiplayersgauge.Set_Maximum(maxp);
 
     if (MPlayerGhosts > 5) {
         MPlayerGhosts = 5;
     }
     MPlayerGhosts = max(MPlayerGhosts, 1);
 
-    aiplayersgauge.Set_Value(MPlayerGhosts - 1);
+    //aiplayersgauge.Set_Value(MPlayerGhosts - 1);
 
     for (auto idx = 0; idx < ai_diff_dropdowns.size(); idx++) {
         ai_diff_dropdowns[idx].Add_Item("Disabled");
@@ -436,7 +441,6 @@ int Com_Scenario_Dialog(void)
         ai_diff_dropdowns[idx].Add_Item("Normal");
         ai_diff_dropdowns[idx].Add_Item("Hard");
         ai_diff_dropdowns[idx].Set_Selected_Index(idx < MPlayerGhosts ? 2 : 0);
-        ai_diff_dropdowns[idx].List.Reset_Index_Change();
         ai_diff_dropdowns[idx].Set_Read_Only(true);
 
         ai_house_dropdowns[idx].Add_Item("None");
@@ -445,7 +449,6 @@ int Com_Scenario_Dialog(void)
         ai_house_dropdowns[idx].Add_Item(Text_String(TXT_N_O_D));
         //ai_house_dropdowns[idx].Add_Item("Dino");
         ai_house_dropdowns[idx].Set_Selected_Index(idx < MPlayerGhosts ? 1 : 0);
-        ai_house_dropdowns[idx].List.Reset_Index_Change();
         ai_house_dropdowns[idx].Set_Read_Only(true);
     }
 
@@ -588,21 +591,21 @@ int Com_Scenario_Dialog(void)
 
                 Fancy_Text_Print(TXT_YOUR_NAME,
                                  d_name_x + (d_name_w / 2),
-                                 d_name_y - d_txt6_h,
+                                 d_name_y - d_txt6_h - (1 * factor),
                                  CC_GREEN,
                                  TBLACK,
                                  TPF_RIGHT | TPF_6PT_GRAD | TPF_USE_GRAD_PAL | TPF_NOSHADOW);
 
                 Fancy_Text_Print(TXT_SIDE_COLON,
                                  d_house_x + (d_house_w / 2),
-                                 d_house_y - d_txt6_h,
+                                 d_house_y - d_txt6_h - (1 * factor),
                                  CC_GREEN,
                                  TBLACK,
                                  TPF_RIGHT | TPF_6PT_GRAD | TPF_USE_GRAD_PAL | TPF_NOSHADOW);
 
                 Fancy_Text_Print(TXT_COLOR_COLON,
                                  d_dialog_x + ((d_dialog_w / 4) * 3),
-                                 d_color_y - d_txt6_h,
+                                 d_color_y - d_txt6_h - (1 * factor),
                                  CC_GREEN,
                                  TBLACK,
                                  TPF_RIGHT | TPF_6PT_GRAD | TPF_USE_GRAD_PAL | TPF_NOSHADOW);
@@ -656,12 +659,12 @@ int Com_Scenario_Dialog(void)
                                  TBLACK,
                                  TPF_RIGHT | TPF_6PT_GRAD | TPF_USE_GRAD_PAL | TPF_NOSHADOW);
 
-                Fancy_Text_Print(TXT_AI_PLAYERS_COLON,
-                                 d_aiplayers_x - 3 * factor,
-                                 d_aiplayers_y,
-                                 CC_GREEN,
-                                 TBLACK,
-                                 TPF_RIGHT | TPF_6PT_GRAD | TPF_USE_GRAD_PAL | TPF_NOSHADOW);
+                // Fancy_Text_Print(TXT_AI_PLAYERS_COLON,
+                //                  d_aiplayers_x - 3 * factor,
+                //                  d_aiplayers_y,
+                //                  CC_GREEN,
+                //                  TBLACK,
+                //                  TPF_RIGHT | TPF_6PT_GRAD | TPF_USE_GRAD_PAL | TPF_NOSHADOW);
 
                 Fancy_Text_Print("Tiberium Growth:", // TODO: Locale file entry
                                  d_tiberiumscale_x - 3 * factor,
@@ -669,6 +672,37 @@ int Com_Scenario_Dialog(void)
                                  CC_GREEN,
                                  TBLACK,
                                  TPF_RIGHT | TPF_6PT_GRAD | TPF_USE_GRAD_PAL | TPF_NOSHADOW);
+
+                Fancy_Text_Print("Player", // TODO: Locale file entry
+                                 (d_aihouse_x - static_cast<int>(nearbyint(d_aihouse_w * 1.5)) - (10 * factor))
+                                    + (static_cast<int>((d_aihouse_w * 1.5) / 1.25)),
+                                 d_aihouse_y - d_txt6_h - (2 * factor),
+                                 CC_GREEN,
+                                 TBLACK,
+                                 TPF_RIGHT | TPF_6PT_GRAD | TPF_USE_GRAD_PAL | TPF_NOSHADOW);
+
+                Fancy_Text_Print("Side", // TODO: Locale file entry
+                                 d_aihouse_x + static_cast<int>(nearbyint(d_aihouse_w / 1.25)),
+                                 d_aihouse_y - d_txt6_h - (2 * factor),
+                                 CC_GREEN,
+                                 TBLACK,
+                                 TPF_RIGHT | TPF_6PT_GRAD | TPF_USE_GRAD_PAL | TPF_NOSHADOW);
+
+                // AI player difficulty and house checkbox labels
+                const auto cur_ai_house_label_x = (d_aihouse_x - static_cast<int>(nearbyint(d_aihouse_w * 1.5))
+                    - (10 * factor)) - 3 * factor;
+                auto cur_ai_house_label_y = d_aihouse_y;
+
+                for (auto idx = 0; idx < ai_diff_dropdowns.size(); idx++) {
+                    Fancy_Text_Print(std::format("AI {}:", idx + 1).c_str(), // TODO: Locale file entry
+                                     cur_ai_house_label_x,
+                                     cur_ai_house_label_y,
+                                     CC_GREEN,
+                                     TBLACK,
+                                     TPF_RIGHT | TPF_6PT_GRAD | TPF_USE_GRAD_PAL | TPF_NOSHADOW);
+
+                    cur_ai_house_label_y += d_aihouse_ystep;
+                }
             }
 
             /*..................................................................
@@ -722,13 +756,13 @@ int Com_Scenario_Dialog(void)
                                  BLACK,
                                  TPF_6PT_GRAD | TPF_USE_GRAD_PAL | TPF_NOSHADOW);
 
-                sprintf(txt, "%d ", MPlayerGhosts);
-                Fancy_Text_Print(txt,
-                                 d_aiplayers_x + d_aiplayers_w + 3 * factor,
-                                 d_aiplayers_y,
-                                 CC_GREEN,
-                                 BLACK,
-                                 TPF_6PT_GRAD | TPF_USE_GRAD_PAL | TPF_NOSHADOW);
+                // sprintf(txt, "%d ", MPlayerGhosts);
+                // Fancy_Text_Print(txt,
+                //                  d_aiplayers_x + d_aiplayers_w + 3 * factor,
+                //                  d_aiplayers_y,
+                //                  CC_GREEN,
+                //                  BLACK,
+                //                  TPF_6PT_GRAD | TPF_USE_GRAD_PAL | TPF_NOSHADOW);
                 sprintf(txt, "%dx ", tiberiumscalegauge.Get_Value() + 1);
                 Fancy_Text_Print(txt,
                                  d_tiberiumscale_x + d_tiberiumscale_w + 3 * factor,
@@ -855,12 +889,12 @@ int Com_Scenario_Dialog(void)
                     collapse_visible_dropdowns();
                     transmit = 1;
                 }
-            }
+                }
             break;
 
-        /*------------------------------------------------------------------
-        User edits the name field; retransmit new game options
-        ------------------------------------------------------------------*/
+            /*------------------------------------------------------------------
+            User edits the name field; retransmit new game options
+            ------------------------------------------------------------------*/
         case (BUTTON_NAME | KN_BUTTON):
             if (!ready_to_go) {
                 strcpy(MPlayerName, namebuf);
@@ -869,9 +903,9 @@ int Com_Scenario_Dialog(void)
             }
             break;
 
-        /*------------------------------------------------------------------
-        House Buttons: set the player's desired House
-        ------------------------------------------------------------------*/
+            /*------------------------------------------------------------------
+            House Buttons: set the player's desired House
+            ------------------------------------------------------------------*/
         case (BUTTON_HOUSE | KN_BUTTON):
             MPlayerHouse = HousesType(housebtn.Current_Index() + HOUSE_GOOD);
             strcpy(MPlayerName, namebuf);
@@ -882,9 +916,9 @@ int Com_Scenario_Dialog(void)
             transmit = true;
             break;
 
-        /*------------------------------------------------------------------
-        New Scenario selected.
-        ------------------------------------------------------------------*/
+            /*------------------------------------------------------------------
+            New Scenario selected.
+            ------------------------------------------------------------------*/
         case (BUTTON_SCENARIOLIST | KN_BUTTON):
             if (scenariolist.Current_Index() != ScenarioIdx && !ready_to_go) {
                 ScenarioIdx = scenariolist.Current_Index();
@@ -898,75 +932,92 @@ int Com_Scenario_Dialog(void)
             }
             break;
 
+            /*------------------------------------------------------------------
+            AI player difficulty dropdown selection changed.
+            ------------------------------------------------------------------*/
+        case (BUTTON_AI_DIFF_1 | KN_BUTTON):
+        case (BUTTON_AI_DIFF_2 | KN_BUTTON):
+        case (BUTTON_AI_DIFF_3 | KN_BUTTON):
+        case (BUTTON_AI_DIFF_4 | KN_BUTTON):
+        case (BUTTON_AI_DIFF_5 | KN_BUTTON): {
+            for (auto idx = BUTTON_AI_DIFF_1; idx < BUTTON_AI_DIFF_5; ++idx) {
+                if (input != (idx | KN_BUTTON)) {
+                    continue;
+                }
+
+                auto& diff_dropdown = ai_diff_dropdowns[idx - BUTTON_AI_DIFF_1];
+
+                // nothing changed, ignore input
+                if (!diff_dropdown.List.Index_Changed()) {
+                    break;
+                }
+
+                auto& house_dropdown = ai_house_dropdowns[idx - BUTTON_AI_DIFF_1];
+
+                const auto diff_was_disabled = diff_dropdown.Current_Index() == 0;
+                const auto diff_was_activated = diff_dropdown.List.Get_Previous_Index() == 0;
+                const auto house_is_disabled = house_dropdown.Current_Index() == 0;
+
+                if (diff_was_disabled) {
+                    // reset house to match disabled AI diff
+                    house_dropdown.Set_Selected_Index(0);
+                } else if (diff_was_activated && house_is_disabled) {
+                    // select a default house of '?' since none is selected
+                    house_dropdown.Set_Selected_Index(1);
+                }
+
+                diff_dropdown.Collapse();
+                house_dropdown.Collapse();
+                display = REDRAW_BACKGROUND;
+                transmit = true;
+                break;
+            }
+
+            break;
+        }
+
+            /*------------------------------------------------------------------
+            AI player house dropdown selection changed.
+            ------------------------------------------------------------------*/
         case (BUTTON_AI_HOUSE_1 | KN_BUTTON):
         case (BUTTON_AI_HOUSE_2 | KN_BUTTON):
         case (BUTTON_AI_HOUSE_3 | KN_BUTTON):
         case (BUTTON_AI_HOUSE_4 | KN_BUTTON):
-        case (BUTTON_AI_HOUSE_5 | KN_BUTTON):
-            for (auto idx = 0; idx < ai_diff_dropdowns.size(); idx++) {
-                auto& diff_dropdown = ai_diff_dropdowns[idx];
-                auto& house_dropdown = ai_house_dropdowns[idx];
-                const auto selected_diff_changed = diff_dropdown.List.Index_Changed();
-                const auto selected_house_changed = house_dropdown.List.Index_Changed();
-
-                // one of the two house dropdowns was changed
-                if (selected_diff_changed || selected_house_changed) {
-                    auto selected_diff_idx = diff_dropdown.Current_Index();
-                    auto selected_house_idx = house_dropdown.Current_Index();
-
-                    const auto diff_was_disabled =  selected_diff_idx == 0 && selected_diff_changed;
-                    const auto house_was_disabled = selected_house_idx == 0 && selected_house_changed;
-                    const auto diff_was_activated =  selected_diff_changed && diff_dropdown.List.Get_Previous_Index() == 0;
-                    const auto house_was_activated = selected_house_changed && house_dropdown.List.Get_Previous_Index() == 0;
-
-                    if (diff_was_disabled) {
-                        // reset house to match disabled AI diff
-                        selected_house_idx = 0;
-                        house_dropdown.Set_Selected_Index(selected_house_idx);
-                        diff_dropdown.List.Reset_Index_Change();
-                    } else if (house_was_disabled) {
-                        // reset diff to match disabled AI house
-                        selected_diff_idx = 0;
-                        diff_dropdown.Set_Selected_Index(selected_diff_idx);
-                        diff_dropdown.List.Reset_Index_Change();
-                    } else if (diff_was_activated && selected_house_idx == 0) {
-                        // select a default house of '?' since none is selected
-                        selected_house_idx = 1;
-                        house_dropdown.Set_Selected_Index(selected_house_idx);
-                        house_dropdown.List.Reset_Index_Change();
-                    } else if (house_was_activated && selected_diff_idx == 0) {
-                        // select a default diff of 'Normal' since none is selected
-                        selected_diff_idx = 2;
-                        diff_dropdown.Set_Selected_Index(selected_diff_idx);
-                        diff_dropdown.List.Reset_Index_Change();
-                    }
-
-                    // adjust indices to match appropriate enum values
-                    const auto house_idx = idx + 1;
-                    const auto selected_diff = selected_diff_idx == 0
-                        ? DIFF_NONE
-                        : static_cast<DiffType>(selected_diff_idx - 1);
-                    const auto selected_house = selected_house_idx < 2
-                        ? HOUSE_NONE
-                        : static_cast<HousesType>(selected_house_idx - 2);
-
-                    CNC_LOG_WARN(
-                        "Setting MUTI{} house to '{}' and acts like: {}",
-                        house_idx,
-                        TdTypeConverter::To_String(selected_diff), TdTypeConverter::To_String(selected_house)
-                    );
-
-                    MPlayerHouses[idx + 1] = selected_house;
-                    MPlayerDifficulty[idx] = selected_diff;
-
-                    diff_dropdown.Collapse();
-                    house_dropdown.Collapse();
-                    display = REDRAW_BACKGROUND;
-                    transmit = true;
+        case (BUTTON_AI_HOUSE_5 | KN_BUTTON): {
+            for (auto idx = BUTTON_AI_HOUSE_1; idx < BUTTON_AI_HOUSE_5; ++idx) {
+                if (input != (idx | KN_BUTTON)) {
+                    continue;
                 }
+
+                auto& house_dropdown = ai_house_dropdowns[idx - BUTTON_AI_HOUSE_1];
+
+                // nothing changed, ignore input
+                if (!house_dropdown.List.Index_Changed()) {
+                    break;
+                }
+
+                auto& diff_dropdown = ai_diff_dropdowns[idx - BUTTON_AI_HOUSE_1];
+
+                const auto house_was_disabled = house_dropdown.Current_Index() == 0;
+                const auto house_was_activated = house_dropdown.List.Get_Previous_Index() == 0;
+                const auto diff_is_disabled = diff_dropdown.Current_Index() == 0;
+
+                if (house_was_disabled) {
+                    // reset diff to match disabled AI house
+                    diff_dropdown.Set_Selected_Index(0);
+                } else if (house_was_activated && diff_is_disabled) {
+                    // select a default diff of 'Normal' since none is selected
+                    diff_dropdown.Set_Selected_Index(2);
+                }
+
+                house_dropdown.Collapse();
+                diff_dropdown.Collapse();
+                display = REDRAW_BACKGROUND;
+                transmit = true;
             }
 
             break;
+        }
 
         /*------------------------------------------------------------------
         User adjusts max # units
@@ -1021,24 +1072,24 @@ int Com_Scenario_Dialog(void)
         /*------------------------------------------------------------------
         User adjusts # of AI players
         ------------------------------------------------------------------*/
-        case (BUTTON_AIPLAYERS | KN_BUTTON):
-            if (!ready_to_go) {
-                MPlayerGhosts = aiplayersgauge.Get_Value();
-                int humans = 1; // One humans.
-                MPlayerGhosts += 1;
-                if (MPlayerGhosts + humans >= 6 /*Rule.MaxPlayers*/) { // if it's pegged, max it out
-                    MPlayerGhosts = 6 /*Rule.MaxPlayers*/ - humans;
-                    aiplayersgauge.Set_Value(MPlayerGhosts - 1);
-                }
-                transmit = true;
-                if (display < REDRAW_MESSAGE)
-                    display = REDRAW_MESSAGE;
-
-                collapse_visible_dropdowns();
-
-                break;
-            }
-            break;
+        // case (BUTTON_AIPLAYERS | KN_BUTTON):
+        //     if (!ready_to_go) {
+        //         MPlayerGhosts = aiplayersgauge.Get_Value();
+        //         int humans = 1; // One humans.
+        //         MPlayerGhosts += 1;
+        //         if (MPlayerGhosts + humans >= 6 /*Rule.MaxPlayers*/) { // if it's pegged, max it out
+        //             MPlayerGhosts = 6 /*Rule.MaxPlayers*/ - humans;
+        //             aiplayersgauge.Set_Value(MPlayerGhosts - 1);
+        //         }
+        //         transmit = true;
+        //         if (display < REDRAW_MESSAGE)
+        //             display = REDRAW_MESSAGE;
+        //
+        //         collapse_visible_dropdowns();
+        //
+        //         break;
+        //     }
+        //     break;
 
         case (BUTTON_TIBERIUMSCALE | KN_BUTTON):
             if (!ready_to_go) {
@@ -1211,6 +1262,35 @@ int Com_Scenario_Dialog(void)
             Scen.CDifficulty = DIFF_EASY;
             Scen.Difficulty = DIFF_HARD;
             break;
+        }
+
+        // set AI player variables from difficulty/house dropdowns
+        MPlayerGhosts = 0;
+
+        for (auto idx = 0; idx < ai_diff_dropdowns.size(); idx++) {
+            auto& diff_dropdown = ai_diff_dropdowns[idx];
+            auto& house_dropdown = ai_house_dropdowns[idx];
+
+            // skip disabled slots
+            if (diff_dropdown.Current_Index() == 0) {
+                continue;
+            }
+
+            // populate 'slot' with correct difficulty and house overrides
+            const auto selected_diff_idx = diff_dropdown.Current_Index();
+            const auto selected_house_idx = house_dropdown.Current_Index();
+
+            const auto selected_diff = selected_diff_idx == 0
+                ? DIFF_NONE
+                : static_cast<DiffType>(selected_diff_idx - 1);
+            const auto selected_house = selected_house_idx < 2
+                ? HOUSE_NONE
+                : static_cast<HousesType>(selected_house_idx - 2);
+
+            MPlayerHouses[MPlayerGhosts + 1] = selected_house;
+            MPlayerDifficulty[MPlayerGhosts + 1] = selected_diff;
+
+            MPlayerGhosts++;
         }
     }
 

--- a/tiberiandawn/nulldlg.cpp
+++ b/tiberiandawn/nulldlg.cpp
@@ -97,6 +97,16 @@ int Com_Scenario_Dialog(void)
     int d_margin1 = 10 * factor;    // margin width/height
     int d_margin2 = 4 * factor;    // margin width/height
 
+    int d_ok_w = 45 * factor;
+    int d_ok_h = 9 * factor;
+    int d_ok_x = d_dialog_x + (d_dialog_w / 6) - (d_ok_w / 2);
+    int d_ok_y = d_dialog_y + d_dialog_h - d_ok_h - d_margin1 - factor * 6;
+
+    int d_cancel_w = 45 * factor;
+    int d_cancel_h = 9 * factor;
+    int d_cancel_x = d_dialog_x + d_dialog_w - (d_dialog_w / 6) - (d_cancel_w / 2) /*d_dialog_cx - (d_cancel_w / 2)*/;
+    int d_cancel_y = d_dialog_y + d_dialog_h - d_cancel_h - d_margin1 - factor * 6;
+
     int d_name_w = 70 * factor;
     int d_name_h = 9 * factor;
     int d_name_x = d_dialog_x + 5 + (d_dialog_w / 4) - (d_name_w / 2);
@@ -120,15 +130,26 @@ int Com_Scenario_Dialog(void)
     int d_opponent_x = d_name_x;
     int d_opponent_y = d_color_y + d_color_h + d_margin2;
 
-    int d_scenariolist_w = 182 * factor;
-    int d_scenariolist_h = 27 * factor;
-    int d_scenariolist_x = d_dialog_cx - (d_scenariolist_w / 2);
-    int d_scenariolist_y = d_opponent_y + d_txt6_h + 3 * factor + d_txt6_h;
+    int d_scenariolist_w = 152 * factor;
+    int d_scenariolist_h = 30 * factor;
+    int d_scenariolist_x = (d_cancel_x + nearbyint(d_cancel_w * 0.8)) - d_scenariolist_w + (10 * factor);
+    int d_scenariolist_y = d_color_y + d_txt6_h + 5 * factor + d_txt6_h;
     d_scenariolist_h *= 2;
+
+    int d_aihouse_w = d_house_w / 3;
+    int d_aihouse_h = (6 * 5 * factor);
+    int d_aihouse_x = d_scenariolist_x - d_aihouse_w - (10 * factor);
+    int d_aihouse_y = d_scenariolist_y + (2 * factor);
+    int d_aihouse_ystep = 10 * factor;
+
+    int d_options_w = nearbyint(d_scenariolist_w * 0.6);
+    int d_options_h = (5 * 6 * factor) + 5 * factor;
+    int d_options_x = (d_scenariolist_x + d_scenariolist_w) - d_options_w;
+    int d_options_y = d_scenariolist_y + d_scenariolist_h + d_margin1 - 2 * factor;
 
     int d_count_w = 25 * factor;
     int d_count_h = 7 * factor;
-    int d_count_y = d_scenariolist_y + d_scenariolist_h + d_margin2;
+    int d_count_y = d_options_y;
     int d_count_x = d_playerlist_x + (d_playerlist_w / 2) + 20 * factor; // fudged
 
     int d_level_w = 25 * factor;
@@ -146,20 +167,10 @@ int Com_Scenario_Dialog(void)
     int d_aiplayers_x = d_playerlist_x + (d_playerlist_w / 2) + 20 * factor; // fudged;
     int d_aiplayers_y = d_credits_y + d_credits_h;
 
-    int d_options_w = 110 * factor;
-    int d_options_h = (5 * 6 * factor) + 4 * factor;
-    int d_options_x = d_dialog_x + 10 + d_dialog_w - 143 * factor;
-    int d_options_y = d_scenariolist_y + d_scenariolist_h + d_margin1 - 2 * factor;
-
-    int d_ok_w = 45 * factor;
-    int d_ok_h = 9 * factor;
-    int d_ok_x = d_dialog_x + (d_dialog_w / 6) - (d_ok_w / 2);
-    int d_ok_y = d_dialog_y + d_dialog_h - d_ok_h - d_margin1 - factor * 6;
-
-    int d_cancel_w = 45 * factor;
-    int d_cancel_h = 9 * factor;
-    int d_cancel_x = d_dialog_x + d_dialog_w - (d_dialog_w / 6) - (d_cancel_w / 2) /*d_dialog_cx - (d_cancel_w / 2)*/;
-    int d_cancel_y = d_dialog_y + d_dialog_h - d_cancel_h - d_margin1 - factor * 6;
+    int d_tiberiumscale_w = 25 * factor;
+    int d_tiberiumscale_h = 7 * factor;
+    int d_tiberiumscale_x = d_playerlist_x + (d_playerlist_w / 2) + 20 * factor; // fudged;
+    int d_tiberiumscale_y = d_aiplayers_y + d_aiplayers_h;
 
     /*........................................................................
     Button Enumerations
@@ -168,8 +179,14 @@ int Com_Scenario_Dialog(void)
     {
         BUTTON_NAME = 100,
         BUTTON_HOUSE,
+        BUTTON_AI_HOUSE_1,
+        BUTTON_AI_HOUSE_2,
+        BUTTON_AI_HOUSE_3,
+        BUTTON_AI_HOUSE_4,
+        BUTTON_AI_HOUSE_5,
         BUTTON_CREDITS,
         BUTTON_AIPLAYERS,
+        BUTTON_TIBERIUMSCALE,
         BUTTON_OPTIONS,
         BUTTON_SCENARIOLIST,
         BUTTON_COUNT,
@@ -267,6 +284,47 @@ int Com_Scenario_Dialog(void)
                            up_button,
                            down_button);
 
+    std::vector<std::unique_ptr<char[]>> ai_diff_strings(5);
+    std::vector<DropListClass> ai_diff_dropdowns;
+    std::vector<std::unique_ptr<char[]>> ai_house_strings(5);
+    std::vector<DropListClass> ai_house_dropdowns;
+
+    auto cur_ai_house_y = d_aihouse_y;
+
+    for (auto h = BUTTON_AI_HOUSE_1; h <= BUTTON_AI_HOUSE_5; ++h) {
+        constexpr auto label_str_length = 25;
+        ai_diff_strings.emplace_back() = std::make_unique<char[]>(label_str_length);
+        ai_house_strings.emplace_back() = std::make_unique<char[]>(label_str_length);
+
+        ai_diff_dropdowns.emplace_back(
+            h,
+            ai_diff_strings.back().get(),
+            label_str_length,
+            TPF_6PT_GRAD | TPF_USE_GRAD_PAL | TPF_NOSHADOW,
+            d_aihouse_x - (nearbyint(d_aihouse_w * 1.5)) - (10 * factor),
+            cur_ai_house_y,
+            nearbyint(d_aihouse_w * 1.5),
+            d_aihouse_h,
+            up_button,
+            down_button
+        );
+
+        ai_house_dropdowns.emplace_back(
+            h,
+            ai_house_strings.back().get(),
+            label_str_length,
+            TPF_6PT_GRAD | TPF_USE_GRAD_PAL | TPF_NOSHADOW,
+            d_aihouse_x,
+            cur_ai_house_y,
+            d_aihouse_w,
+            d_aihouse_h,
+            up_button,
+            down_button
+        );
+
+        cur_ai_house_y += d_aihouse_ystep;
+    }
+
     ListClass scenariolist(BUTTON_SCENARIOLIST,
                            d_scenariolist_x,
                            d_scenariolist_y,
@@ -283,6 +341,8 @@ int Com_Scenario_Dialog(void)
     GaugeClass creditsgauge(BUTTON_CREDITS, d_credits_x, d_credits_y, d_credits_w, d_credits_h);
 
     GaugeClass aiplayersgauge(BUTTON_AIPLAYERS, d_aiplayers_x, d_aiplayers_y, d_aiplayers_w, d_aiplayers_h);
+
+    GaugeClass tiberiumscalegauge(BUTTON_TIBERIUMSCALE, d_tiberiumscale_x, d_tiberiumscale_y, d_tiberiumscale_w, d_tiberiumscale_h);
 
     CheckListClass optionlist(BUTTON_OPTIONS,
                               d_options_x,
@@ -306,7 +366,7 @@ int Com_Scenario_Dialog(void)
 
     SliderClass difficulty(BUTTON_DIFFICULTY,
                            d_name_x,
-                           optionlist.Y + optionlist.Height + d_margin1 + d_margin1,
+                           d_ok_y - (8 * factor) - d_margin1,
                            d_dialog_w - (d_name_x - d_dialog_x) * 2,
                            8 * factor,
                            true);
@@ -324,10 +384,20 @@ int Com_Scenario_Dialog(void)
     commands = &name_edt;
     difficulty.Add_Tail(*commands);
     scenariolist.Add_Tail(*commands);
+
+    for (auto& dropdown : ai_diff_dropdowns) {
+        dropdown.Add_Tail(*commands);
+    }
+
+    for (auto& dropdown : ai_house_dropdowns) {
+        dropdown.Add_Tail(*commands);
+    }
+
     countgauge.Add_Tail(*commands);
     levelgauge.Add_Tail(*commands);
     creditsgauge.Add_Tail(*commands);
     aiplayersgauge.Add_Tail(*commands);
+    tiberiumscalegauge.Add_Tail(*commands);
     optionlist.Add_Tail(*commands);
     okbtn.Add_Tail(*commands);
     cancelbtn.Add_Tail(*commands);
@@ -346,8 +416,38 @@ int Com_Scenario_Dialog(void)
 
     housebtn.Add_Item(Text_String(TXT_G_D_I));
     housebtn.Add_Item(Text_String(TXT_N_O_D));
+    //housebtn.Add_Item("Dino");
     housebtn.Set_Selected_Index(MPlayerHouse - HOUSE_GOOD);
     housebtn.Set_Read_Only(true);
+
+    int maxp = 4 /*Rule.MaxPlayers - 2*/;
+    aiplayersgauge.Set_Maximum(maxp);
+
+    if (MPlayerGhosts > 5) {
+        MPlayerGhosts = 5;
+    }
+    MPlayerGhosts = max(MPlayerGhosts, 1);
+
+    aiplayersgauge.Set_Value(MPlayerGhosts - 1);
+
+    for (auto idx = 0; idx < ai_diff_dropdowns.size(); idx++) {
+        ai_diff_dropdowns[idx].Add_Item("Disabled");
+        ai_diff_dropdowns[idx].Add_Item("Easy");
+        ai_diff_dropdowns[idx].Add_Item("Normal");
+        ai_diff_dropdowns[idx].Add_Item("Hard");
+        ai_diff_dropdowns[idx].Set_Selected_Index(idx < MPlayerGhosts ? 2 : 0);
+        ai_diff_dropdowns[idx].List.Reset_Index_Change();
+        ai_diff_dropdowns[idx].Set_Read_Only(true);
+
+        ai_house_dropdowns[idx].Add_Item("None");
+        ai_house_dropdowns[idx].Add_Item("?");
+        ai_house_dropdowns[idx].Add_Item(Text_String(TXT_G_D_I));
+        ai_house_dropdowns[idx].Add_Item(Text_String(TXT_N_O_D));
+        //ai_house_dropdowns[idx].Add_Item("Dino");
+        ai_house_dropdowns[idx].Set_Selected_Index(idx < MPlayerGhosts ? 1 : 0);
+        ai_house_dropdowns[idx].List.Reset_Index_Change();
+        ai_house_dropdowns[idx].Set_Read_Only(true);
+    }
 
     /*........................................................................
     Init scenario values, only the first time through
@@ -359,7 +459,16 @@ int Com_Scenario_Dialog(void)
         MPlayerCredits = Rule.Get_Rule_Value<int>(GAME_MULTIPLAYER_SECTION, START_CREDITS_DEFAULT_RULE); // init credits & credit buffer
         MPlayerGhosts = 1;
         MPlayerUnitCount = (MPlayerCountMax[MPlayerBases] + MPlayerCountMin[MPlayerBases]) / 2;
+        MPlayerTiberium = 1;
         first_time = false;
+
+        for (auto& player_house : MPlayerHouses) {
+            player_house = HOUSE_NONE;
+        }
+
+        for (auto& player_difficulty : MPlayerDifficulty) {
+            player_difficulty = DIFF_NONE;
+        }
     }
 
     /*........................................................................
@@ -389,15 +498,8 @@ int Com_Scenario_Dialog(void)
     creditsgauge.Set_Maximum(Rule.Get_Rule_Value<int>(GAME_MULTIPLAYER_SECTION, START_CREDITS_MAX_RULE));
     creditsgauge.Set_Value(MPlayerCredits);
 
-    int maxp = 4 /*Rule.MaxPlayers - 2*/;
-    aiplayersgauge.Set_Maximum(maxp);
-
-    if (MPlayerGhosts > 5) {
-        MPlayerGhosts = 5;
-    }
-    MPlayerGhosts = max(MPlayerGhosts, 1);
-
-    aiplayersgauge.Set_Value(MPlayerGhosts - 1);
+    tiberiumscalegauge.Set_Maximum(4);
+    tiberiumscalegauge.Set_Value(MPlayerTiberium < 2 ? 0 : MPlayerTiberium - 1);
 
     /*........................................................................
     Init other scenario parameters
@@ -505,21 +607,21 @@ int Com_Scenario_Dialog(void)
                                  TBLACK,
                                  TPF_RIGHT | TPF_6PT_GRAD | TPF_USE_GRAD_PAL | TPF_NOSHADOW);
 
-                Fancy_Text_Print("Easy",
+                Fancy_Text_Print("Easy", // TODO: Locale file entry
                                  difficulty.X,
                                  difficulty.Y - 8 * factor,
                                  CC_GREEN,
                                  TBLACK,
                                  TPF_6PT_GRAD | TPF_USE_GRAD_PAL | TPF_NOSHADOW);
 
-                Fancy_Text_Print("Hard",
+                Fancy_Text_Print("Hard", // TODO: Locale file entry
                                  difficulty.X + difficulty.Width,
                                  difficulty.Y - 8 * factor,
                                  CC_GREEN,
                                  TBLACK,
                                  TPF_RIGHT | TPF_6PT_GRAD | TPF_USE_GRAD_PAL | TPF_NOSHADOW);
 
-                Fancy_Text_Print("Normal",
+                Fancy_Text_Print("Normal", // TODO: Locale file entry
                                  difficulty.X + difficulty.Width / 2,
                                  difficulty.Y - 8 * factor,
                                  CC_GREEN,
@@ -528,7 +630,7 @@ int Com_Scenario_Dialog(void)
 
                 Fancy_Text_Print(TXT_SCENARIOS,
                                  d_scenariolist_x + (d_scenariolist_w / 2),
-                                 d_scenariolist_y - d_txt6_h,
+                                 d_scenariolist_y - d_txt6_h - (1 * factor),
                                  CC_GREEN,
                                  TBLACK,
                                  TPF_CENTER | TPF_6PT_GRAD | TPF_USE_GRAD_PAL | TPF_NOSHADOW);
@@ -557,6 +659,13 @@ int Com_Scenario_Dialog(void)
                 Fancy_Text_Print(TXT_AI_PLAYERS_COLON,
                                  d_aiplayers_x - 3 * factor,
                                  d_aiplayers_y,
+                                 CC_GREEN,
+                                 TBLACK,
+                                 TPF_RIGHT | TPF_6PT_GRAD | TPF_USE_GRAD_PAL | TPF_NOSHADOW);
+
+                Fancy_Text_Print("Tiberium Growth:", // TODO: Locale file entry
+                                 d_tiberiumscale_x - 3 * factor,
+                                 d_tiberiumscale_y,
                                  CC_GREEN,
                                  TBLACK,
                                  TPF_RIGHT | TPF_6PT_GRAD | TPF_USE_GRAD_PAL | TPF_NOSHADOW);
@@ -620,6 +729,13 @@ int Com_Scenario_Dialog(void)
                                  CC_GREEN,
                                  BLACK,
                                  TPF_6PT_GRAD | TPF_USE_GRAD_PAL | TPF_NOSHADOW);
+                sprintf(txt, "%dx ", tiberiumscalegauge.Get_Value() + 1);
+                Fancy_Text_Print(txt,
+                                 d_tiberiumscale_x + d_tiberiumscale_w + 3 * factor,
+                                 d_tiberiumscale_y,
+                                 CC_GREEN,
+                                 BLACK,
+                                 TPF_6PT_GRAD | TPF_USE_GRAD_PAL | TPF_NOSHADOW);
             }
 
             /*
@@ -637,19 +753,83 @@ int Com_Scenario_Dialog(void)
         ........................... Get user input ............................
         */
         bool droplist_is_dropped = housebtn.IsDropped;
+        std::vector<int> ai_diffs_collapsed;
+        std::vector<int> ai_houses_collapsed;
+
+        for (auto idx = 0; idx < ai_houses_collapsed.size(); idx++) {
+            if (ai_diff_dropdowns[idx].IsDropped) {
+                ai_diffs_collapsed.emplace_back(idx);
+            }
+
+            if (ai_house_dropdowns[idx].IsDropped) {
+                ai_houses_collapsed.emplace_back(idx);
+            }
+        }
+
         input = commands->Input();
 
         /*
-        ** Redraw everything if the droplist collapsed
+        ** Redraw everything if the player house droplist collapsed
         */
         if (droplist_is_dropped && !housebtn.IsDropped) {
             display = REDRAW_BACKGROUND;
         }
 
-        if (input & KN_BUTTON) {
+        /*
+        ** Redraw everything if am AI house droplist collapsed
+        */
+        for (const auto& idx: ai_diffs_collapsed) {
+            if (!ai_diff_dropdowns[idx].IsDropped) {
+                display = REDRAW_BACKGROUND;
+            }
+        }
+
+        for (const auto& idx: ai_houses_collapsed) {
+            if (!ai_house_dropdowns[idx].IsDropped) {
+                display = REDRAW_BACKGROUND;
+            }
+        }
+
+        const auto collapse_visible_dropdowns = [&]() {
             if (housebtn.IsDropped) {
                 housebtn.Collapse();
                 display = REDRAW_BACKGROUND;
+            }
+
+            for (auto idx = 0; idx < ai_houses_collapsed.size(); idx++) {
+                if (ai_diff_dropdowns[i].IsDropped) {
+                    ai_diff_dropdowns[i].Collapse();
+                    display = REDRAW_BACKGROUND;
+                }
+
+                if (ai_house_dropdowns[i].IsDropped) {
+                    ai_house_dropdowns[i].Collapse();
+                    display = REDRAW_BACKGROUND;
+                }
+            }
+        };
+
+        if (input & KN_BUTTON) {
+            // user is interacting with a button, so hide dropdown lists
+            collapse_visible_dropdowns();
+        }
+
+        // for any visible AI house dropdown, if mouse input is received outside it's bounds, hide it
+        for (auto idx = 0; idx < ai_diff_dropdowns.size(); idx++) {
+            if (ai_diff_dropdowns[idx].IsDropped) {
+                if ((Keyboard->MouseQX < ai_diff_dropdowns[idx].X || Keyboard->MouseQX > ai_diff_dropdowns[idx].X + ai_diff_dropdowns[idx].Width)
+                && (Keyboard->MouseQY < ai_diff_dropdowns[idx].Y || Keyboard->MouseQY > ai_diff_dropdowns[idx].Y + ai_diff_dropdowns[idx].Height)) {
+                    ai_diff_dropdowns[idx].Collapse();
+                    display = REDRAW_BACKGROUND;
+                }
+            }
+
+            if (ai_house_dropdowns[idx].IsDropped) {
+                if ((Keyboard->MouseQX < ai_house_dropdowns[idx].X || Keyboard->MouseQX > ai_house_dropdowns[idx].X + ai_house_dropdowns[idx].Width)
+                && (Keyboard->MouseQY < ai_house_dropdowns[idx].Y || Keyboard->MouseQY > ai_house_dropdowns[idx].Y + ai_house_dropdowns[idx].Height)) {
+                    ai_house_dropdowns[idx].Collapse();
+                    display = REDRAW_BACKGROUND;
+                }
             }
         }
 
@@ -671,6 +851,8 @@ int Com_Scenario_Dialog(void)
                     name_edt.Set_Color(MPlayerTColors[MPlayerColorIdx]);
                     name_edt.Flag_To_Redraw();
                     strcpy(MPlayerName, namebuf);
+
+                    collapse_visible_dropdowns();
                     transmit = 1;
                 }
             }
@@ -683,6 +865,7 @@ int Com_Scenario_Dialog(void)
             if (!ready_to_go) {
                 strcpy(MPlayerName, namebuf);
                 transmit = 1;
+                collapse_visible_dropdowns();
             }
             break;
 
@@ -692,6 +875,9 @@ int Com_Scenario_Dialog(void)
         case (BUTTON_HOUSE | KN_BUTTON):
             MPlayerHouse = HousesType(housebtn.Current_Index() + HOUSE_GOOD);
             strcpy(MPlayerName, namebuf);
+
+            collapse_visible_dropdowns();
+
             display = REDRAW_BACKGROUND;
             transmit = true;
             break;
@@ -712,6 +898,76 @@ int Com_Scenario_Dialog(void)
             }
             break;
 
+        case (BUTTON_AI_HOUSE_1 | KN_BUTTON):
+        case (BUTTON_AI_HOUSE_2 | KN_BUTTON):
+        case (BUTTON_AI_HOUSE_3 | KN_BUTTON):
+        case (BUTTON_AI_HOUSE_4 | KN_BUTTON):
+        case (BUTTON_AI_HOUSE_5 | KN_BUTTON):
+            for (auto idx = 0; idx < ai_diff_dropdowns.size(); idx++) {
+                auto& diff_dropdown = ai_diff_dropdowns[idx];
+                auto& house_dropdown = ai_house_dropdowns[idx];
+                const auto selected_diff_changed = diff_dropdown.List.Index_Changed();
+                const auto selected_house_changed = house_dropdown.List.Index_Changed();
+
+                // one of the two house dropdowns was changed
+                if (selected_diff_changed || selected_house_changed) {
+                    auto selected_diff_idx = diff_dropdown.Current_Index();
+                    auto selected_house_idx = house_dropdown.Current_Index();
+
+                    const auto diff_was_disabled =  selected_diff_idx == 0 && selected_diff_changed;
+                    const auto house_was_disabled = selected_house_idx == 0 && selected_house_changed;
+                    const auto diff_was_activated =  selected_diff_changed && diff_dropdown.List.Get_Previous_Index() == 0;
+                    const auto house_was_activated = selected_house_changed && house_dropdown.List.Get_Previous_Index() == 0;
+
+                    if (diff_was_disabled) {
+                        // reset house to match disabled AI diff
+                        selected_house_idx = 0;
+                        house_dropdown.Set_Selected_Index(selected_house_idx);
+                        diff_dropdown.List.Reset_Index_Change();
+                    } else if (house_was_disabled) {
+                        // reset diff to match disabled AI house
+                        selected_diff_idx = 0;
+                        diff_dropdown.Set_Selected_Index(selected_diff_idx);
+                        diff_dropdown.List.Reset_Index_Change();
+                    } else if (diff_was_activated && selected_house_idx == 0) {
+                        // select a default house of '?' since none is selected
+                        selected_house_idx = 1;
+                        house_dropdown.Set_Selected_Index(selected_house_idx);
+                        house_dropdown.List.Reset_Index_Change();
+                    } else if (house_was_activated && selected_diff_idx == 0) {
+                        // select a default diff of 'Normal' since none is selected
+                        selected_diff_idx = 2;
+                        diff_dropdown.Set_Selected_Index(selected_diff_idx);
+                        diff_dropdown.List.Reset_Index_Change();
+                    }
+
+                    // adjust indices to match appropriate enum values
+                    const auto house_idx = idx + 1;
+                    const auto selected_diff = selected_diff_idx == 0
+                        ? DIFF_NONE
+                        : static_cast<DiffType>(selected_diff_idx - 1);
+                    const auto selected_house = selected_house_idx < 2
+                        ? HOUSE_NONE
+                        : static_cast<HousesType>(selected_house_idx - 2);
+
+                    CNC_LOG_WARN(
+                        "Setting MUTI{} house to '{}' and acts like: {}",
+                        house_idx,
+                        TdTypeConverter::To_String(selected_diff), TdTypeConverter::To_String(selected_house)
+                    );
+
+                    MPlayerHouses[idx + 1] = selected_house;
+                    MPlayerDifficulty[idx] = selected_diff;
+
+                    diff_dropdown.Collapse();
+                    house_dropdown.Collapse();
+                    display = REDRAW_BACKGROUND;
+                    transmit = true;
+                }
+            }
+
+            break;
+
         /*------------------------------------------------------------------
         User adjusts max # units
         ------------------------------------------------------------------*/
@@ -721,10 +977,7 @@ int Com_Scenario_Dialog(void)
                 if (display < REDRAW_MESSAGE) {
                     display = REDRAW_MESSAGE;
                 }
-                if (housebtn.IsDropped) {
-                    housebtn.Collapse();
-                    display = REDRAW_BACKGROUND;
-                }
+                collapse_visible_dropdowns();
                 transmit = 1;
             }
             break;
@@ -740,10 +993,7 @@ int Com_Scenario_Dialog(void)
                 if (display < REDRAW_MESSAGE) {
                     display = REDRAW_MESSAGE;
                 }
-                if (housebtn.IsDropped) {
-                    housebtn.Collapse();
-                    display = REDRAW_BACKGROUND;
-                }
+                collapse_visible_dropdowns();
                 transmit = 1;
             }
             break;
@@ -763,10 +1013,7 @@ int Com_Scenario_Dialog(void)
                 if (display < REDRAW_MESSAGE) {
                     display = REDRAW_MESSAGE;
                 }
-                if (housebtn.IsDropped) {
-                    housebtn.Collapse();
-                    display = REDRAW_BACKGROUND;
-                }
+                collapse_visible_dropdowns();
                 transmit = 1;
             }
             break;
@@ -787,12 +1034,25 @@ int Com_Scenario_Dialog(void)
                 if (display < REDRAW_MESSAGE)
                     display = REDRAW_MESSAGE;
 
-                if (housebtn.IsDropped) {
-                    housebtn.Collapse();
-                    display = REDRAW_BACKGROUND;
-                }
+                collapse_visible_dropdowns();
 
                 break;
+            }
+            break;
+
+        case (BUTTON_TIBERIUMSCALE | KN_BUTTON):
+            if (!ready_to_go) {
+                MPlayerTiberium = tiberiumscalegauge.Get_Value() + 1;
+
+                optionlist.Check_Item(1, MPlayerTiberium > 0);
+
+                Special.IsTGrowth = MPlayerTiberium;
+                Special.IsTSpread = MPlayerTiberium;
+
+                if (display < REDRAW_MESSAGE)
+                    display = REDRAW_MESSAGE;
+
+                collapse_visible_dropdowns();
             }
             break;
 
@@ -803,7 +1063,7 @@ int Com_Scenario_Dialog(void)
         Also, if Tiberium gets toggled, we have to set the flags
         in SpecialClass.
         ------------------------------------------------------------------*/
-        case (BUTTON_OPTIONS | KN_BUTTON):
+        case (BUTTON_OPTIONS | KN_BUTTON): {
             if (MPlayerBases != optionlist.Is_Checked(0)) {
                 MPlayerBases = optionlist.Is_Checked(0);
                 if (MPlayerBases) {
@@ -820,7 +1080,14 @@ int Com_Scenario_Dialog(void)
                 countgauge.Set_Maximum(MPlayerCountMax[MPlayerBases] - MPlayerCountMin[MPlayerBases]);
                 countgauge.Set_Value(MPlayerUnitCount - MPlayerCountMin[MPlayerBases]);
             }
-            MPlayerTiberium = optionlist.Is_Checked(1);
+            MPlayerTiberium = optionlist.Is_Checked(1) ? 1 : 0;
+
+            if (tiberiumscalegauge.Get_Value() + 1 > 1) {
+                MPlayerTiberium = tiberiumscalegauge.Get_Value() + 1;
+            }
+
+            tiberiumscalegauge.Set_Value(MPlayerTiberium < 2 ? 0 : MPlayerTiberium - 1);
+
             Special.IsTGrowth = MPlayerTiberium;
             // Rule.IsTGrowth = MPlayerTiberium;
             Special.IsTSpread = MPlayerTiberium;
@@ -832,11 +1099,10 @@ int Com_Scenario_Dialog(void)
             transmit = true;
             if (display < REDRAW_MESSAGE)
                 display = REDRAW_MESSAGE;
-            if (housebtn.IsDropped) {
-                housebtn.Collapse();
-                display = REDRAW_BACKGROUND;
-            }
+
+            collapse_visible_dropdowns();
             break;
+        }
 
         /*------------------------------------------------------------------
         OK: exit loop with true status

--- a/tiberiandawn/rules.cpp
+++ b/tiberiandawn/rules.cpp
@@ -271,7 +271,7 @@ void RulesClass::Init(CCINIClass& ini)
 void RulesClass::Init_For_Scenario(
     const ScenarioClass& scenario,
     const GameType& game_to_play,
-    const SpecialClass special_options,
+    const SpecialClass& special_options,
     const std::optional<bool> superweapons_allowed
 )
 {
@@ -341,8 +341,9 @@ RuleSections& RulesClass::Get_Editable_Rule_Sections()
  */
 void RulesClass::Reset()
 {
-    Sections = RuleSections();
+    Sections.Clear();
     TypeRules.clear();
+    Special.Init();
 }
 
 /**

--- a/tiberiandawn/rules.h
+++ b/tiberiandawn/rules.h
@@ -324,8 +324,8 @@ public:
     void Init_For_Scenario(
         const ScenarioClass& scenario,
         const GameType& game_to_play,
-        SpecialClass special_options,
-        std::optional<bool> superweapons_allowed
+        const SpecialClass& special_options,
+        std::optional<bool> superweapons_allowed = std::nullopt
     );
 
     const RuleSections& Get_Rule_Sections() const;

--- a/tiberiandawn/scenario.cpp
+++ b/tiberiandawn/scenario.cpp
@@ -254,12 +254,12 @@ bool Read_Scenario(char* root)
     CCDebugString("C&C95 - In Read_Scenario.\n");
 
     // capture any setup that was done for a skirmish scenario before clear
-    const auto special_options = Special;
-    const auto allow_superweapons = Rule.AllowSuperWeapons;
+    auto special_options = Special;
+    Special.RuleOverrides = nullptr; // detach rule overrides from global instance
 
     Clear_Scenario();
     ScenarioInit++;
-    if (Read_Scenario_Ini(root, special_options, allow_superweapons)) {
+    if (Read_Scenario_Ini(root, special_options)) {
 
         Fill_In_Data();
 

--- a/tiberiandawn/scenarioini.cpp
+++ b/tiberiandawn/scenarioini.cpp
@@ -1308,6 +1308,7 @@ static void Assign_Houses(void)
             **	Set the house's IsHuman, Credits, ActLike, & RemapTable
             */
             housep->IsHuman = false;
+            CNC_LOG_WARN("Assigning {} acts like: {}", TdTypeConverter::To_String(house), TdTypeConverter::To_String(pref_house));
             housep->Init_Data(color, pref_house, MPlayerCredits);
 
             DiffType difficulty = Scen.CDifficulty;
@@ -1315,7 +1316,23 @@ static void Assign_Houses(void)
             if (Players.Count() > 1 && Rule.IsCompEasyBonus && difficulty > DIFF_EASY) {
                 difficulty = (DiffType)(difficulty - 1);
             }
-            housep->Assign_Handicap(difficulty_override != DIFF_NONE ? difficulty_override : difficulty);
+
+            switch (difficulty_override) {
+                // give the house a nerf
+                case DIFF_EASY:
+                    difficulty = DIFF_HARD;
+                    break;
+                // give the house a buff
+                case DIFF_HARD:
+                    difficulty = DIFF_EASY;
+                    break;
+
+                // just use 'difficulty' as calculated based on given scenario and rules
+                default: break;
+            }
+
+            CNC_LOG_WARN("Assigning {} handicap: {} (override: {})", TdTypeConverter::To_String(house), TdTypeConverter::To_String(difficulty), TdTypeConverter::To_String(difficulty_override));
+            housep->Assign_Handicap(difficulty);
         }
     }
 

--- a/tiberiandawn/scenarioini.cpp
+++ b/tiberiandawn/scenarioini.cpp
@@ -211,7 +211,7 @@ extern void GlyphX_Assign_Houses(void); // ST - 6/25/2019 11:08AM
  * HISTORY:                                                                                    *
  *   10/07/1992 JLB : Created.                                                                 *
  *=============================================================================================*/
-bool Read_Scenario_Ini(char* root, SpecialClass special_options, bool allow_superweapons, bool fresh)
+bool Read_Scenario_Ini(char* root, const SpecialClass& special_options, std::optional<bool> allow_superweapons, bool fresh)
 {
     char fname[_MAX_FNAME + _MAX_EXT]; // full INI filename
     char buf[128];                     // Working string staging buffer.
@@ -1279,13 +1279,17 @@ static void Assign_Houses(void)
     */
     for (i = MPlayerCount; i < MPlayerCount + MPlayerGhosts; i++) {
         if (house_used[i] == false) {
+            const auto house_override = MPlayerHouses[i];
+            const auto difficulty_override = MPlayerDifficulty[i];
 
             /*
             **	Set the house, preferred house (GDI/NOD), and color; get a pointer
             **	to the house instance
             */
             house = (HousesType)(i + (int)HOUSE_MULTI1);
-            pref_house = (HousesType)(Random_Pick(0, 1) + (int)HOUSE_GOOD);
+            pref_house = house_override != HOUSE_NONE
+                ? house_override
+                : (HousesType)(Random_Pick(0, 1) + (int)HOUSE_GOOD);
             for (;;) {
                 color = Random_Pick(REMAP_FIRST, REMAP_LAST);
                 if (color_used[color] == false) {
@@ -1311,7 +1315,7 @@ static void Assign_Houses(void)
             if (Players.Count() > 1 && Rule.IsCompEasyBonus && difficulty > DIFF_EASY) {
                 difficulty = (DiffType)(difficulty - 1);
             }
-            housep->Assign_Handicap(difficulty);
+            housep->Assign_Handicap(difficulty_override != DIFF_NONE ? difficulty_override : difficulty);
         }
     }
 

--- a/tiberiandawn/scenarioini.cpp
+++ b/tiberiandawn/scenarioini.cpp
@@ -1308,7 +1308,7 @@ static void Assign_Houses(void)
             **	Set the house's IsHuman, Credits, ActLike, & RemapTable
             */
             housep->IsHuman = false;
-            CNC_LOG_WARN("Assigning {} acts like: {} (override: {})", house, pref_house, house_override);
+            CNC_LOG_INFO("Assigning {} acts like: {} (override: {})", house, pref_house, house_override);
             housep->Init_Data(color, pref_house, MPlayerCredits);
 
             DiffType difficulty = Scen.CDifficulty;
@@ -1331,7 +1331,7 @@ static void Assign_Houses(void)
                 default: break;
             }
 
-            CNC_LOG_DEBUG("Assigning {} handicap: {} (override: {})", house, difficulty, difficulty_override);
+            CNC_LOG_INFO("Assigning {} handicap: {} (override: {})", house, difficulty, difficulty_override);
             housep->Assign_Handicap(difficulty);
         }
     }

--- a/tiberiandawn/scenarioini.cpp
+++ b/tiberiandawn/scenarioini.cpp
@@ -1308,7 +1308,7 @@ static void Assign_Houses(void)
             **	Set the house's IsHuman, Credits, ActLike, & RemapTable
             */
             housep->IsHuman = false;
-            CNC_LOG_WARN("Assigning {} acts like: {}", TdTypeConverter::To_String(house), TdTypeConverter::To_String(pref_house));
+            CNC_LOG_WARN("Assigning {} acts like: {} (override: {})", house, pref_house, house_override);
             housep->Init_Data(color, pref_house, MPlayerCredits);
 
             DiffType difficulty = Scen.CDifficulty;
@@ -1331,7 +1331,7 @@ static void Assign_Houses(void)
                 default: break;
             }
 
-            CNC_LOG_WARN("Assigning {} handicap: {} (override: {})", TdTypeConverter::To_String(house), TdTypeConverter::To_String(difficulty), TdTypeConverter::To_String(difficulty_override));
+            CNC_LOG_DEBUG("Assigning {} handicap: {} (override: {})", house, difficulty, difficulty_override);
             housep->Assign_Handicap(difficulty);
         }
     }

--- a/tiberiandawn/skirmishdlg.cpp
+++ b/tiberiandawn/skirmishdlg.cpp
@@ -1,47 +1,13 @@
-//
-// Copyright 2020 Electronic Arts Inc.
-//
-// TiberianDawn.DLL and RedAlert.dll and corresponding source code is free
-// software: you can redistribute it and/or modify it under the terms of
-// the GNU General Public License as published by the Free Software Foundation,
-// either version 3 of the License, or (at your option) any later version.
-
-// TiberianDawn.DLL and RedAlert.dll and corresponding source code is distributed
-// in the hope that it will be useful, but with permitted additional restrictions
-// under Section 7 of the GPL. See the GNU General Public License in LICENSE.TXT
-// distributed with this program. You should have received a copy of the
-// GNU General Public License along with permitted additional restrictions
-// with this program. If not, see https://github.com/electronicarts/CnC_Remastered_Collection
-
-/* $Header:   F:\projects\c&c\vcs\code\nulldlg.cpv   1.9   16 Oct 1995 16:52:12   JOE_BOSTIC  $ */
-/***************************************************************************
- **   C O N F I D E N T I A L --- W E S T W O O D    S T U D I O S        **
- ***************************************************************************
- *                                                                         *
- *                 Project Name : Command & Conquer                        *
- *                                                                         *
- *                    File Name : NULLDLG.CPP                              *
- *                                                                         *
- *                   Programmer : Bill R. Randolph                         *
- *                                                                         *
- *                   Start Date : 04/29/95                                 *
- *                                                                         *
- *                  Last Update : April 29, 1995 [BRR]                     *
- *                                                                         *
- *-------------------------------------------------------------------------*
- * Functions:                                                              *
- *   Com_Scenario_Dialog -- Skirmish game scenario selection dialog        *
- * - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - */
 #include "function.h"
 #include "drop.h"
 #include "framelimit.h"
 
 struct ControlDimension
 {
-    int x = 0;
-    int y = 0;
-    int w = 0;
-    int h = 0;
+    int X = 0;
+    int Y = 0;
+    int W = 0;
+    int H = 0;
 };
 
 class SkirmishScenarioDialog final
@@ -63,12 +29,12 @@ class SkirmishScenarioDialog final
         BUTTON_AI_HOUSE_3,
         BUTTON_AI_HOUSE_4,
         BUTTON_AI_HOUSE_5,
-        BUTTON_CREDITS,
-        BUTTON_TIBERIUMSCALE,
         BUTTON_OPTIONS,
-        BUTTON_SCENARIOLIST,
+        BUTTON_SCENARIO_LIST,
         BUTTON_COUNT,
         BUTTON_LEVEL,
+        BUTTON_CREDITS,
+        BUTTON_TIBERIUM_SCALE,
         BUTTON_OK,
         BUTTON_LOAD,
         BUTTON_CANCEL,
@@ -79,8 +45,8 @@ class SkirmishScenarioDialog final
         BUTTON_COLOR_4,
         BUTTON_COLOR_5,
         BUTTON_COLOR_6,
-        BUTTON_PLAYERLIST // not used
-    } ButtonType;
+        BUTTON_PLAYER_LIST // not used
+    } ControlType;
 
     /*........................................................................
     Redraw values: in order from "top" to "bottom" layer of the dialog
@@ -98,8 +64,10 @@ class SkirmishScenarioDialog final
     static constexpr auto DropdownTextLength = 25;
     static inline int OptionTabs[] = {8};
 
-    // dimensions
+    // display scale
     int Factor;
+
+    // dimensions
 
     int X;
     int Y;
@@ -112,18 +80,103 @@ class SkirmishScenarioDialog final
     int MarginHeight;
 
     // button shapes
+
     void const* UpButtonShape;
     void const* DownButtonShape;
 
-    std::map<ButtonType, ControlDimension> Dimensions;
-    std::map<ButtonType, std::unique_ptr<char[]>> Text;
-    std::map<ButtonType, std::unique_ptr<GadgetClass>> Controls;
+    // controls
+
+    std::map<ControlType, ControlDimension> Dimensions;
+    std::map<ControlType, std::unique_ptr<char[]>> Text;
+    std::map<ControlType, std::unique_ptr<GadgetClass>> Controls;
     GadgetClass* CommandChain;
 
+    bool Is_Mouse_Over_Rectangle(const int start_x, const int start_y, const int end_x, const int end_y)
+    {
+        return Keyboard->MouseQX >= start_x
+            && Keyboard->MouseQX <= end_x
+            && Keyboard->MouseQY >= start_y
+            && Keyboard->MouseQY <= end_y;
+    }
+
+    bool Is_Mouse_Outside_Control_Dimensions(const GadgetClass& control)
+    {
+        return (Keyboard->MouseQX < control.X || Keyboard->MouseQX > control.X + control.Width)
+            && (Keyboard->MouseQY < control.Y || Keyboard->MouseQY > control.Y + control.Height);
+    }
+
     template<class T>
-    T& Get_Control(const ButtonType type)
+    T& Get_Control(const ControlType type)
     {
         return *reinterpret_cast<T*>(Controls[type].get());
+    }
+
+    KeyNumType Get_Input(RedrawType& display)
+    {
+        auto& house_dropdown = Get_Control<DropListClass>(BUTTON_HOUSE);
+        const bool droplist_is_dropped = house_dropdown.IsDropped;
+        std::vector<ControlType> ai_diffs_collapsed;
+        std::vector<ControlType> ai_houses_collapsed;
+
+        for (auto control = BUTTON_AI_DIFF_1; control <= BUTTON_AI_DIFF_5; ++control) {
+            if (Get_Control<DropListClass>(control).IsDropped) {
+                ai_diffs_collapsed.emplace_back(control);
+            }
+
+            const auto house_btn = static_cast<ControlType>(control + 5);
+
+            if (Get_Control<DropListClass>(house_btn).IsDropped) {
+                ai_houses_collapsed.emplace_back(house_btn);
+            }
+        }
+
+        const auto input = CommandChain->Input();
+
+        /*
+        ** Redraw everything if the player house droplist collapsed
+        */
+        if (droplist_is_dropped && !house_dropdown.IsDropped) {
+            display = REDRAW_BACKGROUND;
+        }
+
+        /*
+        ** Redraw everything if an AI house droplist collapsed
+        */
+        for (const auto& control: ai_diffs_collapsed) {
+            if (!Get_Control<DropListClass>(control).IsDropped) {
+                display = REDRAW_BACKGROUND;
+            }
+        }
+
+        for (const auto& control: ai_houses_collapsed) {
+            if (!Get_Control<DropListClass>(control).IsDropped) {
+                display = REDRAW_BACKGROUND;
+            }
+        }
+
+        if (input & KN_BUTTON) {
+            // user is interacting with a button, so hide dropdown lists
+            Collapse_Visible_Dropdowns(display);
+        }
+
+        // for any visible AI house dropdown, if mouse input is received outside it's bounds, hide it
+        for (auto control = BUTTON_AI_DIFF_1; control <= BUTTON_AI_DIFF_5; ++control) {
+            const auto house_btn = static_cast<ControlType>(control + 5);
+            auto& diff_dropdown = Get_Control<DropListClass>(control);
+            auto& ai_house_dropdown = Get_Control<DropListClass>(house_btn);
+
+            if (diff_dropdown.IsDropped && Is_Mouse_Outside_Control_Dimensions(diff_dropdown)) {
+                diff_dropdown.Collapse();
+                display = REDRAW_BACKGROUND;
+            }
+
+            if (ai_house_dropdown.IsDropped && Is_Mouse_Outside_Control_Dimensions(ai_house_dropdown)) {
+                ai_house_dropdown.Collapse();
+                display = REDRAW_BACKGROUND;
+            }
+        }
+
+        return input;
     }
 
     void Render(RedrawType& display)
@@ -135,7 +188,7 @@ class SkirmishScenarioDialog final
 
         Hide_Mouse();
         /*
-        .................. Redraw backgound & dialog box ...................
+        .................. Redraw background & dialog box ...................
         */
         if (display >= REDRAW_BACKGROUND) {
             Dialog_Box(X, Y, Width, Height);
@@ -143,7 +196,8 @@ class SkirmishScenarioDialog final
             // init font variables
 
             Fancy_Text_Print(
-                TXT_NONE, 0, 0, TBLACK, TBLACK, TPF_CENTER | TPF_6PT_GRAD | TPF_USE_GRAD_PAL | TPF_NOSHADOW);
+                TXT_NONE, 0, 0, TBLACK, TBLACK, TPF_CENTER | TPF_6PT_GRAD | TPF_USE_GRAD_PAL | TPF_NOSHADOW
+            );
 
             /*...............................................................
             Dialog & Field labels
@@ -159,22 +213,22 @@ class SkirmishScenarioDialog final
 #endif // FORCE_WINSOCK
 
             Fancy_Text_Print(TXT_YOUR_NAME,
-                             Dimensions[BUTTON_NAME].x + (Dimensions[BUTTON_NAME].w / 2),
-                             Dimensions[BUTTON_NAME].y - TextHeight - (1 * Factor),
+                             Dimensions[BUTTON_NAME].X + (Dimensions[BUTTON_NAME].W / 2),
+                             Dimensions[BUTTON_NAME].Y - TextHeight - (1 * Factor),
                              CC_GREEN,
                              TBLACK,
                              TPF_RIGHT | TPF_6PT_GRAD | TPF_USE_GRAD_PAL | TPF_NOSHADOW);
 
             Fancy_Text_Print(TXT_SIDE_COLON,
-                             Dimensions[BUTTON_HOUSE].x + (Dimensions[BUTTON_HOUSE].w / 2),
-                             Dimensions[BUTTON_HOUSE].y - TextHeight - (1 * Factor),
+                             Dimensions[BUTTON_HOUSE].X + (Dimensions[BUTTON_HOUSE].W / 2),
+                             Dimensions[BUTTON_HOUSE].Y - TextHeight - (1 * Factor),
                              CC_GREEN,
                              TBLACK,
                              TPF_RIGHT | TPF_6PT_GRAD | TPF_USE_GRAD_PAL | TPF_NOSHADOW);
 
             Fancy_Text_Print(TXT_COLOR_COLON,
                              X + ((Width / 4) * 3),
-                             Dimensions[BUTTON_COLOR_1].y - TextHeight - (1 * Factor),
+                             Dimensions[BUTTON_COLOR_1].Y - TextHeight - (1 * Factor),
                              CC_GREEN,
                              TBLACK,
                              TPF_RIGHT | TPF_6PT_GRAD | TPF_USE_GRAD_PAL | TPF_NOSHADOW);
@@ -203,67 +257,68 @@ class SkirmishScenarioDialog final
                              TPF_CENTER | TPF_6PT_GRAD | TPF_USE_GRAD_PAL | TPF_NOSHADOW);
 
             Fancy_Text_Print(TXT_SCENARIOS,
-                             Dimensions[BUTTON_SCENARIOLIST].x + (Dimensions[BUTTON_SCENARIOLIST].w / 2),
-                             Dimensions[BUTTON_SCENARIOLIST].y - TextHeight - (1 * Factor),
+                             Dimensions[BUTTON_SCENARIO_LIST].X + (Dimensions[BUTTON_SCENARIO_LIST].W / 2),
+                             Dimensions[BUTTON_SCENARIO_LIST].Y - TextHeight - (1 * Factor),
                              CC_GREEN,
                              TBLACK,
                              TPF_CENTER | TPF_6PT_GRAD | TPF_USE_GRAD_PAL | TPF_NOSHADOW);
 
             Fancy_Text_Print(TXT_COUNT,
-                             Dimensions[BUTTON_COUNT].x - 3 * Factor,
-                             Dimensions[BUTTON_COUNT].y,
+                             Dimensions[BUTTON_COUNT].X - 3 * Factor,
+                             Dimensions[BUTTON_COUNT].Y,
                              CC_GREEN,
                              TBLACK,
                              TPF_NOSHADOW | TPF_6PT_GRAD | TPF_USE_GRAD_PAL | TPF_RIGHT);
 
             Fancy_Text_Print(TXT_LEVEL,
-                             Dimensions[BUTTON_LEVEL].x - 3 * Factor,
-                             Dimensions[BUTTON_LEVEL].y,
+                             Dimensions[BUTTON_LEVEL].X - 3 * Factor,
+                             Dimensions[BUTTON_LEVEL].Y,
                              CC_GREEN,
                              TBLACK,
                              TPF_NOSHADOW | TPF_6PT_GRAD | TPF_USE_GRAD_PAL | TPF_RIGHT);
 
             Fancy_Text_Print(TXT_START_CREDITS_COLON,
-                             Dimensions[BUTTON_CREDITS].x - 3 * Factor,
-                             Dimensions[BUTTON_CREDITS].y,
+                             Dimensions[BUTTON_CREDITS].X - 3 * Factor,
+                             Dimensions[BUTTON_CREDITS].Y,
                              CC_GREEN,
                              TBLACK,
                              TPF_RIGHT | TPF_6PT_GRAD | TPF_USE_GRAD_PAL | TPF_NOSHADOW);
 
             Fancy_Text_Print("Tiberium Growth:", // TODO: Locale file entry
-                             Dimensions[BUTTON_TIBERIUMSCALE].x - 3 * Factor,
-                             Dimensions[BUTTON_TIBERIUMSCALE].y,
+                             Dimensions[BUTTON_TIBERIUM_SCALE].X - 3 * Factor,
+                             Dimensions[BUTTON_TIBERIUM_SCALE].Y,
                              CC_GREEN,
                              TBLACK,
                              TPF_RIGHT | TPF_6PT_GRAD | TPF_USE_GRAD_PAL | TPF_NOSHADOW);
 
             // AI player setting headers
             Fancy_Text_Print("Player", // TODO: Locale file entry
-                             (Dimensions[BUTTON_AI_HOUSE_1].x
-                                - static_cast<int>(nearbyint(Dimensions[BUTTON_AI_HOUSE_1].w * 1.5)) - (10 * Factor))
-                                + (static_cast<int>((Dimensions[BUTTON_AI_HOUSE_1].w * 1.5) / 1.25)),
-                             Dimensions[BUTTON_AI_HOUSE_1].y - TextHeight - (2 * Factor),
+                             (Dimensions[BUTTON_AI_HOUSE_1].X
+                                - static_cast<int>(nearbyint(Dimensions[BUTTON_AI_HOUSE_1].W * 1.5)) - (10 * Factor))
+                                + (static_cast<int>((Dimensions[BUTTON_AI_HOUSE_1].W * 1.5) / 1.25)),
+                             Dimensions[BUTTON_AI_HOUSE_1].Y - TextHeight - (2 * Factor),
                              CC_GREEN,
                              TBLACK,
                              TPF_RIGHT | TPF_6PT_GRAD | TPF_USE_GRAD_PAL | TPF_NOSHADOW);
 
             Fancy_Text_Print("Side", // TODO: Locale file entry
-                             Dimensions[BUTTON_AI_HOUSE_1].x
-                                + static_cast<int>(nearbyint(Dimensions[BUTTON_AI_HOUSE_1].w / 1.25)),
-                             Dimensions[BUTTON_AI_HOUSE_1].y - TextHeight - (2 * Factor),
+                             Dimensions[BUTTON_AI_HOUSE_1].X
+                                + static_cast<int>(nearbyint(Dimensions[BUTTON_AI_HOUSE_1].W / 1.25)),
+                             Dimensions[BUTTON_AI_HOUSE_1].Y - TextHeight - (2 * Factor),
                              CC_GREEN,
                              TBLACK,
                              TPF_RIGHT | TPF_6PT_GRAD | TPF_USE_GRAD_PAL | TPF_NOSHADOW);
 
             // AI player difficulty and house checkbox labels
-            const auto cur_ai_house_label_x = (Dimensions[BUTTON_AI_HOUSE_1].x
-                - static_cast<int>(nearbyint(Dimensions[BUTTON_AI_HOUSE_1].w * 1.5))
+            const auto cur_ai_house_label_x = (Dimensions[BUTTON_AI_HOUSE_1].X
+                - static_cast<int>(nearbyint(Dimensions[BUTTON_AI_HOUSE_1].W * 1.5))
                 - (10 * Factor)) - 3 * Factor;
 
             for (auto control = BUTTON_AI_DIFF_1; control <= BUTTON_AI_DIFF_5; ++control) {
-                Fancy_Text_Print(std::format("AI {}:", control - BUTTON_HOUSE).c_str(), // TODO: Locale file entry
+                // TODO: Locale file entry
+                Fancy_Text_Print(std::format("AI {}:", control - BUTTON_HOUSE).c_str(),
                                  cur_ai_house_label_x,
-                                 Dimensions[control].y,
+                                 Dimensions[control].Y,
                                  CC_GREEN,
                                  TBLACK,
                                  TPF_RIGHT | TPF_6PT_GRAD | TPF_USE_GRAD_PAL | TPF_NOSHADOW);
@@ -277,17 +332,17 @@ class SkirmishScenarioDialog final
             for (auto control = BUTTON_COLOR_1; control <= BUTTON_COLOR_6; ++control) {
                 const auto mplayer_idx = control - BUTTON_COLOR_1;
 
-                LogicPage->Fill_Rect(Dimensions[control].x + 1 * Factor,
-                                     Dimensions[control].y + 1 * Factor,
-                                     Dimensions[control].x + 1 * Factor + Dimensions[control].w - 2 * Factor,
-                                     Dimensions[control].y + 1 * Factor + Dimensions[control].h - 2 * Factor,
+                LogicPage->Fill_Rect(Dimensions[control].X + 1 * Factor,
+                                     Dimensions[control].Y + 1 * Factor,
+                                     Dimensions[control].X + 1 * Factor + Dimensions[control].W - 2 * Factor,
+                                     Dimensions[control].Y + 1 * Factor + Dimensions[control].H - 2 * Factor,
                                      MPlayerGColors[mplayer_idx]);
 
                 Draw_Box(
-                    Dimensions[control].x,
-                    Dimensions[control].y,
-                    Dimensions[control].w,
-                    Dimensions[control].h,
+                    Dimensions[control].X,
+                    Dimensions[control].Y,
+                    Dimensions[control].W,
+                    Dimensions[control].H,
                     mplayer_idx == MPlayerColorIdx ? BOXSTYLE_GREEN_DOWN : BOXSTYLE_GREEN_RAISED,
                     false
                 );
@@ -301,8 +356,8 @@ class SkirmishScenarioDialog final
         if (display >= REDRAW_MESSAGE) {
             sprintf(txt, "%d ", MPlayerUnitCount);
             Fancy_Text_Print(txt,
-                             Dimensions[BUTTON_COUNT].x + Dimensions[BUTTON_COUNT].w + 3 * Factor,
-                             Dimensions[BUTTON_COUNT].y,
+                             Dimensions[BUTTON_COUNT].X + Dimensions[BUTTON_COUNT].W + 3 * Factor,
+                             Dimensions[BUTTON_COUNT].Y,
                              CC_GREEN,
                              BLACK,
                              TPF_6PT_GRAD | TPF_USE_GRAD_PAL | TPF_NOSHADOW);
@@ -313,23 +368,23 @@ class SkirmishScenarioDialog final
                 sprintf(txt, "**");
             }
             Fancy_Text_Print(txt,
-                             Dimensions[BUTTON_LEVEL].x + Dimensions[BUTTON_LEVEL].w + 3 * Factor,
-                             Dimensions[BUTTON_LEVEL].y,
+                             Dimensions[BUTTON_LEVEL].X + Dimensions[BUTTON_LEVEL].W + 3 * Factor,
+                             Dimensions[BUTTON_LEVEL].Y,
                              CC_GREEN,
                              BLACK,
                              TPF_6PT_GRAD | TPF_USE_GRAD_PAL | TPF_NOSHADOW);
             sprintf(txt, "%d ", MPlayerCredits);
             Fancy_Text_Print(txt,
-                             Dimensions[BUTTON_CREDITS].x + Dimensions[BUTTON_CREDITS].w + 3 * Factor,
-                             Dimensions[BUTTON_CREDITS].y,
+                             Dimensions[BUTTON_CREDITS].X + Dimensions[BUTTON_CREDITS].W + 3 * Factor,
+                             Dimensions[BUTTON_CREDITS].Y,
                              CC_GREEN,
                              BLACK,
                              TPF_6PT_GRAD | TPF_USE_GRAD_PAL | TPF_NOSHADOW);
 
-            sprintf(txt, "%dx ", Get_Control<GaugeClass>(BUTTON_TIBERIUMSCALE).Get_Value() + 1);
+            sprintf(txt, "%dx ", Get_Control<GaugeClass>(BUTTON_TIBERIUM_SCALE).Get_Value() + 1);
             Fancy_Text_Print(txt,
-                             Dimensions[BUTTON_TIBERIUMSCALE].x + Dimensions[BUTTON_TIBERIUMSCALE].w + 3 * Factor,
-                             Dimensions[BUTTON_TIBERIUMSCALE].y,
+                             Dimensions[BUTTON_TIBERIUM_SCALE].X + Dimensions[BUTTON_TIBERIUM_SCALE].W + 3 * Factor,
+                             Dimensions[BUTTON_TIBERIUM_SCALE].Y,
                              CC_GREEN,
                              BLACK,
                              TPF_6PT_GRAD | TPF_USE_GRAD_PAL | TPF_NOSHADOW);
@@ -346,6 +401,32 @@ class SkirmishScenarioDialog final
         display = REDRAW_NONE;
     }
 
+    void Collapse_Visible_Dropdowns(RedrawType& display)
+    {
+        auto& house_dropdown = Get_Control<DropListClass>(BUTTON_HOUSE);
+
+        if (house_dropdown.IsDropped) {
+            house_dropdown.Collapse();
+            display = REDRAW_BACKGROUND;
+        }
+
+        for (auto control = BUTTON_AI_DIFF_1; control <= BUTTON_AI_DIFF_5; ++control) {
+            const auto house_btn = static_cast<ControlType>(control + 5);
+            auto& ai_diff_dropdown = Get_Control<DropListClass>(control);
+            auto& ai_house_dropdown = Get_Control<DropListClass>(house_btn);
+
+            if (ai_diff_dropdown.IsDropped) {
+                ai_diff_dropdown.Collapse();
+                display = REDRAW_BACKGROUND;
+            }
+
+            if (ai_house_dropdown.IsDropped) {
+                ai_house_dropdown.Collapse();
+                display = REDRAW_BACKGROUND;
+            }
+        }
+    }
+
     void Init_UI_State()
     {
         auto& option_list = Get_Control<CheckListClass>(BUTTON_OPTIONS);
@@ -356,35 +437,35 @@ class SkirmishScenarioDialog final
         option_list.Add_Item(Text_String(TXT_BASES_ON));
         option_list.Add_Item("Tiberium Regrows"); // TODO: Locale file entry
         option_list.Add_Item(Text_String(TXT_CRATES_ON));
-        //optionlist.Add_Item(Text_String(TXT_SHADOW_REGROWS)); // TODO: Implement for TD? (copied from RA)
+        //option_list.Add_Item(Text_String(TXT_SHADOW_REGROWS)); // TODO: Implement for TD? (copied from RA)
         option_list.Add_Item(Text_String(TXT_CAPTURE_THE_FLAG));
 
         option_list.Check_Item(0, MPlayerBases);
         option_list.Check_Item(1, MPlayerTiberium);
         option_list.Check_Item(2, MPlayerGoodies);
-        //optionlist.Check_Item(3, Special.IsShadowGrow);
+        //option_list.Check_Item(3, Special.IsShadowGrow);
         option_list.Check_Item(3, Special.IsCaptureTheFlag);
 
-        auto& levelgauge = Get_Control<GaugeClass>(BUTTON_LEVEL);
-        levelgauge.Set_Maximum(MPLAYER_BUILD_LEVEL_MAX - 1);
-        levelgauge.Set_Value(BuildLevel - 1);
+        auto& level_gauge = Get_Control<GaugeClass>(BUTTON_LEVEL);
+        level_gauge.Set_Maximum(MPLAYER_BUILD_LEVEL_MAX - 1);
+        level_gauge.Set_Value(BuildLevel - 1);
 
-        auto& countgauge = Get_Control<GaugeClass>(BUTTON_COUNT);
-        countgauge.Set_Maximum(MPlayerCountMax[MPlayerBases] - MPlayerCountMin[MPlayerBases]);
-        countgauge.Set_Value(MPlayerUnitCount - MPlayerCountMin[MPlayerBases]);
+        auto& count_gauge = Get_Control<GaugeClass>(BUTTON_COUNT);
+        count_gauge.Set_Maximum(MPlayerCountMax[MPlayerBases] - MPlayerCountMin[MPlayerBases]);
+        count_gauge.Set_Value(MPlayerUnitCount - MPlayerCountMin[MPlayerBases]);
 
-        auto& creditsgauge = Get_Control<GaugeClass>(BUTTON_CREDITS);
-        creditsgauge.Set_Maximum(Rule.Get_Rule_Value<int>(GAME_MULTIPLAYER_SECTION, START_CREDITS_MAX_RULE));
-        creditsgauge.Set_Value(MPlayerCredits);
+        auto& credits_gauge = Get_Control<GaugeClass>(BUTTON_CREDITS);
+        credits_gauge.Set_Maximum(Rule.Get_Rule_Value<int>(GAME_MULTIPLAYER_SECTION, START_CREDITS_MAX_RULE));
+        credits_gauge.Set_Value(MPlayerCredits);
 
-        auto& tiberiumscalegauge = Get_Control<GaugeClass>(BUTTON_TIBERIUMSCALE);
-        tiberiumscalegauge.Set_Maximum(4);
-        tiberiumscalegauge.Set_Value(MPlayerTiberium < 2 ? 0 : MPlayerTiberium - 1);
+        auto& tiberium_scale_gauge = Get_Control<GaugeClass>(BUTTON_TIBERIUM_SCALE);
+        tiberium_scale_gauge.Set_Maximum(4);
+        tiberium_scale_gauge.Set_Value(MPlayerTiberium < 2 ? 0 : MPlayerTiberium - 1);
 
-        auto& scenariolist = Get_Control<ListClass>(BUTTON_SCENARIOLIST);
+        auto& scenario_list = Get_Control<ListClass>(BUTTON_SCENARIO_LIST);
 
         for (auto i = 0; i < MPlayerScenarios.Count(); i++) {
-            scenariolist.Add_Item(strupr(MPlayerScenarios[i]));
+            scenario_list.Add_Item(strupr(MPlayerScenarios[i]));
         }
         ScenarioIdx = 0; // 1st scenario is selected
 
@@ -392,7 +473,7 @@ class SkirmishScenarioDialog final
         for (auto i = 0; i < MPlayerFilenum.Count(); i++) {
             if (MPlayerFilenum[i] == MPlayerScenarioNumber) {
                 ScenarioIdx = i;
-                scenariolist.Set_Selected_Index(i);
+                scenario_list.Set_Selected_Index(i);
                 break;
             }
         }
@@ -474,10 +555,10 @@ class SkirmishScenarioDialog final
                 BUTTON_OK,
                 TXT_OK,
                 TPF_CENTER | TPF_6PT_GRAD | TPF_USE_GRAD_PAL | TPF_NOSHADOW,
-                Dimensions[BUTTON_OK].x,
-                Dimensions[BUTTON_OK].y,
-                Dimensions[BUTTON_OK].w,
-                Dimensions[BUTTON_OK].h
+                Dimensions[BUTTON_OK].X,
+                Dimensions[BUTTON_OK].Y,
+                Dimensions[BUTTON_OK].W,
+                Dimensions[BUTTON_OK].H
             )
         );
         Get_Control<TextButtonClass>(BUTTON_OK).Add_Tail(*CommandChain);
@@ -487,10 +568,10 @@ class SkirmishScenarioDialog final
                 BUTTON_CANCEL,
                 TXT_CANCEL,
                 TPF_CENTER | TPF_6PT_GRAD | TPF_USE_GRAD_PAL | TPF_NOSHADOW,
-                Dimensions[BUTTON_CANCEL].x,
-                Dimensions[BUTTON_CANCEL].y,
-                Dimensions[BUTTON_CANCEL].w,
-                Dimensions[BUTTON_CANCEL].h
+                Dimensions[BUTTON_CANCEL].X,
+                Dimensions[BUTTON_CANCEL].Y,
+                Dimensions[BUTTON_CANCEL].W,
+                Dimensions[BUTTON_CANCEL].H
             )
         );
         Get_Control<TextButtonClass>(BUTTON_CANCEL).Add_Tail(*CommandChain);
@@ -501,9 +582,9 @@ class SkirmishScenarioDialog final
         Controls[BUTTON_DIFFICULTY] = std::unique_ptr<GadgetClass>(
             new SliderClass(
                 BUTTON_DIFFICULTY,
-                Dimensions[BUTTON_NAME].x,
-                Dimensions[BUTTON_OK].y - (8 * Factor) - MarginWidth,
-                Width - (Dimensions[BUTTON_NAME].x - X) * 2,
+                Dimensions[BUTTON_NAME].X,
+                Dimensions[BUTTON_OK].Y - (8 * Factor) - MarginWidth,
+                Width - (Dimensions[BUTTON_NAME].X - X) * 2,
                 8 * Factor,
                 true
             )
@@ -524,39 +605,27 @@ class SkirmishScenarioDialog final
 
     void Init_Bottom_Row()
     {
-        Controls[BUTTON_COUNT] = std::unique_ptr<GadgetClass>(
-            new GaugeClass(BUTTON_COUNT, Dimensions[BUTTON_COUNT].x, Dimensions[BUTTON_COUNT].y, Dimensions[BUTTON_COUNT].w, Dimensions[BUTTON_COUNT].h)
-        );
-        Get_Control<GaugeClass>(BUTTON_COUNT).Add_Tail(*CommandChain);
-
-        Controls[BUTTON_LEVEL] = std::unique_ptr<GadgetClass>(
-            new GaugeClass(BUTTON_LEVEL, Dimensions[BUTTON_LEVEL].x, Dimensions[BUTTON_LEVEL].y, Dimensions[BUTTON_LEVEL].w, Dimensions[BUTTON_LEVEL].h)
-        );
-        Get_Control<GaugeClass>(BUTTON_LEVEL).Add_Tail(*CommandChain);
-
-        Controls[BUTTON_CREDITS] = std::unique_ptr<GadgetClass>(
-            new GaugeClass(BUTTON_CREDITS, Dimensions[BUTTON_CREDITS].x, Dimensions[BUTTON_CREDITS].y, Dimensions[BUTTON_CREDITS].w, Dimensions[BUTTON_CREDITS].h)
-        );
-        Get_Control<GaugeClass>(BUTTON_CREDITS).Add_Tail(*CommandChain);
-
-        Controls[BUTTON_TIBERIUMSCALE] = std::unique_ptr<GadgetClass>(
-            new GaugeClass(
-                BUTTON_TIBERIUMSCALE,
-                Dimensions[BUTTON_TIBERIUMSCALE].x,
-                Dimensions[BUTTON_TIBERIUMSCALE].y,
-                Dimensions[BUTTON_TIBERIUMSCALE].w,
-                Dimensions[BUTTON_TIBERIUMSCALE].h
-            )
-        );
-        Get_Control<GaugeClass>(BUTTON_TIBERIUMSCALE).Add_Tail(*CommandChain);
+        // init gauges
+        for (auto control = BUTTON_COUNT; control <= BUTTON_TIBERIUM_SCALE; ++control) {
+            Controls[control] = std::unique_ptr<GadgetClass>(
+                new GaugeClass(
+                    control,
+                    Dimensions[control].X,
+                    Dimensions[control].Y,
+                    Dimensions[control].W,
+                    Dimensions[control].H
+                )
+            );
+            Get_Control<GaugeClass>(control).Add_Tail(*CommandChain);
+        }
 
         Controls[BUTTON_OPTIONS] = std::unique_ptr<GadgetClass>(
             new CheckListClass(
                 BUTTON_OPTIONS,
-                Dimensions[BUTTON_OPTIONS].x,
-                Dimensions[BUTTON_OPTIONS].y,
-                Dimensions[BUTTON_OPTIONS].w,
-                Dimensions[BUTTON_OPTIONS].h,
+                Dimensions[BUTTON_OPTIONS].X,
+                Dimensions[BUTTON_OPTIONS].Y,
+                Dimensions[BUTTON_OPTIONS].W,
+                Dimensions[BUTTON_OPTIONS].H,
                 TPF_6PT_GRAD | TPF_USE_GRAD_PAL | TPF_NOSHADOW,
                 UpButtonShape,
                 DownButtonShape
@@ -568,7 +637,7 @@ class SkirmishScenarioDialog final
     void Init_Middle_Row()
     {
         for (auto control = BUTTON_AI_DIFF_1; control <= BUTTON_AI_DIFF_5; ++control) {
-            const auto house_control = static_cast<ButtonType>(control + 5);
+            const auto house_control = static_cast<ControlType>(control + 5);
 
             Text[control] = std::make_unique<char[]>(DropdownTextLength);
             Text[house_control] = std::make_unique<char[]>(DropdownTextLength);
@@ -579,10 +648,10 @@ class SkirmishScenarioDialog final
                     Text[control].get(),
                     DropdownTextLength,
                     TPF_6PT_GRAD | TPF_USE_GRAD_PAL | TPF_NOSHADOW,
-                    Dimensions[control].x,
-                    Dimensions[control].y,
-                    Dimensions[control].w,
-                    Dimensions[control].h,
+                    Dimensions[control].X,
+                    Dimensions[control].Y,
+                    Dimensions[control].W,
+                    Dimensions[control].H,
                     UpButtonShape,
                     DownButtonShape
                 )
@@ -595,10 +664,10 @@ class SkirmishScenarioDialog final
                     Text[house_control].get(),
                     DropdownTextLength,
                     TPF_6PT_GRAD | TPF_USE_GRAD_PAL | TPF_NOSHADOW,
-                    Dimensions[house_control].x,
-                    Dimensions[house_control].y,
-                    Dimensions[house_control].w,
-                    Dimensions[house_control].h,
+                    Dimensions[house_control].X,
+                    Dimensions[house_control].Y,
+                    Dimensions[house_control].W,
+                    Dimensions[house_control].H,
                     UpButtonShape,
                     DownButtonShape
                 )
@@ -606,19 +675,19 @@ class SkirmishScenarioDialog final
             Get_Control<DropListClass>(house_control).Add_Tail(*CommandChain);
         }
 
-        Controls[BUTTON_SCENARIOLIST] = std::unique_ptr<GadgetClass>(
+        Controls[BUTTON_SCENARIO_LIST] = std::unique_ptr<GadgetClass>(
             new ListClass(
-                BUTTON_SCENARIOLIST,
-                Dimensions[BUTTON_SCENARIOLIST].x,
-                Dimensions[BUTTON_SCENARIOLIST].y,
-                Dimensions[BUTTON_SCENARIOLIST].w,
-                Dimensions[BUTTON_SCENARIOLIST].h,
+                BUTTON_SCENARIO_LIST,
+                Dimensions[BUTTON_SCENARIO_LIST].X,
+                Dimensions[BUTTON_SCENARIO_LIST].Y,
+                Dimensions[BUTTON_SCENARIO_LIST].W,
+                Dimensions[BUTTON_SCENARIO_LIST].H,
                 TPF_6PT_GRAD | TPF_USE_GRAD_PAL | TPF_NOSHADOW,
                 UpButtonShape,
                 DownButtonShape
             )
         );
-        Get_Control<ListClass>(BUTTON_SCENARIOLIST).Add_Tail(*CommandChain);
+        Get_Control<ListClass>(BUTTON_SCENARIO_LIST).Add_Tail(*CommandChain);
     }
 
     void Init_Top_Row()
@@ -630,10 +699,10 @@ class SkirmishScenarioDialog final
                 Text[BUTTON_NAME].get(),
                 MPLAYER_NAME_MAX,
                 TPF_6PT_GRAD | TPF_USE_GRAD_PAL | TPF_NOSHADOW,
-                Dimensions[BUTTON_NAME].x,
-                Dimensions[BUTTON_NAME].y,
-                Dimensions[BUTTON_NAME].w,
-                Dimensions[BUTTON_NAME].h,
+                Dimensions[BUTTON_NAME].X,
+                Dimensions[BUTTON_NAME].Y,
+                Dimensions[BUTTON_NAME].W,
+                Dimensions[BUTTON_NAME].H,
                 EditClass::ALPHANUMERIC
             )
         );
@@ -645,10 +714,10 @@ class SkirmishScenarioDialog final
                 Text[BUTTON_HOUSE].get(),
                 DropdownTextLength,
                 TPF_6PT_GRAD | TPF_USE_GRAD_PAL | TPF_NOSHADOW,
-                Dimensions[BUTTON_HOUSE].x,
-                Dimensions[BUTTON_HOUSE].y,
-                Dimensions[BUTTON_HOUSE].w,
-                Dimensions[BUTTON_HOUSE].h,
+                Dimensions[BUTTON_HOUSE].X,
+                Dimensions[BUTTON_HOUSE].Y,
+                Dimensions[BUTTON_HOUSE].W,
+                Dimensions[BUTTON_HOUSE].H,
                 UpButtonShape,
                 DownButtonShape
             )
@@ -697,106 +766,106 @@ class SkirmishScenarioDialog final
 
         Dimensions.clear();
 
-        Dimensions[BUTTON_OK].w = 45 * Factor;
-        Dimensions[BUTTON_OK].h = 9 * Factor;
-        Dimensions[BUTTON_OK].x = X + (Width / 6) - (Dimensions[BUTTON_OK].w / 2);
-        Dimensions[BUTTON_OK].y = Y + Height - Dimensions[BUTTON_OK].h - MarginWidth - Factor * 6;
+        Dimensions[BUTTON_OK].W = 45 * Factor;
+        Dimensions[BUTTON_OK].H = 9 * Factor;
+        Dimensions[BUTTON_OK].X = X + (Width / 6) - (Dimensions[BUTTON_OK].W / 2);
+        Dimensions[BUTTON_OK].Y = Y + Height - Dimensions[BUTTON_OK].H - MarginWidth - Factor * 6;
 
-        Dimensions[BUTTON_CANCEL].w = 45 * Factor;
-        Dimensions[BUTTON_CANCEL].h = 9 * Factor;
-        Dimensions[BUTTON_CANCEL].x = X + Width - (Width / 6) - (Dimensions[BUTTON_CANCEL].w / 2);
-        Dimensions[BUTTON_CANCEL].y = Y + Height - Dimensions[BUTTON_CANCEL].h - MarginWidth - Factor * 6;
+        Dimensions[BUTTON_CANCEL].W = 45 * Factor;
+        Dimensions[BUTTON_CANCEL].H = 9 * Factor;
+        Dimensions[BUTTON_CANCEL].X = X + Width - (Width / 6) - (Dimensions[BUTTON_CANCEL].W / 2);
+        Dimensions[BUTTON_CANCEL].Y = Y + Height - Dimensions[BUTTON_CANCEL].H - MarginWidth - Factor * 6;
 
-        Dimensions[BUTTON_NAME].w = 70 * Factor;
-        Dimensions[BUTTON_NAME].h = 9 * Factor;
-        Dimensions[BUTTON_NAME].x = X + 5 + (Width / 4) - (Dimensions[BUTTON_NAME].w / 2);
-        Dimensions[BUTTON_NAME].y = Y + MarginHeight + TextHeight + 1 * Factor;
+        Dimensions[BUTTON_NAME].W = 70 * Factor;
+        Dimensions[BUTTON_NAME].H = 9 * Factor;
+        Dimensions[BUTTON_NAME].X = X + 5 + (Width / 4) - (Dimensions[BUTTON_NAME].W / 2);
+        Dimensions[BUTTON_NAME].Y = Y + MarginHeight + TextHeight + 1 * Factor;
 
-        Dimensions[BUTTON_HOUSE].w = 60 * Factor;
-        Dimensions[BUTTON_HOUSE].h = (3 * 5 * Factor);
-        Dimensions[BUTTON_HOUSE].x = Center - (Dimensions[BUTTON_HOUSE].w / 2);
-        Dimensions[BUTTON_HOUSE].y = Dimensions[BUTTON_NAME].y;
+        Dimensions[BUTTON_HOUSE].W = 60 * Factor;
+        Dimensions[BUTTON_HOUSE].H = (3 * 5 * Factor);
+        Dimensions[BUTTON_HOUSE].X = Center - (Dimensions[BUTTON_HOUSE].W / 2);
+        Dimensions[BUTTON_HOUSE].Y = Dimensions[BUTTON_NAME].Y;
 
-        Dimensions[BUTTON_COLOR_1].w = 10 * Factor;
-        Dimensions[BUTTON_COLOR_1].h = 9 * Factor;
-        Dimensions[BUTTON_COLOR_1].y = Dimensions[BUTTON_NAME].y;
-        Dimensions[BUTTON_COLOR_1].x = X + ((Width / 4) * 3) - (Dimensions[BUTTON_COLOR_1].w * 3);
+        Dimensions[BUTTON_COLOR_1].W = 10 * Factor;
+        Dimensions[BUTTON_COLOR_1].H = 9 * Factor;
+        Dimensions[BUTTON_COLOR_1].Y = Dimensions[BUTTON_NAME].Y;
+        Dimensions[BUTTON_COLOR_1].X = X + ((Width / 4) * 3) - (Dimensions[BUTTON_COLOR_1].W * 3);
 
         for (auto control = BUTTON_COLOR_2; control <= BUTTON_COLOR_6; ++control) {
             Dimensions[control] = Dimensions[BUTTON_COLOR_1];
-            Dimensions[control].x = Dimensions[control].x + (Dimensions[control].w * (control - BUTTON_COLOR_1));
+            Dimensions[control].X = Dimensions[control].X + (Dimensions[control].W * (control - BUTTON_COLOR_1));
         }
 
-        Dimensions[BUTTON_PLAYERLIST].w = 118 * Factor;
-        Dimensions[BUTTON_PLAYERLIST].x = X + MarginWidth + MarginWidth + 5 * Factor;
+        Dimensions[BUTTON_PLAYER_LIST].W = 118 * Factor;
+        Dimensions[BUTTON_PLAYER_LIST].X = X + MarginWidth + MarginWidth + 5 * Factor;
 
-        Dimensions[BUTTON_SCENARIOLIST].w = 140 * Factor;
-        Dimensions[BUTTON_SCENARIOLIST].h = 30 * Factor;
-        Dimensions[BUTTON_SCENARIOLIST].x =
-            (Dimensions[BUTTON_CANCEL].x + static_cast<int>(nearbyint(Dimensions[BUTTON_CANCEL].w * 0.8)))
-            - Dimensions[BUTTON_SCENARIOLIST].w + (20 * Factor);
-        Dimensions[BUTTON_SCENARIOLIST].y = Dimensions[BUTTON_COLOR_1].y + TextHeight + 5 * Factor + TextHeight;
+        Dimensions[BUTTON_SCENARIO_LIST].W = 140 * Factor;
+        Dimensions[BUTTON_SCENARIO_LIST].H = 30 * Factor;
+        Dimensions[BUTTON_SCENARIO_LIST].X =
+            (Dimensions[BUTTON_CANCEL].X + static_cast<int>(nearbyint(Dimensions[BUTTON_CANCEL].W * 0.8)))
+            - Dimensions[BUTTON_SCENARIO_LIST].W + (20 * Factor);
+        Dimensions[BUTTON_SCENARIO_LIST].Y = Dimensions[BUTTON_COLOR_1].Y + TextHeight + 5 * Factor + TextHeight;
 
-        Dimensions[BUTTON_SCENARIOLIST].h *= 2;
+        Dimensions[BUTTON_SCENARIO_LIST].H *= 2;
 
         // right column of AI house controls
-        Dimensions[BUTTON_AI_HOUSE_1].w = static_cast<int>(nearbyint(Dimensions[BUTTON_HOUSE].w / 1.75));
-        Dimensions[BUTTON_AI_HOUSE_1].h = (6 * 5 * Factor);
-        Dimensions[BUTTON_AI_HOUSE_1].x = Dimensions[BUTTON_SCENARIOLIST].x
-            - Dimensions[BUTTON_AI_HOUSE_1].w - (10 * Factor);
-        Dimensions[BUTTON_AI_HOUSE_1].y = Dimensions[BUTTON_SCENARIOLIST].y + (5 * Factor);
+        Dimensions[BUTTON_AI_HOUSE_1].W = static_cast<int>(nearbyint(Dimensions[BUTTON_HOUSE].W / 1.75));
+        Dimensions[BUTTON_AI_HOUSE_1].H = (6 * 5 * Factor);
+        Dimensions[BUTTON_AI_HOUSE_1].X = Dimensions[BUTTON_SCENARIO_LIST].X
+            - Dimensions[BUTTON_AI_HOUSE_1].W - (10 * Factor);
+        Dimensions[BUTTON_AI_HOUSE_1].Y = Dimensions[BUTTON_SCENARIO_LIST].Y + (5 * Factor);
 
         for (auto control = BUTTON_AI_HOUSE_2; control <= BUTTON_AI_HOUSE_5; ++control) {
-            const auto previous_control = static_cast<ButtonType>(control - 1);
+            const auto previous_control = static_cast<ControlType>(control - 1);
 
             Dimensions[control] = Dimensions[BUTTON_AI_HOUSE_1];
-            Dimensions[control].y = Dimensions[previous_control].y + 10 * Factor;
+            Dimensions[control].Y = Dimensions[previous_control].Y + 10 * Factor;
         }
 
         // left column of AI house controls
-        Dimensions[BUTTON_AI_DIFF_1].w = static_cast<int>(nearbyint(Dimensions[BUTTON_AI_HOUSE_1].w * 1.5));
-        Dimensions[BUTTON_AI_DIFF_1].h = Dimensions[BUTTON_AI_HOUSE_1].h;
-        Dimensions[BUTTON_AI_DIFF_1].x = Dimensions[BUTTON_AI_HOUSE_1].x
-            - static_cast<int>(nearbyint(Dimensions[BUTTON_AI_HOUSE_1].w * 1.5)) - (10 * Factor);
-        Dimensions[BUTTON_AI_DIFF_1].y = Dimensions[BUTTON_AI_HOUSE_1].y;
+        Dimensions[BUTTON_AI_DIFF_1].W = static_cast<int>(nearbyint(Dimensions[BUTTON_AI_HOUSE_1].W * 1.5));
+        Dimensions[BUTTON_AI_DIFF_1].H = Dimensions[BUTTON_AI_HOUSE_1].H;
+        Dimensions[BUTTON_AI_DIFF_1].X = Dimensions[BUTTON_AI_HOUSE_1].X
+            - static_cast<int>(nearbyint(Dimensions[BUTTON_AI_HOUSE_1].W * 1.5)) - (10 * Factor);
+        Dimensions[BUTTON_AI_DIFF_1].Y = Dimensions[BUTTON_AI_HOUSE_1].Y;
 
         for (auto control = BUTTON_AI_DIFF_2; control <= BUTTON_AI_DIFF_5; ++control) {
-            const auto previous_control = static_cast<ButtonType>(control - 1);
+            const auto previous_control = static_cast<ControlType>(control - 1);
 
             Dimensions[control] = Dimensions[BUTTON_AI_DIFF_1];
-            Dimensions[control].y = Dimensions[previous_control].y + 10 * Factor;
+            Dimensions[control].Y = Dimensions[previous_control].Y + 10 * Factor;
         }
 
-        Dimensions[BUTTON_OPTIONS].w = static_cast<int>(nearbyint(Dimensions[BUTTON_SCENARIOLIST].w * 0.8));
-        Dimensions[BUTTON_OPTIONS].h = (5 * 6 * Factor) + 5 * Factor;
-        Dimensions[BUTTON_OPTIONS].x = (Dimensions[BUTTON_SCENARIOLIST].x + Dimensions[BUTTON_SCENARIOLIST].w)
-            - Dimensions[BUTTON_OPTIONS].w;
-        Dimensions[BUTTON_OPTIONS].y = Dimensions[BUTTON_SCENARIOLIST].y + Dimensions[BUTTON_SCENARIOLIST].h
+        Dimensions[BUTTON_OPTIONS].W = static_cast<int>(nearbyint(Dimensions[BUTTON_SCENARIO_LIST].W * 0.8));
+        Dimensions[BUTTON_OPTIONS].H = (5 * 6 * Factor) + 5 * Factor;
+        Dimensions[BUTTON_OPTIONS].X = (Dimensions[BUTTON_SCENARIO_LIST].X + Dimensions[BUTTON_SCENARIO_LIST].W)
+            - Dimensions[BUTTON_OPTIONS].W;
+        Dimensions[BUTTON_OPTIONS].Y = Dimensions[BUTTON_SCENARIO_LIST].Y + Dimensions[BUTTON_SCENARIO_LIST].H
             + MarginWidth - 2 * Factor;
 
-        Dimensions[BUTTON_COUNT].w = 25 * Factor;
-        Dimensions[BUTTON_COUNT].h = 7 * Factor;
-        Dimensions[BUTTON_COUNT].y = Dimensions[BUTTON_OPTIONS].y;
-        Dimensions[BUTTON_COUNT].x = Dimensions[BUTTON_PLAYERLIST].x + (Dimensions[BUTTON_PLAYERLIST].w / 2)
+        Dimensions[BUTTON_COUNT].W = 25 * Factor;
+        Dimensions[BUTTON_COUNT].H = 7 * Factor;
+        Dimensions[BUTTON_COUNT].Y = Dimensions[BUTTON_OPTIONS].Y;
+        Dimensions[BUTTON_COUNT].X = Dimensions[BUTTON_PLAYER_LIST].X + (Dimensions[BUTTON_PLAYER_LIST].W / 2)
             + 20 * Factor;
 
-        Dimensions[BUTTON_LEVEL].w = 25 * Factor;
-        Dimensions[BUTTON_LEVEL].h = 7 * Factor;
-        Dimensions[BUTTON_LEVEL].y = Dimensions[BUTTON_COUNT].y + Dimensions[BUTTON_COUNT].h;
-        Dimensions[BUTTON_LEVEL].x = Dimensions[BUTTON_PLAYERLIST].x + (Dimensions[BUTTON_PLAYERLIST].w / 2)
+        Dimensions[BUTTON_LEVEL].W = 25 * Factor;
+        Dimensions[BUTTON_LEVEL].H = 7 * Factor;
+        Dimensions[BUTTON_LEVEL].Y = Dimensions[BUTTON_COUNT].Y + Dimensions[BUTTON_COUNT].H;
+        Dimensions[BUTTON_LEVEL].X = Dimensions[BUTTON_PLAYER_LIST].X + (Dimensions[BUTTON_PLAYER_LIST].W / 2)
             + 20 * Factor;
 
-        Dimensions[BUTTON_CREDITS].w = 25 * Factor;
-        Dimensions[BUTTON_CREDITS].h = 7 * Factor;
-        Dimensions[BUTTON_CREDITS].x = Dimensions[BUTTON_PLAYERLIST].x + (Dimensions[BUTTON_PLAYERLIST].w / 2)
+        Dimensions[BUTTON_CREDITS].W = 25 * Factor;
+        Dimensions[BUTTON_CREDITS].H = 7 * Factor;
+        Dimensions[BUTTON_CREDITS].X = Dimensions[BUTTON_PLAYER_LIST].X + (Dimensions[BUTTON_PLAYER_LIST].W / 2)
             + 20 * Factor;
-        Dimensions[BUTTON_CREDITS].y = Dimensions[BUTTON_LEVEL].y + Dimensions[BUTTON_LEVEL].h;
+        Dimensions[BUTTON_CREDITS].Y = Dimensions[BUTTON_LEVEL].Y + Dimensions[BUTTON_LEVEL].H;
 
-        Dimensions[BUTTON_TIBERIUMSCALE].w = 25 * Factor;
-        Dimensions[BUTTON_TIBERIUMSCALE].h = 7 * Factor;
-        Dimensions[BUTTON_TIBERIUMSCALE].x = Dimensions[BUTTON_PLAYERLIST].x + (Dimensions[BUTTON_PLAYERLIST].w / 2)
+        Dimensions[BUTTON_TIBERIUM_SCALE].W = 25 * Factor;
+        Dimensions[BUTTON_TIBERIUM_SCALE].H = 7 * Factor;
+        Dimensions[BUTTON_TIBERIUM_SCALE].X = Dimensions[BUTTON_PLAYER_LIST].X + (Dimensions[BUTTON_PLAYER_LIST].W / 2)
             + 20 * Factor;
-        Dimensions[BUTTON_TIBERIUMSCALE].y = Dimensions[BUTTON_CREDITS].y + Dimensions[BUTTON_CREDITS].h;
+        Dimensions[BUTTON_TIBERIUM_SCALE].Y = Dimensions[BUTTON_CREDITS].Y + Dimensions[BUTTON_CREDITS].H;
     }
 
 public:
@@ -810,11 +879,11 @@ public:
 
     ~SkirmishScenarioDialog()
     {
-        if (!Controls.contains(BUTTON_SCENARIOLIST) || Controls[BUTTON_SCENARIOLIST].get() == nullptr) {
+        if (!Controls.contains(BUTTON_SCENARIO_LIST) || Controls[BUTTON_SCENARIO_LIST].get() == nullptr) {
             return;
         }
 
-        auto& scenario_list = Get_Control<ListClass>(BUTTON_SCENARIOLIST);
+        auto& scenario_list = Get_Control<ListClass>(BUTTON_SCENARIO_LIST);
 
         while (scenario_list.Count()) {
             // free dynamically allocated strings
@@ -845,110 +914,10 @@ public:
                 display = REDRAW_ALL;
             }
 
-            /*
-            ........................ Invoke game callback .........................
-            */
             Call_Back();
-
-            /*
-            ...................... Refresh display if needed ......................
-            */
             Render(display);
 
-            /*
-            ........................... Get user input ............................
-            */
-            auto& house_dropdown = Get_Control<DropListClass>(BUTTON_HOUSE);
-            const bool droplist_is_dropped = house_dropdown.IsDropped;
-            std::vector<ButtonType> ai_diffs_collapsed;
-            std::vector<ButtonType> ai_houses_collapsed;
-
-            for (auto control = BUTTON_AI_DIFF_1; control <= BUTTON_AI_DIFF_5; ++control) {
-                if (Get_Control<DropListClass>(control).IsDropped) {
-                    ai_diffs_collapsed.emplace_back(control);
-                }
-
-                const auto house_btn = static_cast<ButtonType>(control + 5);
-
-                if (Get_Control<DropListClass>(house_btn).IsDropped) {
-                    ai_houses_collapsed.emplace_back(house_btn);
-                }
-            }
-
-            auto input = CommandChain->Input();
-
-            /*
-            ** Redraw everything if the player house droplist collapsed
-            */
-            if (droplist_is_dropped && !house_dropdown.IsDropped) {
-                display = REDRAW_BACKGROUND;
-            }
-
-            /*
-            ** Redraw everything if an AI house droplist collapsed
-            */
-            for (const auto& control: ai_diffs_collapsed) {
-                if (!Get_Control<DropListClass>(control).IsDropped) {
-                    display = REDRAW_BACKGROUND;
-                }
-            }
-
-            for (const auto& control: ai_houses_collapsed) {
-                if (!Get_Control<DropListClass>(control).IsDropped) {
-                    display = REDRAW_BACKGROUND;
-                }
-            }
-
-            const auto collapse_visible_dropdowns = [&]() {
-                if (house_dropdown.IsDropped) {
-                    house_dropdown.Collapse();
-                    display = REDRAW_BACKGROUND;
-                }
-
-                for (auto control = BUTTON_AI_DIFF_1; control <= BUTTON_AI_DIFF_5; ++control) {
-                    const auto house_btn = static_cast<ButtonType>(control + 5);
-                    auto& diff_dropdown = Get_Control<DropListClass>(control);
-                    auto& house_dropdown = Get_Control<DropListClass>(house_btn);
-
-                    if (diff_dropdown.IsDropped) {
-                        diff_dropdown.Collapse();
-                        display = REDRAW_BACKGROUND;
-                    }
-
-                    if (house_dropdown.IsDropped) {
-                        house_dropdown.Collapse();
-                        display = REDRAW_BACKGROUND;
-                    }
-                }
-            };
-
-            if (input & KN_BUTTON) {
-                // user is interacting with a button, so hide dropdown lists
-                collapse_visible_dropdowns();
-            }
-
-            // for any visible AI house dropdown, if mouse input is received outside it's bounds, hide it
-            for (auto control = BUTTON_AI_DIFF_1; control <= BUTTON_AI_DIFF_5; ++control) {
-                const auto house_btn = static_cast<ButtonType>(control + 5);
-                auto& diff_dropdown = Get_Control<DropListClass>(control);
-                auto& house_dropdown = Get_Control<DropListClass>(house_btn);
-
-                if (diff_dropdown.IsDropped) {
-                    if ((Keyboard->MouseQX < diff_dropdown.X || Keyboard->MouseQX > diff_dropdown.X + diff_dropdown.Width)
-                    && (Keyboard->MouseQY < diff_dropdown.Y || Keyboard->MouseQY > diff_dropdown.Y + diff_dropdown.Height)) {
-                        diff_dropdown.Collapse();
-                        display = REDRAW_BACKGROUND;
-                    }
-                }
-
-                if (house_dropdown.IsDropped) {
-                    if ((Keyboard->MouseQX < house_dropdown.X || Keyboard->MouseQX > house_dropdown.X + house_dropdown.Width)
-                    && (Keyboard->MouseQY < house_dropdown.Y || Keyboard->MouseQY > house_dropdown.Y + house_dropdown.Height)) {
-                        house_dropdown.Collapse();
-                        display = REDRAW_BACKGROUND;
-                    }
-                }
-            }
+            auto input = Get_Input(display);
 
             /*
             ---------------------------- Process input ----------------------------
@@ -958,19 +927,26 @@ public:
                 User clicks on a color button
                 ------------------------------------------------------------------*/
                 case KN_LMOUSE:
-                    if (Keyboard->MouseQX > Dimensions[BUTTON_COLOR_1].x && Keyboard->MouseQX < (Dimensions[BUTTON_COLOR_6].x + Dimensions[BUTTON_COLOR_6].w)
-                        && Keyboard->MouseQY > Dimensions[BUTTON_COLOR_1].y && Keyboard->MouseQY < (Dimensions[BUTTON_COLOR_6].y + Dimensions[BUTTON_COLOR_6].h)) {
-                        MPlayerPrefColor = (Keyboard->MouseQX - Dimensions[BUTTON_COLOR_1].x) / Dimensions[BUTTON_COLOR_1].w;
+                    if (
+                        Is_Mouse_Over_Rectangle(
+                            Dimensions[BUTTON_COLOR_1].X,
+                            Dimensions[BUTTON_COLOR_1].Y,
+                            (Dimensions[BUTTON_COLOR_6].X + Dimensions[BUTTON_COLOR_6].W),
+                            (Dimensions[BUTTON_COLOR_6].Y + Dimensions[BUTTON_COLOR_6].H)
+                        )
+                    ) {
+                        MPlayerPrefColor = (Keyboard->MouseQX - Dimensions[BUTTON_COLOR_1].X)
+                            / Dimensions[BUTTON_COLOR_1].W;
                         MPlayerColorIdx = MPlayerPrefColor;
                         display = REDRAW_COLORS;
 
                         auto& name_edt = Get_Control<EditClass>(BUTTON_NAME);
-
                         name_edt.Set_Color(MPlayerTColors[MPlayerColorIdx]);
                         name_edt.Flag_To_Redraw();
+
                         strcpy(MPlayerName, Text[BUTTON_NAME].get());
 
-                        collapse_visible_dropdowns();
+                        Collapse_Visible_Dropdowns(display);
                     }
                     break;
 
@@ -979,7 +955,8 @@ public:
                     ------------------------------------------------------------------*/
                 case (BUTTON_NAME | KN_BUTTON): {
                     strcpy(MPlayerName, Text[BUTTON_NAME].get());
-                    collapse_visible_dropdowns();
+
+                    Collapse_Visible_Dropdowns(display);
                     break;
                 }
 
@@ -987,11 +964,12 @@ public:
                     House Buttons: set the player's desired House
                     ------------------------------------------------------------------*/
                 case (BUTTON_HOUSE | KN_BUTTON): {
-                    MPlayerHouse = HousesType(house_dropdown.Current_Index() + HOUSE_GOOD);
+                    MPlayerHouse = static_cast<HousesType>(
+                        Get_Control<DropListClass>(BUTTON_HOUSE).Current_Index() + HOUSE_GOOD
+                    );
                     strcpy(MPlayerName, Text[BUTTON_NAME].get());
 
-                    collapse_visible_dropdowns();
-
+                    Collapse_Visible_Dropdowns(display);
                     display = REDRAW_BACKGROUND;
                     break;
                 }
@@ -999,10 +977,11 @@ public:
                     /*------------------------------------------------------------------
                     New Scenario selected.
                     ------------------------------------------------------------------*/
-                case (BUTTON_SCENARIOLIST | KN_BUTTON): {
-                    auto& scenariolist = Get_Control<ListClass>(BUTTON_SCENARIOLIST);
-                    if (scenariolist.Current_Index() != ScenarioIdx) {
-                        ScenarioIdx = scenariolist.Current_Index();
+                case (BUTTON_SCENARIO_LIST | KN_BUTTON): {
+                    auto& scenario_list = Get_Control<ListClass>(BUTTON_SCENARIO_LIST);
+
+                    if (scenario_list.Current_Index() != ScenarioIdx) {
+                        ScenarioIdx = scenario_list.Current_Index();
 
                         // store the scenario number rather than current scenario list index
                         // (index will change if maps are added/removed by player)
@@ -1026,29 +1005,29 @@ public:
                             continue;
                         }
 
-                        const auto house_btn = static_cast<ButtonType>(control + 5);
-                        auto& diff_dropdown = Get_Control<DropListClass>(control);
-                        auto& house_dropdown = Get_Control<DropListClass>(house_btn);
+                        const auto house_btn = static_cast<ControlType>(control + 5);
+                        auto& ai_diff_dropdown = Get_Control<DropListClass>(control);
+                        auto& ai_house_dropdown = Get_Control<DropListClass>(house_btn);
 
                         // nothing changed, ignore input
-                        if (!diff_dropdown.List.Index_Changed()) {
+                        if (!ai_diff_dropdown.List.Index_Changed()) {
                             break;
                         }
 
-                        const auto diff_was_disabled = diff_dropdown.Current_Index() == 0;
-                        const auto diff_was_activated = diff_dropdown.List.Get_Previous_Index() == 0;
-                        const auto house_is_disabled = house_dropdown.Current_Index() == 0;
+                        const auto diff_was_disabled = ai_diff_dropdown.Current_Index() == 0;
+                        const auto diff_was_activated = ai_diff_dropdown.List.Get_Previous_Index() == 0;
+                        const auto house_is_disabled = ai_house_dropdown.Current_Index() == 0;
 
                         if (diff_was_disabled) {
                             // reset house to match disabled AI diff
-                            house_dropdown.Set_Selected_Index(0);
+                            ai_house_dropdown.Set_Selected_Index(0);
                         } else if (diff_was_activated && house_is_disabled) {
                             // select a default house of '?' since none is selected
-                            house_dropdown.Set_Selected_Index(1);
+                            ai_house_dropdown.Set_Selected_Index(1);
                         }
 
-                        diff_dropdown.Collapse();
-                        house_dropdown.Collapse();
+                        ai_diff_dropdown.Collapse();
+                        ai_house_dropdown.Collapse();
                         display = REDRAW_BACKGROUND;
                         break;
                     }
@@ -1069,29 +1048,29 @@ public:
                             continue;
                         }
 
-                        const auto diff_btn = static_cast<ButtonType>(control - 5);
-                        auto& diff_dropdown = Get_Control<DropListClass>(diff_btn);
-                        auto& house_dropdown = Get_Control<DropListClass>(control);
+                        const auto diff_btn = static_cast<ControlType>(control - 5);
+                        auto& ai_diff_dropdown = Get_Control<DropListClass>(diff_btn);
+                        auto& ai_house_dropdown = Get_Control<DropListClass>(control);
 
                         // nothing changed, ignore input
-                        if (!house_dropdown.List.Index_Changed()) {
+                        if (!ai_house_dropdown.List.Index_Changed()) {
                             break;
                         }
 
-                        const auto house_was_disabled = house_dropdown.Current_Index() == 0;
-                        const auto house_was_activated = house_dropdown.List.Get_Previous_Index() == 0;
-                        const auto diff_is_disabled = diff_dropdown.Current_Index() == 0;
+                        const auto house_was_disabled = ai_house_dropdown.Current_Index() == 0;
+                        const auto house_was_activated = ai_house_dropdown.List.Get_Previous_Index() == 0;
+                        const auto diff_is_disabled = ai_diff_dropdown.Current_Index() == 0;
 
                         if (house_was_disabled) {
                             // reset diff to match disabled AI house
-                            diff_dropdown.Set_Selected_Index(0);
+                            ai_diff_dropdown.Set_Selected_Index(0);
                         } else if (house_was_activated && diff_is_disabled) {
                             // select a default diff of 'Normal' since none is selected
-                            diff_dropdown.Set_Selected_Index(2);
+                            ai_diff_dropdown.Set_Selected_Index(2);
                         }
 
-                        house_dropdown.Collapse();
-                        diff_dropdown.Collapse();
+                        ai_house_dropdown.Collapse();
+                        ai_diff_dropdown.Collapse();
                         display = REDRAW_BACKGROUND;
                     }
 
@@ -1104,10 +1083,11 @@ public:
                 case (BUTTON_COUNT | KN_BUTTON): {
                     MPlayerUnitCount = Get_Control<GaugeClass>(BUTTON_COUNT).Get_Value()
                         + MPlayerCountMin[MPlayerBases];
+
                     if (display < REDRAW_MESSAGE) {
                         display = REDRAW_MESSAGE;
                     }
-                    collapse_visible_dropdowns();
+                    Collapse_Visible_Dropdowns(display);
                     break;
                 }
 
@@ -1116,12 +1096,15 @@ public:
                 ------------------------------------------------------------------*/
                 case (BUTTON_LEVEL | KN_BUTTON): {
                     BuildLevel = Get_Control<GaugeClass>(BUTTON_LEVEL).Get_Value() + 1;
-                    if (BuildLevel > MPLAYER_BUILD_LEVEL_MAX) // if it's pegged, max it out
+                    if (BuildLevel > MPLAYER_BUILD_LEVEL_MAX) {
+                        // if it's pegged, max it out
                         BuildLevel = MPLAYER_BUILD_LEVEL_MAX;
+                    }
+
                     if (display < REDRAW_MESSAGE) {
                         display = REDRAW_MESSAGE;
                     }
-                    collapse_visible_dropdowns();
+                    Collapse_Visible_Dropdowns(display);
                     break;
                 }
 
@@ -1139,22 +1122,22 @@ public:
                     if (display < REDRAW_MESSAGE) {
                         display = REDRAW_MESSAGE;
                     }
-                    collapse_visible_dropdowns();
+                    Collapse_Visible_Dropdowns(display);
                     break;
                 }
 
-                case (BUTTON_TIBERIUMSCALE | KN_BUTTON): {
-                    MPlayerTiberium = Get_Control<GaugeClass>(BUTTON_TIBERIUMSCALE).Get_Value() + 1;
+                case (BUTTON_TIBERIUM_SCALE | KN_BUTTON): {
+                    MPlayerTiberium = Get_Control<GaugeClass>(BUTTON_TIBERIUM_SCALE).Get_Value() + 1;
 
                     Get_Control<CheckListClass>(BUTTON_OPTIONS).Check_Item(1, MPlayerTiberium > 0);
 
                     Special.IsTGrowth = MPlayerTiberium;
                     Special.IsTSpread = MPlayerTiberium;
 
-                    if (display < REDRAW_MESSAGE)
+                    if (display < REDRAW_MESSAGE) {
                         display = REDRAW_MESSAGE;
-
-                    collapse_visible_dropdowns();
+                    }
+                    Collapse_Visible_Dropdowns(display);
                     break;
                 }
 
@@ -1166,44 +1149,53 @@ public:
                 in SpecialClass.
                 ------------------------------------------------------------------*/
                 case (BUTTON_OPTIONS | KN_BUTTON): {
-                    auto& optionlist = Get_Control<CheckListClass>(BUTTON_OPTIONS);
-                    auto countgauge = Get_Control<GaugeClass>(BUTTON_COUNT);
-                    auto tiberiumscalegauge = Get_Control<GaugeClass>(BUTTON_TIBERIUMSCALE);
+                    auto& option_list = Get_Control<CheckListClass>(BUTTON_OPTIONS);
+                    auto count_gauge = Get_Control<GaugeClass>(BUTTON_COUNT);
+                    auto tiberium_scale_gauge = Get_Control<GaugeClass>(BUTTON_TIBERIUM_SCALE);
 
-                    if (MPlayerBases != optionlist.Is_Checked(0)) {
-                        MPlayerBases = optionlist.Is_Checked(0);
+                    if (MPlayerBases != option_list.Is_Checked(0)) {
+                        MPlayerBases = option_list.Is_Checked(0);
+
                         if (MPlayerBases) {
-                            MPlayerUnitCount = Fixed_To_Cardinal(MPlayerCountMax[1] - MPlayerCountMin[1],
-                                                                 Cardinal_To_Fixed(MPlayerCountMax[0] - MPlayerCountMin[0],
-                                                                                   MPlayerUnitCount - MPlayerCountMin[0]))
-                                               + MPlayerCountMin[1];
+                            MPlayerUnitCount = Fixed_To_Cardinal(
+                                MPlayerCountMax[1] - MPlayerCountMin[1],
+                                Cardinal_To_Fixed(
+                                    MPlayerCountMax[0] - MPlayerCountMin[0],
+                                    MPlayerUnitCount - MPlayerCountMin[0]
+                                )
+                            ) + MPlayerCountMin[1];
                         } else {
-                            MPlayerUnitCount = Fixed_To_Cardinal(MPlayerCountMax[0] - MPlayerCountMin[0],
-                                                                 Cardinal_To_Fixed(MPlayerCountMax[1] - MPlayerCountMin[1],
-                                                                                   MPlayerUnitCount - MPlayerCountMin[1]))
-                                               + MPlayerCountMin[0];
+                            MPlayerUnitCount = Fixed_To_Cardinal(
+                                MPlayerCountMax[0] - MPlayerCountMin[0],
+                                Cardinal_To_Fixed(
+                                    MPlayerCountMax[1] - MPlayerCountMin[1],
+                                    MPlayerUnitCount - MPlayerCountMin[1]
+                                )
+                            ) + MPlayerCountMin[0];
                         }
-                        countgauge.Set_Maximum(MPlayerCountMax[MPlayerBases] - MPlayerCountMin[MPlayerBases]);
-                        countgauge.Set_Value(MPlayerUnitCount - MPlayerCountMin[MPlayerBases]);
-                    }
-                    MPlayerTiberium = optionlist.Is_Checked(1) ? 1 : 0;
 
-                    if (tiberiumscalegauge.Get_Value() + 1 > 1) {
-                        MPlayerTiberium = tiberiumscalegauge.Get_Value() + 1;
+                        count_gauge.Set_Maximum(MPlayerCountMax[MPlayerBases] - MPlayerCountMin[MPlayerBases]);
+                        count_gauge.Set_Value(MPlayerUnitCount - MPlayerCountMin[MPlayerBases]);
                     }
 
-                    tiberiumscalegauge.Set_Value(MPlayerTiberium < 2 ? 0 : MPlayerTiberium - 1);
+                    MPlayerTiberium = option_list.Is_Checked(1) ? 1 : 0;
+
+                    if (tiberium_scale_gauge.Get_Value() + 1 > 1) {
+                        MPlayerTiberium = tiberium_scale_gauge.Get_Value() + 1;
+                    }
+
+                    tiberium_scale_gauge.Set_Value(MPlayerTiberium < 2 ? 0 : MPlayerTiberium - 1);
 
                     Special.IsTGrowth = MPlayerTiberium;
                     Special.IsTSpread = MPlayerTiberium;
 
-                    MPlayerGoodies = optionlist.Is_Checked(2);
-                    Special.IsCaptureTheFlag = optionlist.Is_Checked(3);
+                    MPlayerGoodies = option_list.Is_Checked(2);
+                    Special.IsCaptureTheFlag = option_list.Is_Checked(3);
 
-                    if (display < REDRAW_MESSAGE)
+                    if (display < REDRAW_MESSAGE) {
                         display = REDRAW_MESSAGE;
-
-                    collapse_visible_dropdowns();
+                    }
+                    Collapse_Visible_Dropdowns(display);
                     break;
                 }
 
@@ -1228,6 +1220,7 @@ public:
 
                     // warn that no AI players are enabled
                     WWMessageBox().Process(TXT_ONLY_ONE, TXT_OOPS);
+
                     display = REDRAW_ALL;
                     break;
                 }
@@ -1236,10 +1229,13 @@ public:
                 CANCEL: send a SIGN_OFF, bail out with error code
                 ------------------------------------------------------------------*/
                 case (KN_ESC): {
-                    if (Messages.Get_Edit_Buf() != NULL) {
+                    if (Messages.Get_Edit_Buf() != nullptr) {
                         Messages.Input(input);
-                        if (display < REDRAW_MESSAGE)
+
+                        if (display < REDRAW_MESSAGE) {
                             display = REDRAW_MESSAGE;
+                        }
+
                         break;
                     }
                 }
@@ -1274,39 +1270,42 @@ public:
         .....................................................................*/
         Scen.Scenario = MPlayerFilenum[ScenarioIdx];
 
-        int diff = Get_Control<SliderClass>(BUTTON_DIFFICULTY).Get_Value() * (Rule.IsFineDifficulty ? 1 : 2);
-        switch (diff) {
-        case 0:
-            Scen.CDifficulty = DIFF_HARD;
-            Scen.Difficulty = DIFF_EASY;
-            break;
+        switch (
+            Get_Control<SliderClass>(BUTTON_DIFFICULTY).Get_Value() * (Rule.IsFineDifficulty ? 1 : 2)
+        ) {
+            case 0:
+                Scen.CDifficulty = DIFF_HARD;
+                Scen.Difficulty = DIFF_EASY;
+                break;
 
-        case 1:
-            Scen.CDifficulty = DIFF_HARD;
-            Scen.Difficulty = DIFF_NORMAL;
-            break;
+            case 1:
+                Scen.CDifficulty = DIFF_HARD;
+                Scen.Difficulty = DIFF_NORMAL;
+                break;
 
-        case 2:
-            Scen.CDifficulty = DIFF_NORMAL;
-            Scen.Difficulty = DIFF_NORMAL;
-            break;
+            case 2:
+                Scen.CDifficulty = DIFF_NORMAL;
+                Scen.Difficulty = DIFF_NORMAL;
+                break;
 
-        case 3:
-            Scen.CDifficulty = DIFF_EASY;
-            Scen.Difficulty = DIFF_NORMAL;
-            break;
+            case 3:
+                Scen.CDifficulty = DIFF_EASY;
+                Scen.Difficulty = DIFF_NORMAL;
+                break;
 
-        case 4:
-            Scen.CDifficulty = DIFF_EASY;
-            Scen.Difficulty = DIFF_HARD;
-            break;
+            case 4:
+                Scen.CDifficulty = DIFF_EASY;
+                Scen.Difficulty = DIFF_HARD;
+                break;
+
+            default: break; // do nothing
         }
 
         // set AI player variables from difficulty/house dropdowns
         MPlayerGhosts = 0;
 
         for (auto control = BUTTON_AI_DIFF_1; control <= BUTTON_AI_DIFF_5; ++control) {
-            const auto house_btn = static_cast<ButtonType>(control + 5);
+            const auto house_btn = static_cast<ControlType>(control + 5);
             auto& diff_dropdown = Get_Control<DropListClass>(control);
             auto& house_dropdown = Get_Control<DropListClass>(house_btn);
 
@@ -1334,51 +1333,10 @@ public:
     }
 };
 
-/***********************************************************************************************
- * Com_Scenario_Dialog -- Serial game scenario selection dialog                                *
- *                                                                                             *
- *                                                                                             *
- *    ┌────────────────────────────────────────────────────────────┐                           *
- *    │                        Serial Game                         │                           *
- *    │                                                            │                           *
- *    │     Your Name: __________          House: [GDI] [NOD]      │                           *
- *    │       Credits: ______      Desired Color: [ ][ ][ ][ ]     │                           *
- *    │      Opponent: Name                                        │                           *
- *    │                                                            │                           *
- *    │                         Scenario                           │                           *
- *    │                  ┌──────────────────┬─┐                    │                           *
- *    │                  │ Hell's Kitchen   │ │                    │                           *
- *    │                  │ Heaven's Gate    ├─┤                    │                           *
- *    │                  │      ...         │ │                    │                           *
- *    │                  │                  ├─┤                    │                           *
- *    │                  │                  │ │                    │                           *
- *    │                  └──────────────────┴─┘                    │                           *
- *    │                 [  Bases   ] [ Crates     ]                │                           *
- *    │                 [ Tiberium ] [ AI Players ]                │                           *
- *    │                                                            │                           *
- *    │                      [OK]    [Cancel]                      │                           *
- *    │   ┌────────────────────────────────────────────────────┐   │                           *
- *    │   │                                                    │   │                           *
- *    │   │                                                    │   │                           *
- *    │   └────────────────────────────────────────────────────┘   │                           *
- *    │                       [Send Message]                       │                           *
- *    └────────────────────────────────────────────────────────────┘                           *
- *                                                                                             *
- * INPUT:                                                                                      *
- *      none.                                                                                  *
- *                                                                                             *
- * OUTPUT:                                                                                     *
- *      true = success, false = cancel                                                         *
- *                                                                                             *
- * WARNINGS:                                                                                   *
- *      MPlayerName & MPlayerGameName must contain this player's name.                         *
- *                                                                                             *
- * HISTORY:                                                                                    *
- *   02/14/1995 BR : Created.                                                                  *
- *=============================================================================================*/
-#define TXT_HOST_INTERNET_GAME 4567 + 1
-#define TXT_JOIN_INTERNET_GAME 4567 + 2
-int Com_Scenario_Dialog(void)
+/**
+ * Present a dialog to set up options for a Skirmish single player game.
+ */
+int Skirmish_Scenario_Dialog()
 {
     const auto factor = (SeenBuff.Get_Width() == 320) ? 1 : 2;
     const auto width = Try_Get_Resolution_Mode_Width().value_or(SeenBuff.Get_Width());
@@ -1414,4 +1372,4 @@ int Com_Scenario_Dialog(void)
     Write_MultiPlayer_Settings();
 
     return result;
-} /* end of Com_Scenario_Dialog */
+}

--- a/tiberiandawn/special.cpp
+++ b/tiberiandawn/special.cpp
@@ -419,6 +419,47 @@ int Fetch_Difficulty(void)
     return (slider.Get_Value() * (Rule.IsFineDifficulty ? 1 : 2));
 }
 
+void SpecialClass::Init()
+{
+    IsScrollMod = false;
+    IsGross = false;
+    IsEasy = false;
+    IsDifficult = false;
+    IsSpeedBuild = false;
+    IsDefenderAdvantage = true;
+    IsVisibleTarget = false;
+    IsVariation = false;
+    IsJurassic = false;
+    IsJuvenile = false;
+    IsSmartDefense = false;
+    IsTreeTarget = false;
+    IsMCVDeploy = false;
+    IsVisceroids = false;
+    IsMonoEnabled = false;
+    IsInert = false;
+    IsShowPath = false;
+    IsThreePoint = false;
+    IsTGrowth = true;
+    IsTSpread = true;
+    IsTFast = true;
+    IsRoad = false;
+    IsScatter = false;
+    IsCaptureTheFlag = false;
+    IsNamed = false;
+    IsFromInstall = false;
+    IsSeparate = false;
+    IsEarlyWin = false;
+    HealthBarDisplayMode = HB_SELECTED;
+    ResourceBarDisplayMode = RB_SELECTED;
+    ModernBalance = false;
+
+    if (RuleOverrides != nullptr) {
+        delete RuleOverrides;
+    }
+
+    RuleOverrides = new RuleSections();
+}
+
 TO_JSON(SpecialClass)
 {
     BITFIELD_TO_JSON(IsEasy);
@@ -452,10 +493,18 @@ TO_JSON(SpecialClass)
     FIELD_VALUE_TO_JSON(HealthBarDisplayMode, static_cast<int>(p.HealthBarDisplayMode));
     FIELD_VALUE_TO_JSON(ResourceBarDisplayMode, static_cast<int>(p.ResourceBarDisplayMode));
     BITFIELD_TO_JSON(ModernBalance);
+
+    if (p.RuleOverrides != nullptr) {
+        FIELD_VALUE_TO_JSON(RuleOverrides, *p.RuleOverrides);
+    } else {
+        j[NAMEOF(RuleOverrides)] = nlohmann::json::object();
+    }
 }
 
 FROM_JSON(SpecialClass)
 {
+    p.Init();
+
     BITFIELD_FROM_JSON(IsEasy);
     BITFIELD_FROM_JSON(IsDifficult);
     BITFIELD_FROM_JSON(IsSpeedBuild);
@@ -516,4 +565,11 @@ FROM_JSON(SpecialClass)
     );
 
     BITFIELD_FROM_JSON(ModernBalance);
+
+    if (p.RuleOverrides == nullptr) {
+        throw CncJsonException("Attempted to deserialize SpecialClass from json when RuleOverrides was nullptr");
+    }
+
+    p.RuleOverrides->Clear();
+    FIELD_FROM_JSON_TO_VALUE(NAMEOF(RuleOverrides), *p.RuleOverrides);
 }

--- a/tiberiandawn/special.h
+++ b/tiberiandawn/special.h
@@ -44,40 +44,7 @@
 class BITFIELD_STRUCT SpecialClass
 {
 public:
-    void Init(void)
-    {
-        IsScrollMod = false;
-        IsGross = false;
-        IsEasy = false;
-        IsDifficult = false;
-        IsSpeedBuild = false;
-        IsDefenderAdvantage = true;
-        IsVisibleTarget = false;
-        IsVariation = false;
-        IsJurassic = false;
-        IsJuvenile = false;
-        IsSmartDefense = false;
-        IsTreeTarget = false;
-        IsMCVDeploy = false;
-        IsVisceroids = false;
-        IsMonoEnabled = false;
-        IsInert = false;
-        IsShowPath = false;
-        IsThreePoint = false;
-        IsTGrowth = true;
-        IsTSpread = true;
-        IsTFast = true;
-        IsRoad = false;
-        IsScatter = false;
-        IsCaptureTheFlag = false;
-        IsNamed = false;
-        IsFromInstall = false;
-        IsSeparate = false;
-        IsEarlyWin = false;
-        HealthBarDisplayMode = HB_SELECTED;
-        ResourceBarDisplayMode = RB_SELECTED;
-        ModernBalance = false;
-    }
+    void Init();
 
     /*
     **	Is the game flagged for easy mode?
@@ -273,6 +240,11 @@ public:
     // Fixes issue from Change 738397 2020/07/17 14:06:03
     //
     //
+    RuleSections* RuleOverrides;
+
+    RuleSections& Overrides();
+
+    const RuleSections& Overrides() const;
 
     /**
      * Set values in this instance based on rule section values.

--- a/tiberiandawn/techno.cpp
+++ b/tiberiandawn/techno.cpp
@@ -1048,13 +1048,6 @@ void TechnoClass::Draw_It(int x, int y, WindowNumberType window)
 {
     Clear_Redraw_Flag();
 
-    /*
-    **	Guard against object in shroud.
-    */
-    if (!Debug_Map && !Map[Coord_Cell(Map.Pixel_To_Coord(x, y))].Is_Visible(PlayerPtr)) {
-        return;
-    }
-
 #ifdef REMASTER_BUILD
     WindowNumberType line_frame_cmp = WINDOW_VIRTUAL;
 #else

--- a/tiberiandawn/typeconverter.cpp
+++ b/tiberiandawn/typeconverter.cpp
@@ -31,6 +31,7 @@ static const TwoWayMap<CCPaletteType, std::string> CCPalettePatchTable = {{ CC_G
  */
 static const std::vector ScenarioVarExcludes = {SCEN_VAR_COUNT};
 static const std::vector VocExcludes = {VOC_FIRST, VOC_COUNT};
+static const std::vector DiffExcludes = {DIFF_FIRST, DIFF_LAST};
 static const std::vector TemplateExcludes = {TEMPLATE_COUNT};
 
 #define ENUM_TYPE_PAIR(TYPE, ...) { Get_Type_Name<TYPE>(), EnumTypeInfo<TYPE>(__VA_ARGS__) }
@@ -57,7 +58,7 @@ const std::unordered_map<std::string_view, EnumTypeInfoVariant> TdTypeConverter:
     ENUM_TYPE_PAIR(VocType,                      "VOC_",         VOC_NONE,                               VOC_BEACON,                               {},                  VocExcludes,         false),
     ENUM_TYPE_PAIR(PlayerColorType,              "REMAP_",       REMAP_NONE,                             REMAP_LAST,                               {},                  {},                  false),
     ENUM_TYPE_PAIR(HouseColorType,               "HOUSE_COLOR_", HOUSE_COLOR_BAD,                        HOUSE_COLOR_NEUTRAL,                      {},                  {},                  false),
-    ENUM_TYPE_PAIR(DiffType,                     "DIFF_",        DIFF_FIRST,                             DIFF_LAST,                                {},                  {},                  false),
+    ENUM_TYPE_PAIR(DiffType,                     "DIFF_",        DIFF_NONE,                              DIFF_LAST,                                {},                  {},                  false),
     ENUM_TYPE_PAIR(ScenarioDirType,              "SCEN_DIR_",    SCEN_DIR_NONE,                          SCEN_DIR_LAST,                            {},                  {},                  false),
     ENUM_TYPE_PAIR(ScenarioVarType,              "SCEN_VAR_",    SCEN_VAR_NONE,                          SCEN_VAR_LOSE,                            {},                  ScenarioVarExcludes, false),
     ENUM_TYPE_PAIR(SourceType,                   "SOURCE_",      SOURCE_NONE,                            SOURCE_OCEAN,                             {},                  {},                  false),

--- a/tiberiandawn/typeconverter.h
+++ b/tiberiandawn/typeconverter.h
@@ -88,7 +88,7 @@ public:
     requires SupportedByTdTypeConverter<T>
     static const TwoWayMap<T, std::string>& Get_Type_Map()
     {
-        static std::shared_ptr<TwoWayMap<T, std::string>> type_map;
+        static std::unique_ptr<TwoWayMap<T, std::string>> type_map;
         static std::once_flag once_flag;
 
         // create type map once, the first time T is requested

--- a/tiberiandawn/typeconverter.h
+++ b/tiberiandawn/typeconverter.h
@@ -560,3 +560,19 @@ private:
 
     TdTypeConverter() = delete;
 };
+
+// std::format support for TD enum types
+template <SupportedByTdTypeConverter T>
+struct std::formatter<T> : std::formatter<std::string> {
+    auto format(T value, format_context& ctx) const {
+        return formatter<string>::format(TdTypeConverter::To_String(value), ctx);
+    }
+};
+
+// spdlog fmt library support for TD enum types
+template <SupportedByTdTypeConverter T>
+struct fmt::formatter<T> : fmt::formatter<std::string> {
+    auto format(const T& value, format_context& ctx) const {
+        return formatter<std::string>::format(TdTypeConverter::To_String(value), ctx);
+    }
+};

--- a/tiberiandawn/typeconverter.h
+++ b/tiberiandawn/typeconverter.h
@@ -1,9 +1,12 @@
 #pragma once
 
+#include <format>
 #include <optional>
 #include <stdexcept>
 #include <string>
 #include <type_traits>
+
+#include <fmt/format.h>
 
 #include "common/enum.h"
 #include "common/json.h"
@@ -569,10 +572,10 @@ struct std::formatter<T> : std::formatter<std::string> {
     }
 };
 
-// spdlog fmt library support for TD enum types
+// spdlog fmt library support for TD enum types (used by spdlog
 template <SupportedByTdTypeConverter T>
 struct fmt::formatter<T> : fmt::formatter<std::string> {
-    auto format(const T& value, format_context& ctx) const {
+    auto format(const T& value, fmt::format_context& ctx) const {
         return formatter<std::string>::format(TdTypeConverter::To_String(value), ctx);
     }
 };

--- a/tiberiandawn/unit.cpp
+++ b/tiberiandawn/unit.cpp
@@ -2045,13 +2045,6 @@ void UnitClass::Draw_It(int x, int y, WindowNumberType window)
         return;
 
     /*
-    **	Guard against object in shroud.
-    */
-    if (!Debug_Map && !Map[Coord_Cell(Map.Pixel_To_Coord(x, y))].Is_Visible(PlayerPtr)) {
-        return;
-    }
-
-    /*
     **	If drawing of this unit is not explicitly prohibited, then proceed
     **	with the render process.
     */


### PR DESCRIPTION
Allow changing the difficulty and house for each AI player in the Tiberian Dawn Skirmish setup screen. Also adds the ability to set a 'Tiberium Growth' scale for Skirmish games so it grows and spreads more quickly.

- New layout in Skirmish screen
- DOS layout tested

## Features

- **td**: Add AI House and Difficulty selection to Skirmish menu
- **td**: Rule overrides in SpecialClass for general behavior modification before scenario load
- **td**: Custom format specifier for converter enum types to allow std::format and spdlog to natively format values
- **td**: Moved Skirmish dialog to unique file instead of replacing old null modem file

## Fixes

- **td**: Revert shroud drawing logic fix for all but *flying* aircraft (causing glitches and unit not rendering on edge map)
