### PR TITLE
feat(td): Display Updates, Dialog/Placement Fixes and Upstream Sync

### DIFF
--- a/common/settings.cpp
+++ b/common/settings.cpp
@@ -25,6 +25,7 @@ SettingsClass::SettingsClass()
     Video.Height = 600;
     Video.StretchWidth = 0;
     Video.StretchHeight = 0;
+    Video.HiResStretch = true;
     Video.Windowed = false;
     Video.Display = 1;
     Video.Boxing = true;
@@ -71,6 +72,7 @@ void SettingsClass::Load(std::string ini_file_name, INIClass& ini)
          .Load("VideoHeight").With_Binding(Video.Height)
          .Load("StretchWidth").With_Binding(Video.StretchWidth)
          .Load("StretchHeight").With_Binding(Video.StretchHeight)
+         .Load("HiResStretch").With_Binding(Video.HiResStretch).With_Comment("Stretch menus and videos to fill the screen when using high resolutions")
          .Load("Windowed").With_Binding(Video.Windowed)
          .Load("Boxing").With_Binding(Video.Boxing)
          .Load("BoxingAspectRatio").With_Comment("4:3, 16:9 etc.").With_Binding(Video.BoxingAspectRatio)
@@ -161,6 +163,7 @@ void SettingsClass::Update_Sections()
         .Set("VideoHeight", Video.Height)
         .Set("StretchWidth", Video.StretchWidth)
         .Set("StretchHeight", Video.StretchHeight)
+        .Set("HiResStretch", Video.HiResStretch)
         .Set("Windowed", Video.Windowed)
         .Set("Boxing", Video.Boxing)
         .Set("BoxingAspectRatio", Video.BoxingAspectRatio)

--- a/common/settings.cpp
+++ b/common/settings.cpp
@@ -21,7 +21,7 @@ SettingsClass::SettingsClass()
     ** Video settings
     */
     // TODO: Could offer presets through the launcher or a ini setting (retro, modern etc.)
-    Video.Width = 800;
+    Video.Width = 960; // == 1.5x Win95 resolution
     Video.Height = 600;
     Video.StretchWidth = 0;
     Video.StretchHeight = 0;

--- a/common/settings.h
+++ b/common/settings.h
@@ -37,6 +37,7 @@ public:
         int Height;
         int StretchWidth;
         int StretchHeight;
+        bool HiResStretch;
         bool Windowed;
         bool Boxing;
         std::string BoxingAspectRatio;

--- a/common/video.h
+++ b/common/video.h
@@ -113,12 +113,13 @@ enum ResolutionMode
     MODE_DOS,
     // custom resolution
     MODE_HIGH_RES,
-    // zoom into default resolution
-    MODE_ZOOM
+    // video is temporarily displaying content design for original game resolution
+    MODE_ORIGINAL_RES
 };
 
 ResolutionMode Get_Current_Resolution_Mode();
 
+void Set_Current_Resolution_Mode(ResolutionMode resolution_mode, bool enable_original_res_stretch);
 void Set_Current_Resolution_Mode(ResolutionMode resolution_mode);
 
 /**
@@ -148,23 +149,23 @@ std::optional<int> Try_Get_Resolution_Mode_Height();
 /**
  * Enter the standard resolution mode for the game engine, if current resolution mode supports it.
  *
- * Generally this should be called after clearing the screen to prevent zoom in artifacts.
+ * Generally this should be called after clearing the screen to prevent stretch artifacts.
  *
  * This mode is currently used for menus, videos, CPS animations and score screens.
  *
  * Supported video backends: sdl2
 */
-void Enter_Zoomed_Resolution_Mode();
+void Enter_Original_Resolution_Mode();
 
 /**
  * Enter the dynamic high resolution mode for the game engine, if current resolution mode supports it.
  *
- * Call this to reset calls to Enter_Standard_Resolution_Mode().
+ * Call this to reset calls to Enter_Original_Resolution_Mode().
  *
  * This mode is currently only used when playing a scenario.
  *
  * Supported video backends: sdl2
  */
-void Leave_Zoomed_Resolution_Mode();
+void Leave_Original_Resolution_Mode();
 
 #endif // VIDEO_H

