### PR TITLE
feat(td): Type Converter Tweaks

### DIFF
--- a/tiberiandawn/ruleseditordlg.cpp
+++ b/tiberiandawn/ruleseditordlg.cpp
@@ -696,8 +696,9 @@ class RulesEditorDialog : public Dialog<RulesEditorControls>
                 } else {
                     Get_Control<EditClass>(value_control).Enable();
                     Get_Control<TextButtonClass>(edit_button).Disable(true);
-                    Get_Control<TextButtonClass>(help_button).Enable();
                 }
+
+                Get_Control<TextButtonClass>(help_button).Enable();
             },
             [&] (const auto& controls) {
                 // clear and disable unneeded controls

--- a/tiberiandawn/typeconverter.cpp
+++ b/tiberiandawn/typeconverter.cpp
@@ -5,10 +5,10 @@
 /**
  * Make some type names more human-readable or less confusing.
  */
-const std::unordered_map<std::string, std::string_view> TdTypeConverter::TypeNamePatchTable = {
-    { NAMEOF(AnimType), "Animation" },
-    { NAMEOF(HousesType), "House" },
-    { NAMEOF(StructType), "Building" }
+const std::unordered_map<size_t, std::string_view> TdTypeConverter::TypeNamePatchTable = {
+    { TYPE_ID(AnimType), "Animation" },
+    { TYPE_ID(HousesType), "House" },
+    { TYPE_ID(StructType), "Building" }
 };
 
 /**
@@ -34,11 +34,11 @@ static const std::vector ScenarioVarExcludes = {SCEN_VAR_COUNT};
 static const std::vector TemplateExcludes = {TEMPLATE_COUNT};
 static const std::vector VocExcludes = {VOC_FIRST, VOC_COUNT};
 
-#define ENUM_TYPE_PAIR(TYPE, ...) { Get_Type_Name<TYPE>(), EnumTypeInfo<TYPE>(__VA_ARGS__) }
+#define ENUM_TYPE_PAIR(TYPE, ...) { typeid(TYPE).hash_code(), EnumTypeInfo<TYPE>(__VA_ARGS__) }
 
 // Info about each enum supported type, indexed against it's typename
-const std::unordered_map<std::string_view, EnumTypeInfoVariant> TdTypeConverter::EnumTypes = {
-    //            [Typename]                    [Prefix]        [Min Valid Val]                         [Max Valid Val]                           [INI Patch Table]    [Excluded Vals]      [Allow non-enum values?]
+const std::unordered_map<size_t, EnumTypeInfoVariant> TdTypeConverter::EnumTypes = {
+    //             [Typename]                    [Prefix]        [Min Valid Val]                         [Max Valid Val]                           [INI Patch Table]    [Excluded Vals]      [Allow non-enum values?]
     ENUM_TYPE_PAIR(AircraftType,                 "AIRCRAFT_",    AIRCRAFT_NONE,                          AIRCRAFT_LAST,                            AircraftPatchTable,  {},                  false),
     ENUM_TYPE_PAIR(AnimType,                     "ANIM_",        ANIM_NONE,                              ANIM_LAST,                                AnimPatchTable,      {},                  false),
     ENUM_TYPE_PAIR(ArmorType,                    "ARMOR_",       ARMOR_NONE,                             ARMOR_LAST,                               {},                  {},                  false),

--- a/tiberiandawn/typeconverter.h
+++ b/tiberiandawn/typeconverter.h
@@ -22,6 +22,8 @@
 #include "typeconvertermacros.h"
 #include "typevariants.h"
 
+#define TYPE_ID(TYPE) typeid(TYPE).hash_code()
+
 /**
  * Implementation of TypeConverter concept found in common/rulesections.h for Tiberian Dawn.
  *
@@ -42,30 +44,28 @@
  *
  * To add a new type to the converter:
  *
- *   - Add type to SupportedByTdTypeConverter, ConverterTypeVariant and EnumTypeInfoVariant (see typevariants.h)
+ *   - Add type to TD_ENUMS_FORMAT macro (see typevariants.h)
  *   - Add entry to TdTypeConverter::EnumTypes with relevant values (see enumtypeinfo.h)
- *   - Update Variant method bodies in typeconverter.cpp to handle new types
+ *
  */
 class TdTypeConverter final
 {
 public:
     static constexpr std::string_view EnumPostfix = "Type";
-    static const std::unordered_map<std::string, std::string_view> TypeNamePatchTable;
-    static const std::unordered_map<std::string_view, EnumTypeInfoVariant> EnumTypes;
+    static const std::unordered_map<size_t, std::string_view> TypeNamePatchTable;
+    static const std::unordered_map<size_t, EnumTypeInfoVariant> EnumTypes;
 
     template<class T>
     requires SupportedByTdTypeConverter<T>
     static const EnumTypeInfo<T>& Get_Info_For_Type()
     {
-        const auto type_name = Get_Type_Name<T>();
-
-        if (!EnumTypes.contains(type_name)) {
+        if (!EnumTypes.contains(TYPE_ID(T))) {
             throw std::invalid_argument("Attempted to get info for an unsupported EnumTypeInfoVariant type, "
                                         "this is normally caused by variant being updated without updating "
                                         "supporting code");
         }
 
-        const auto& type_info_variant = EnumTypes.at(type_name);
+        const auto& type_info_variant = EnumTypes.at(TYPE_ID(T));
         const auto type_info_ptr = std::get_if<EnumTypeInfo<T>>(&type_info_variant);
 
         if (type_info_ptr == nullptr) {
@@ -396,8 +396,8 @@ public:
             // get enum type name and remove EnumPostfix
             const auto raw_type_name = std::string(magic_enum::enum_type_name<T>());
 
-            if (TypeNamePatchTable.contains(raw_type_name)) {
-                type_name = TypeNamePatchTable.at(raw_type_name);
+            if (TypeNamePatchTable.contains(TYPE_ID(T))) {
+                type_name = TypeNamePatchTable.at(TYPE_ID(T));
                 return;
             }
 
@@ -578,7 +578,7 @@ private:
 template <SupportedByTdTypeConverter T>
 struct std::formatter<T> : std::formatter<std::string> {
     auto format(T value, format_context& ctx) const {
-        return formatter<string>::format(TdTypeConverter::To_String(value), ctx);
+        return formatter<string>::format(TdTypeConverter::To_String_Variant(value), ctx);
     }
 };
 
@@ -586,7 +586,7 @@ struct std::formatter<T> : std::formatter<std::string> {
 template <SupportedByTdTypeConverter T>
 struct fmt::formatter<T> : fmt::formatter<std::string> {
     auto format(const T& value, fmt::format_context& ctx) const {
-        return formatter<std::string>::format(TdTypeConverter::To_String(value), ctx);
+        return formatter<std::string>::format(TdTypeConverter::To_String_Variant(value), ctx);
     }
 };
 

--- a/tiberiandawn/typevariants.h
+++ b/tiberiandawn/typevariants.h
@@ -5,116 +5,77 @@
 #include "teamtype.h"
 #include "trigger.h"
 
+// convenience macro for using commas as a parameter to other macros
+#define MACRO_COMMA ,
+
+// convenience macro to allow re-using the tiberian dawn enum type list to create variants and concepts
+#define TD_ENUMS_FORMAT(PREFIX, POSTFIX, POSTFIX_LAST) \
+    PREFIX AircraftType POSTFIX \
+    PREFIX AnimType POSTFIX \
+    PREFIX ArmorType POSTFIX \
+    PREFIX BulletType POSTFIX \
+    PREFIX BSizeType POSTFIX \
+    PREFIX BStateType POSTFIX \
+    PREFIX CCPaletteType POSTFIX \
+    PREFIX CloakType POSTFIX \
+    PREFIX DiffType POSTFIX \
+    PREFIX DirType POSTFIX \
+    PREFIX DoorClass::DoorStateType POSTFIX \
+    PREFIX DoType POSTFIX \
+    PREFIX EventType POSTFIX \
+    PREFIX FacingType POSTFIX \
+    PREFIX FactoryType POSTFIX \
+    PREFIX GameType POSTFIX \
+    PREFIX HouseColorType POSTFIX \
+    PREFIX HousesType POSTFIX \
+    PREFIX InfantryType POSTFIX \
+    PREFIX KeyNumType POSTFIX \
+    PREFIX KindType POSTFIX \
+    PREFIX LandType POSTFIX \
+    PREFIX LayerType POSTFIX \
+    PREFIX MissionType POSTFIX \
+    PREFIX MouseType POSTFIX \
+    PREFIX MPHType POSTFIX \
+    PREFIX OverlayType POSTFIX \
+    PREFIX PlayerColorType POSTFIX \
+    PREFIX RadarEnum POSTFIX \
+    PREFIX RadioMessageType POSTFIX \
+    PREFIX RTTIType POSTFIX \
+    PREFIX ScenarioDirType POSTFIX \
+    PREFIX ScenarioPlayerType POSTFIX \
+    PREFIX ScenarioVarType POSTFIX \
+    PREFIX SpecialWeaponType POSTFIX \
+    PREFIX SmudgeType POSTFIX \
+    PREFIX SourceType POSTFIX \
+    PREFIX SpeedType POSTFIX \
+    PREFIX StateType POSTFIX \
+    PREFIX StructType POSTFIX \
+    PREFIX TeamMissionType POSTFIX \
+    PREFIX TemplateType POSTFIX \
+    PREFIX TerrainType POSTFIX \
+    PREFIX TheaterType POSTFIX \
+    PREFIX TriggerClass::ActionType POSTFIX \
+    PREFIX TriggerClass::PersistantType POSTFIX \
+    PREFIX UnitType POSTFIX \
+    PREFIX UrgencyType POSTFIX \
+    PREFIX VocType POSTFIX \
+    PREFIX VoxType POSTFIX \
+    PREFIX WarheadType POSTFIX \
+    PREFIX WeaponType POSTFIX \
+    PREFIX ZoneType POSTFIX_LAST
+
+// type constraint for converter methods
 template<typename T>
 concept SupportedByTdTypeConverter = (
-    std::is_same_v<T, AircraftType> ||
-    std::is_same_v<T, AnimType> ||
-    std::is_same_v<T, ArmorType> ||
-    std::is_same_v<T, BulletType> ||
-    std::is_same_v<T, BSizeType> ||
-    std::is_same_v<T, BStateType> ||
-    std::is_same_v<T, CCPaletteType> ||
-    std::is_same_v<T, CloakType> ||
-    std::is_same_v<T, DiffType> ||
-    std::is_same_v<T, DirType> ||
-    std::is_same_v<T, DoorClass::DoorStateType> ||
-    std::is_same_v<T, DoType> ||
-    std::is_same_v<T, EventType> ||
-    std::is_same_v<T, FacingType> ||
-    std::is_same_v<T, FactoryType> ||
-    std::is_same_v<T, GameType> ||
-    std::is_same_v<T, HouseColorType> ||
-    std::is_same_v<T, HousesType> ||
-    std::is_same_v<T, InfantryType> ||
-    std::is_same_v<T, KeyNumType> ||
-    std::is_same_v<T, KindType> ||
-    std::is_same_v<T, LandType> ||
-    std::is_same_v<T, LayerType> ||
-    std::is_same_v<T, MissionType> ||
-    std::is_same_v<T, MouseType> ||
-    std::is_same_v<T, MPHType> ||
-    std::is_same_v<T, OverlayType> ||
-    std::is_same_v<T, PlayerColorType> ||
-    std::is_same_v<T, RadarEnum> ||
-    std::is_same_v<T, RadioMessageType> ||
-    std::is_same_v<T, RTTIType> ||
-    std::is_same_v<T, ScenarioDirType> ||
-    std::is_same_v<T, ScenarioPlayerType> ||
-    std::is_same_v<T, ScenarioVarType> ||
-    std::is_same_v<T, SpecialWeaponType> ||
-    std::is_same_v<T, SmudgeType> ||
-    std::is_same_v<T, SourceType> ||
-    std::is_same_v<T, SpeedType> ||
-    std::is_same_v<T, StateType>||
-    std::is_same_v<T, StructType> ||
-    std::is_same_v<T, TeamMissionType> ||
-    std::is_same_v<T, TemplateType> ||
-    std::is_same_v<T, TerrainType> ||
-    std::is_same_v<T, TheaterType> ||
-    std::is_same_v<T, TriggerClass::ActionType> ||
-    std::is_same_v<T, TriggerClass::PersistantType> ||
-    std::is_same_v<T, UnitType> ||
-    std::is_same_v<T, UrgencyType> ||
-    std::is_same_v<T, VocType> ||
-    std::is_same_v<T, VoxType> ||
-    std::is_same_v<T, WarheadType> ||
-    std::is_same_v<T, WeaponType> ||
-    std::is_same_v<T, ZoneType>
+    TD_ENUMS_FORMAT(std::is_same_v<T MACRO_COMMA, > ||, >)
 );
 
-// Matches the SupportedByTdTypeConverter Concept types
+// variant alternative to SupportedByTdTypeConverter
 using ConverterTypeVariant = std::variant<
-    AircraftType,
-    AnimType,
-    ArmorType,
-    BulletType,
-    BSizeType,
-    BStateType,
-    CCPaletteType,
-    CloakType,
-    DiffType,
-    DirType,
-    DoorClass::DoorStateType,
-    DoType,
-    EventType,
-    FacingType,
-    FactoryType,
-    GameType,
-    HouseColorType,
-    HousesType,
-    InfantryType,
-    KeyNumType,
-    KindType,
-    LandType,
-    LayerType,
-    MissionType,
-    MouseType,
-    MPHType,
-    OverlayType,
-    PlayerColorType,
-    RadarEnum,
-    RadioMessageType,
-    RTTIType,
-    ScenarioDirType,
-    ScenarioPlayerType,
-    ScenarioVarType,
-    SpecialWeaponType,
-    SmudgeType,
-    SourceType,
-    SpeedType,
-    StateType,
-    StructType,
-    TeamMissionType,
-    TemplateType,
-    TerrainType,
-    TheaterType,
-    TriggerClass::ActionType,
-    TriggerClass::PersistantType,
-    UnitType,
-    UrgencyType,
-    VocType,
-    VoxType,
-    WarheadType,
-    WeaponType,
-    ZoneType
+    TD_ENUMS_FORMAT(, MACRO_COMMA, )
+>;
+
+// used to enable storing string conversion maps for each enum type in a stl container
+using EnumTwoWayMapVariant = std::variant<
+    TD_ENUMS_FORMAT(TwoWayMap<, MACRO_COMMA std::string>MACRO_COMMA, MACRO_COMMA std::string>)
 >;


### PR DESCRIPTION
## Features

- **td**: Make all converter variant based templates feed off macro that holds all enum type names

## Fixes

- **td**: Rules Editor hides help buttons on navigate back for converter rules