--- a/common/video_ddraw.cpp
+++ b/common/video_ddraw.cpp
@@ -1369,6 +1369,21 @@ void Set_Current_Resolution_Mode(const ResolutionMode)
     // TODO: Resolution mode support not implemented
 }
 
+void Set_Current_Resolution_Mode(const ResolutionMode, const bool)
+{
+    // TODO: Resolution mode support not implemented
+}
+
+void Enter_Original_Resolution_Mode()
+{
+    // TODO: Resolution mode support not implemented
+}
+
+void Leave_Original_Resolution_Mode()
+{
+    // TODO: Resolution mode support not implemented
+}
+
 std::optional<int> Try_Get_Resolution_Mode_Width()
 {
     // TODO: Resolution mode support not implemented
@@ -1381,12 +1396,4 @@ std::optional<int> Try_Get_Resolution_Mode_Height()
     return std::nullopt;
 }
 
-void Enter_Zoomed_Resolution_Mode()
-{
-    // TODO: Resolution mode support not implemented
-}
 
-void Leave_Zoomed_Resolution_Mode()
-{
-    // TODO: Resolution mode support not implemented
-}

--- a/common/video_null.cpp
+++ b/common/video_null.cpp
@@ -308,6 +308,21 @@ void Set_Current_Resolution_Mode(const ResolutionMode)
     // TODO: Resolution mode support not implemented
 }
 
+void Set_Current_Resolution_Mode(const ResolutionMode, const bool)
+{
+    // TODO: Resolution mode support not implemented
+}
+
+void Enter_Original_Resolution_Mode()
+{
+    // TODO: Resolution mode support not implemented
+}
+
+void Leave_Original_Resolution_Mode()
+{
+    // TODO: Resolution mode support not implemented
+}
+
 std::optional<int> Try_Get_Resolution_Mode_Width()
 {
     // TODO: Resolution mode support not implemented
@@ -320,12 +335,4 @@ std::optional<int> Try_Get_Resolution_Mode_Height()
     return std::nullopt;
 }
 
-void Enter_Zoomed_Resolution_Mode()
-{
-    // TODO: Resolution mode support not implemented
-}
 
-void Leave_Zoomed_Resolution_Mode()
-{
-    // TODO: Resolution mode support not implemented
-}

--- a/common/video_sdl1.cpp
+++ b/common/video_sdl1.cpp
@@ -550,6 +550,21 @@ void Set_Current_Resolution_Mode(const ResolutionMode)
     // TODO: Resolution mode support not implemented
 }
 
+void Set_Current_Resolution_Mode(const ResolutionMode, const bool)
+{
+    // TODO: Resolution mode support not implemented
+}
+
+void Enter_Original_Resolution_Mode()
+{
+    // TODO: Resolution mode support not implemented
+}
+
+void Leave_Original_Resolution_Mode()
+{
+    // TODO: Resolution mode support not implemented
+}
+
 std::optional<int> Try_Get_Resolution_Mode_Width()
 {
     // TODO: Resolution mode support not implemented
@@ -562,12 +577,4 @@ std::optional<int> Try_Get_Resolution_Mode_Height()
     return std::nullopt;
 }
 
-void Enter_Zoomed_Resolution_Mode()
-{
-    // TODO: Resolution mode support not implemented
-}
 
-void Leave_Zoomed_Resolution_Mode()
-{
-    // TODO: Resolution mode support not implemented
-}

--- a/common/video_sdl2.cpp
+++ b/common/video_sdl2.cpp
@@ -62,6 +62,7 @@ static SDL_Palette* palette;
 static Uint32 pixel_format;
 static SDL_Rect render_dst;
 static ResolutionMode CurrentResolutionMode = MODE_DEFAULT;
+static bool StretchOriginalResolution = true;
 
 static struct
 {
@@ -522,8 +523,11 @@ void Move_Video_Mouse(const float xrel, const float yrel)
         next_y = 0;
     }
 
-    if (Get_Current_Resolution_Mode() == MODE_ZOOM && (next_x > 639 || next_y > 399)) {
-        // prevent mouse leaving screen in zoom mode
+    if (
+        Get_Current_Resolution_Mode() == MODE_ORIGINAL_RES
+        && (next_x > (DefaultWidth - 1) || next_y > (DefaultHeight - 1))
+    ) {
+        // prevent mouse leaving the bounds of original resolution content
         return;
     }
 
@@ -933,10 +937,23 @@ public:
         SDL_UpdateTexture(texture, NULL, windowSurface->pixels, windowSurface->pitch);
         SDL_RenderClear(renderer);
 
-        if (CurrentResolutionMode == MODE_ZOOM) {
+        if (CurrentResolutionMode == MODE_ORIGINAL_RES) {
             constexpr SDL_Rect src_rect = {0, 0, DefaultWidth, DefaultHeight};
 
-            SDL_RenderCopy(renderer, texture, &src_rect, &render_dst);
+            if (StretchOriginalResolution) {
+                // 'stretch' the content to fill the screen
+                SDL_RenderCopy(renderer, texture, &src_rect, &render_dst);
+            } else {
+                const SDL_Rect center_dst = {
+                    .x = (render_dst.w / 2) - (DefaultWidth / 2),
+                    .y = (render_dst.h / 2) - (DefaultHeight / 2),
+                    .w = DefaultWidth,
+                    .h = DefaultHeight
+                };
+
+                // render the content in the center of the screen
+                SDL_RenderCopy(renderer, texture, &src_rect, &center_dst);
+            }
         } else {
             SDL_RenderCopy(renderer, texture, nullptr, &render_dst);
         }
@@ -998,6 +1015,12 @@ ResolutionMode Get_Current_Resolution_Mode()
     return CurrentResolutionMode;
 }
 
+void Set_Current_Resolution_Mode(const ResolutionMode resolution_mode, const bool enable_original_res_stretch)
+{
+    CurrentResolutionMode = resolution_mode;
+    StretchOriginalResolution = enable_original_res_stretch;
+}
+
 void Set_Current_Resolution_Mode(const ResolutionMode resolution_mode)
 {
     CurrentResolutionMode = resolution_mode;
@@ -1009,7 +1032,7 @@ std::optional<int> Try_Get_Resolution_Mode_Width()
         return std::nullopt;
     }
 
-    if (Get_Current_Resolution_Mode() == MODE_ZOOM) {
+    if (Get_Current_Resolution_Mode() == MODE_ORIGINAL_RES) {
         return DefaultWidth;
     }
 
@@ -1022,34 +1045,38 @@ std::optional<int> Try_Get_Resolution_Mode_Height()
         return std::nullopt;
     }
 
-    if (Get_Current_Resolution_Mode() == MODE_ZOOM) {
+    if (Get_Current_Resolution_Mode() == MODE_ORIGINAL_RES) {
         return DefaultHeight;
     }
 
     return frontSurface->GetHeight();
 }
 
-void Enter_Zoomed_Resolution_Mode()
+void Enter_Original_Resolution_Mode()
 {
     const auto resolution_mode = Get_Current_Resolution_Mode();
 
     if (resolution_mode == MODE_DOS || resolution_mode == MODE_DEFAULT) {
-        // these modes never zoom in
+        // these modes never change
         return;
     }
 
-    Set_Current_Resolution_Mode(MODE_ZOOM);
+    Set_Current_Resolution_Mode(MODE_ORIGINAL_RES);
 
-    // center mouse in zoomed view
-    Move_Video_Mouse_Absolute(DefaultWidth / 2, DefaultHeight / 2);
+    // center mouse when rendering content designed for original resolution
+    if (StretchOriginalResolution) {
+        Move_Video_Mouse_Absolute(DefaultWidth / 2, DefaultHeight / 2);
+    } else if (frontSurface != nullptr) {
+        Move_Video_Mouse_Absolute(frontSurface->GetWidth() / 2, frontSurface->GetHeight() / 2);
+    }
 }
 
-void Leave_Zoomed_Resolution_Mode()
+void Leave_Original_Resolution_Mode()
 {
     const auto resolution_mode = Get_Current_Resolution_Mode();
 
     if (resolution_mode == MODE_DOS || resolution_mode == MODE_DEFAULT) {
-        // these modes never zoom out
+        // these modes never change
         return;
     }
 

--- a/docs/hi-resolution/README.md
+++ b/docs/hi-resolution/README.md
@@ -28,9 +28,9 @@ The below diagram shows how the video backend is used from Tiberian Dawn/Red Ale
 
 Internally the SDL2 backend uses an enum to set the 'mode' which drives how then window is initialized and resolution configured:
 
-- The game engine can set the mode to `MODE_HIGH_RES`, this enables hi-res and 'zooming' in and out of 640x400
-- `MODE_ZOOM` mode is used to signal that SDL2 should crop the game to this resolution when rendering frames
-- The `Enter_Zoomed_Resolution_Mode` and `Leave_Zoomed_Resolution_Mode` functions trigger the change in mode
+- The game engine can set the mode to `MODE_HIGH_RES`, this enables hi-res
+- `MODE_ORIGINAL_RES` mode is used to signal that SDL2 should crop the game to 640x400 when rendering frames
+- The `Enter_Original_Resolution_Mode` and `Leave_Original_Resolution_Mode` functions trigger the change in mode
 - For code that needs to determine the current displayed ares (Zoomed or full) the `Try_Get_Resolution_Mode_Width` and `Try_Get_Resolution_Mode_Height` return either the zoomed resolution or full resolution dependent on the current mode
 
 See: `ResolutionMode` in [video.h](../../common/video.h)

--- a/redalert/conquer.cpp
+++ b/redalert/conquer.cpp
@@ -2436,7 +2436,7 @@ void Play_Movie(char const* name, ThemeType theme, bool clrscrn, bool immediate)
 
         VQAHandle* vqa = NULL;
 
-        Enter_Zoomed_Resolution_Mode();
+        Enter_Original_Resolution_Mode();
 
 #ifdef MOVIE640
         if (IsVQ640) {

--- a/redalert/init.cpp
+++ b/redalert/init.cpp
@@ -1862,7 +1862,7 @@ void Load_Title_Page(bool visible)
 {
     const char* titlepict = RESFACTOR == 1 ? "TITLE.CPS" : "TITLE.PCX";
 
-    Enter_Zoomed_Resolution_Mode();
+    Enter_Original_Resolution_Mode();
 
     Load_Title_Screen((char*)titlepict, &HidPage, (unsigned char*)CCPalette.Get_Data());
     if (visible) {

--- a/redalert/saveload.cpp
+++ b/redalert/saveload.cpp
@@ -635,7 +635,7 @@ bool Load_Game(const char* file_name)
     */
     Clear_Scenario();
 
-    Leave_Zoomed_Resolution_Mode();
+    Leave_Original_Resolution_Mode();
 
     /*
     **	Load the scenario global information.

--- a/redalert/scenario.cpp
+++ b/redalert/scenario.cpp
@@ -399,7 +399,7 @@ bool Start_Scenario(char* name, bool briefing)
             Show_Mouse();
         }
 
-        Leave_Zoomed_Resolution_Mode();
+        Leave_Original_Resolution_Mode();
 
         Restate_Mission(Scen.ScenarioName, TXT_OK, TXT_NONE);
     }
@@ -412,7 +412,7 @@ bool Start_Scenario(char* name, bool briefing)
         Play_Movie(Scen.ActionMovie, Scen.TransitTheme);
     }
 
-    Leave_Zoomed_Resolution_Mode();
+    Leave_Original_Resolution_Mode();
 
     if (Scen.TransitTheme == THEME_NONE) {
         Theme.Queue_Song(THEME_FIRST);
@@ -1211,7 +1211,7 @@ void Do_Lose(void)
 #endif // CHEAT_KEYS
     Play_Movie(Scen.LoseMovie);
 
-    Leave_Zoomed_Resolution_Mode();
+    Leave_Original_Resolution_Mode();
 
     /*
     ** Start same scenario again

--- a/redalert/score.cpp
+++ b/redalert/score.cpp
@@ -381,7 +381,7 @@ void ScoreClass::Presentation(void)
     Set_Logic_Page(SysMemPage);
     BlackPalette.Set();
 
-    Enter_Zoomed_Resolution_Mode();
+    Enter_Original_Resolution_Mode();
 
     void const* country4 = MFCD::Retrieve("COUNTRY4.AUD");
     void const* sfx4 = MFCD::Retrieve("SFX4.AUD");
@@ -1699,7 +1699,7 @@ void Multi_Score_Presentation(void)
     HidPage.Clear();
     Hide_Mouse();
 
-    Enter_Zoomed_Resolution_Mode();
+    Enter_Original_Resolution_Mode();
 
     void* anim = Open_Animation(
         "MLTIPLYR.WSA", (WSAOpenType)(WSA_OPEN_FROM_MEM | WSA_OPEN_TO_PAGE), (unsigned char*)ScorePalette.Get_Data());

--- a/redalert/startup.cpp
+++ b/redalert/startup.cpp
@@ -805,6 +805,6 @@ void Resolve_Resolution_Mode()
         ScreenWidth = Settings.Video.Width;
         ScreenHeight = Settings.Video.Height;
 
-        Set_Current_Resolution_Mode(MODE_HIGH_RES);
+        Set_Current_Resolution_Mode(MODE_HIGH_RES, Settings.Video.HiResStretch);
     }
 }

--- a/tiberiandawn/conquer.cpp
+++ b/tiberiandawn/conquer.cpp
@@ -2292,7 +2292,7 @@ void Play_Movie(char const* name, ThemeType theme, bool clrscrn)
         Keyboard->Clear();
 
         // we are playing a video (which plays at 640x400) so zoom in if needed
-        Enter_Zoomed_Resolution_Mode();
+        Enter_Original_Resolution_Mode();
 
         VQAHandle* vqa = NULL;
 

--- a/tiberiandawn/display.cpp
+++ b/tiberiandawn/display.cpp
@@ -1258,7 +1258,7 @@ CELL DisplayClass::Set_Cursor_Pos(CELL pos)
         x = Coord_XCell(TacticalCoord) + Lepton_To_Cell(TacLeptonWidth) - w;
     //	if (x+w >= TacMapX+TacWidth) x = TacMapX+TacWidth-w;
     if (y + h >= Coord_YCell(TacticalCoord) + Lepton_To_Cell(TacLeptonHeight))
-        x = Coord_YCell(TacticalCoord) + Lepton_To_Cell(TacLeptonHeight) - h;
+        y = Coord_YCell(TacticalCoord) + Lepton_To_Cell(TacLeptonHeight) - h;
     //	if (y+h >= TacMapY+TacHeight) y = TacMapY+TacHeight-h;
     pos = XY_Cell(x, y) - ZoneOffset;
 

--- a/tiberiandawn/ending.cpp
+++ b/tiberiandawn/ending.cpp
@@ -68,7 +68,7 @@ void GDI_Ending(void)
     if (CCFileClass("TRAILER.VQA").Is_Available()) {
         Fade_Palette_To(BlackPalette, FADE_PALETTE_MEDIUM, Call_Back);
         // we are about to show a CPS scaled to full resolution, so zoom out
-        Leave_Zoomed_Resolution_Mode();
+        Leave_Original_Resolution_Mode();
 
         Load_Uncompress(CCFileClass("ATTRACT2.CPS"), SysMemPage, SysMemPage, Palette);
         SysMemPage.Scale(SeenBuff, 0, 0, 0, 0, 320, 199, SeenBuff.Get_Width(), SeenBuff.Get_Height());
@@ -85,7 +85,7 @@ void GDI_Ending(void)
 
     Fade_Palette_To(BlackPalette, FADE_PALETTE_MEDIUM, Call_Back);
     // we are about to show a CPS scaled to full resolution, so zoom out
-    Leave_Zoomed_Resolution_Mode();
+    Leave_Original_Resolution_Mode();
 
     Load_Uncompress(CCFileClass("ATTRACT2.CPS"), SysMemPage, SysMemPage, Palette);
     SysMemPage.Scale(SeenBuff, 0, 0, 0, 0, 320, 199, SeenBuff.Get_Width(), SeenBuff.Get_Height());
@@ -226,7 +226,7 @@ void Nod_Ending(void)
     if (CCFileClass("TRAILER.VQA").Is_Available()) {
         Fade_Palette_To(BlackPalette, FADE_PALETTE_MEDIUM, Call_Back);
         // we are about to show a CPS scaled to full resolution, so zoom out
-        Leave_Zoomed_Resolution_Mode();
+        Leave_Original_Resolution_Mode();
 
         Load_Uncompress(CCFileClass("ATTRACT2.CPS"), SysMemPage, SysMemPage, Palette);
         SysMemPage.Scale(SeenBuff, 0, 0, 0, 0, 320, 199, SeenBuff.Get_Width(), SeenBuff.Get_Height());
@@ -243,7 +243,7 @@ void Nod_Ending(void)
 
     Fade_Palette_To(BlackPalette, FADE_PALETTE_MEDIUM, Call_Back);
     // we are about to show a CPS scaled to full resolution, so zoom out
-    Leave_Zoomed_Resolution_Mode();
+    Leave_Original_Resolution_Mode();
 
     Load_Uncompress(CCFileClass("ATTRACT2.CPS"), SysMemPage, SysMemPage, Palette);
     SysMemPage.Scale(SeenBuff, 0, 0, 0, 0, 320, 199, SeenBuff.Get_Width(), SeenBuff.Get_Height());

--- a/tiberiandawn/goptions.cpp
+++ b/tiberiandawn/goptions.cpp
@@ -399,7 +399,7 @@ void GameOptionsClass::Process(void)
                     Theme.Queue_Song(THEME_PICK_ANOTHER);
 
                     // player might have watched the briefing/action movie, so ensure we leave zoom mode
-                    Leave_Zoomed_Resolution_Mode();
+                    Leave_Original_Resolution_Mode();
 
                     process = false;
                 }

--- a/tiberiandawn/init.cpp
+++ b/tiberiandawn/init.cpp
@@ -111,7 +111,7 @@ bool Init_Game(int, char*[])
     CncLogger::OnFatalError = [](const auto& err) {
         Fade_Palette_To(GamePalette, FADE_PALETTE_FAST, Call_Back);
         // the error may have happened whilst zoomed in, revert that if so
-        Leave_Zoomed_Resolution_Mode();
+        Leave_Original_Resolution_Mode();
         Show_Mouse();
 
         Speak(VOX_FAIL);
@@ -854,7 +854,7 @@ bool Select_Game(bool fade)
                 */
                 if (fade) {
                     // we are about to render the title screen background (rendered at 640x400) so zoom in if needed
-                    Enter_Zoomed_Resolution_Mode();
+                    Enter_Original_Resolution_Mode();
                 }
 
                 Load_Title_Screen(TitlePicture, &HidPage, Palette);
@@ -1303,7 +1303,7 @@ bool Select_Game(bool fade)
                 if (CCFileClass("TRAILER.VQA").Is_Available()) {
                     Fade_Palette_To(BlackPalette, FADE_PALETTE_MEDIUM, Call_Back);
                     // we are about to show a CPS scaled to full resolution, so zoom out
-                    Leave_Zoomed_Resolution_Mode();
+                    Leave_Original_Resolution_Mode();
                     VisiblePage.Clear();
                     if (CCFileClass("ATTRACT2.CPS").Is_Available()) {
                         Load_Uncompress(CCFileClass("ATTRACT2.CPS"), SysMemPage, SysMemPage, Palette);
@@ -1323,7 +1323,7 @@ bool Select_Game(bool fade)
                 if (CCFileClass("SIZZLE.VQA").Is_Available()) {
                     Fade_Palette_To(BlackPalette, FADE_PALETTE_MEDIUM, Call_Back);
                     // we are about to show a CPS scaled to full resolution, so zoom out
-                    Leave_Zoomed_Resolution_Mode();
+                    Leave_Original_Resolution_Mode();
 
                     VisiblePage.Clear();
                     if (CCFileClass("ATTRACT2.CPS").Is_Available()) {
@@ -1344,7 +1344,7 @@ bool Select_Game(bool fade)
                 if (CCFileClass("SIZZLE2.VQA").Is_Available()) {
                     Fade_Palette_To(BlackPalette, FADE_PALETTE_MEDIUM, Call_Back);
                     // we are about to show a CPS scaled to full resolution, so zoom out
-                    Leave_Zoomed_Resolution_Mode();
+                    Leave_Original_Resolution_Mode();
 
                     VisiblePage.Clear();
                     if (CCFileClass("ATTRACT2.CPS").Is_Available()) {
@@ -1364,7 +1364,7 @@ bool Select_Game(bool fade)
 
                 Fade_Palette_To(BlackPalette, FADE_PALETTE_MEDIUM, Call_Back);
                 // we are about to show a CPS scaled to full resolution, so zoom out
-                Leave_Zoomed_Resolution_Mode();
+                Leave_Original_Resolution_Mode();
 
                 VisiblePage.Clear();
                 if (CCFileClass("ATTRACT2.CPS").Is_Available()) {

--- a/tiberiandawn/menus.cpp
+++ b/tiberiandawn/menus.cpp
@@ -458,7 +458,7 @@ int Main_Menu(unsigned int timeout)
     int scale_factor = Get_Resolution_Factor() + 1;
 
     // we are about to view the main menu (rendered at 640x400) so zoom in if needed
-    Enter_Zoomed_Resolution_Mode();
+    Enter_Original_Resolution_Mode();
 
     int D_DIALOG_W = 152 * scale_factor, D_DIALOG_H = 136 * scale_factor, D_DIALOG_X = 85 * scale_factor,
         D_DIALOG_Y = 0, D_DIALOG_CX = D_DIALOG_X + (D_DIALOG_W / scale_factor),

--- a/tiberiandawn/saveload.cpp
+++ b/tiberiandawn/saveload.cpp
@@ -395,7 +395,7 @@ bool Load_Game(const char* file_name)
     // TabClass::One_Time and it's associated base class methods - these depend on the excepted resolution being set to
     // calculate constants correctly, so zoom out
     const auto resolution_mode = Get_Current_Resolution_Mode();
-    Leave_Zoomed_Resolution_Mode();
+    Leave_Original_Resolution_Mode();
     Call_Back();
 
     const auto save_header = SaveGameResolver::Load(
@@ -579,7 +579,7 @@ bool Load_Game_Binary(const char* file_name)
     // we are about to load a scenario, which means Map.Load will call TabClass::One_Time and the base class methods
     // - these depend on the excepted resolution being set to calculate constants correctly, so zoom out
     const auto resolution_mode = Get_Current_Resolution_Mode();
-    Leave_Zoomed_Resolution_Mode();
+    Leave_Original_Resolution_Mode();
 
     Call_Back();
     /*

--- a/tiberiandawn/scenario.cpp
+++ b/tiberiandawn/scenario.cpp
@@ -146,13 +146,13 @@ bool Start_Scenario(char* root, bool briefing)
             }
 
             // we are about to start the scenario, so zoom out
-            Leave_Zoomed_Resolution_Mode();
+            Leave_Original_Resolution_Mode();
         } else {
             Play_Movie(BriefMovie);
             Play_Movie(ActionMovie, Scen.TransitTheme);
 
             // we are about to start the scenario, so zoom out
-            Leave_Zoomed_Resolution_Mode();
+            Leave_Original_Resolution_Mode();
 #ifdef NEWMENU
 
             char buffer[_MAX_FNAME + _MAX_EXT + 4];
@@ -713,7 +713,7 @@ void Do_Lose(void)
     Play_Movie(LoseMovie);
 
     // we are about to show a user popup, so zoom out
-    Leave_Zoomed_Resolution_Mode();
+    Leave_Original_Resolution_Mode();
 
     /*
     ** Start same scenario again

--- a/tiberiandawn/score.cpp
+++ b/tiberiandawn/score.cpp
@@ -646,7 +646,7 @@ void ScoreClass::Presentation(void)
     Set_Palette(BlackPalette);
 
     // we are about to render the scenario score screen at 640x400, so zoom in
-    Enter_Zoomed_Resolution_Mode();
+    Enter_Original_Resolution_Mode();
 
     Set_Logic_Page(SysMemPage);
 
@@ -2041,7 +2041,7 @@ void Multi_Score_Presentation(void)
     Set_Palette(BlackPalette);
 
     // we are about to render the multiplayer scenario score screen at 640x400, so zoom in
-    Enter_Zoomed_Resolution_Mode();
+    Enter_Original_Resolution_Mode();
 
     anim = Open_Animation("MLTIPLYR.WSA", NULL, 0L, (WSAOpenType)(WSA_OPEN_FROM_MEM | WSA_OPEN_TO_PAGE), Palette);
     Hide_Mouse();

--- a/tiberiandawn/special.cpp
+++ b/tiberiandawn/special.cpp
@@ -266,6 +266,8 @@ void Special_Dialog(void)
             }
             break;
         }
+
+        Frame_Limiter();
     }
 
     Map.Revert_Mouse_Shape();

--- a/tiberiandawn/startup.cpp
+++ b/tiberiandawn/startup.cpp
@@ -670,6 +670,6 @@ void Resolve_Resolution_Mode()
         ScreenWidth = Settings.Video.Width;
         ScreenHeight = Settings.Video.Height;
 
-        Set_Current_Resolution_Mode(MODE_HIGH_RES);
+        Set_Current_Resolution_Mode(MODE_HIGH_RES, Settings.Video.HiResStretch);
     }
 }

--- a/wiki/2.Enhancements.md
+++ b/wiki/2.Enhancements.md
@@ -52,7 +52,7 @@ These enhancements work in both Tiberian Dawn and Red Alert.
 
 The game engines have been updated to support resolutions higher than 640x400, so you can see more of the map whilst playing.
 
-Note: NCO will start up at 960x600 mode by default (Game menus and videos are still rendered at 640x400)
+Note: NCO will start up at 960x600 mode by default (Game menus and videos are stretched to fill the screen)
 
 #### Tiberian Dawn
 
@@ -66,6 +66,7 @@ VideoWidth=960
 VideoHeight=600
 StretchWidth=0 ; change me if using windowed mode
 StretchHeight=0 ; change me if using windowed mode
+HiResStretch=yes ; set to 'no' to disable stretching movies/menus
 ```
 
 **Note**: To find `conquer.ini`, follow the steps for your Operating System below:
@@ -86,6 +87,7 @@ VideoWidth=960
 VideoHeight=600
 StretchWidth=0 ; change me if using windowed mode
 StretchHeight=0 ; change me if using windowed mode
+HiResStretch=yes ; set to 'no' to disable stretching movies/menus
 ```
 
 **Note**: To find `redalert.ini`, follow the steps for your Operating System below:

--- a/wiki/2.Enhancements.md
+++ b/wiki/2.Enhancements.md
@@ -52,7 +52,7 @@ These enhancements work in both Tiberian Dawn and Red Alert.
 
 The game engines have been updated to support resolutions higher than 640x400, so you can see more of the map whilst playing.
 
-Note: NCO will start up in 800x600 mode by default (Game menus and videos are still rendered at 640x400)
+Note: NCO will start up at 960x600 mode by default (Game menus and videos are still rendered at 640x400)
 
 #### Tiberian Dawn
 
@@ -62,10 +62,10 @@ You can set any desired resolution in `conquer.ini` by setting the `VideoWidth` 
 
 ```ini
 [Video]
-VideoWidth=800
+VideoWidth=960
 VideoHeight=600
-StretchWidth=0
-StretchHeight=0
+StretchWidth=0 ; change me if using windowed mode
+StretchHeight=0 ; change me if using windowed mode
 ```
 
 **Note**: To find `conquer.ini`, follow the steps for your Operating System below:
@@ -82,10 +82,10 @@ You can set any desired resolution in `redalert.ini` by setting the `VideoWidth`
 
 ```ini
 [Video]
-VideoWidth=800
+VideoWidth=960
 VideoHeight=600
-StretchWidth=0
-StretchHeight=0
+StretchWidth=0 ; change me if using windowed mode
+StretchHeight=0 ; change me if using windowed mode
 ```
 
 **Note**: To find `redalert.ini`, follow the steps for your Operating System below:


### PR DESCRIPTION
## Features

feat(common): Set default resolution to 1.5x Win95 resolution (960x600)
feat(common): Add HiResStretch video setting to allow disabling menu/video stretch in hi-res

## Fixes

fix(td): Special Dialog Rendering in Normal Game Mode
fix(td): Placement not working on bottom row of map

## Chores

chore(all): Sync with Vanilla TD Upstream